### PR TITLE
Add Avalonia views for core workflows and wire MainWindow

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -3,6 +3,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+        xmlns:views="clr-namespace:PulseAPK.Avalonia.Views"
+        xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PulseAPK.Avalonia.MainWindow"
         x:DataType="vm:MainViewModel"
@@ -10,33 +12,48 @@
 
     <Window.DataTemplates>
         <DataTemplate DataType="{x:Type vm:DecompileViewModel}">
-            <TextBlock Text="Decompile View (Not Ported Yet)" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <views:DecompileView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:BuildViewModel}">
-            <TextBlock Text="Build View (Not Ported Yet)" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <views:BuildView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
-            <TextBlock Text="Settings View (Not Ported Yet)" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <views:SettingsView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AnalyserViewModel}">
-            <TextBlock Text="Analyser View (Not Ported Yet)" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <views:AnalyserView/>
         </DataTemplate>
         <DataTemplate DataType="{x:Type vm:AboutViewModel}">
-            <TextBlock Text="About View (Not Ported Yet)" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            <views:AboutView/>
         </DataTemplate>
     </Window.DataTemplates>
 
-    <Grid ColumnDefinitions="200, *">
+    <Grid ColumnDefinitions="220, *">
         <!-- Sidebar -->
-        <Border Grid.Column="0" Background="#202020" Padding="10">
+        <Border Grid.Column="0" Background="#202020" Padding="16">
             <StackPanel Spacing="10">
-                <TextBlock Text="PulseAPK" FontSize="20" FontWeight="Bold" Foreground="Cyan" HorizontalAlignment="Center" Margin="0,0,0,20"/>
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
+                           FontSize="20"
+                           FontWeight="Bold"
+                           Foreground="Cyan"
+                           HorizontalAlignment="Center"
+                           Margin="0,0,0,20"/>
                 
-                <Button Command="{Binding NavigateToDecompileCommand}" Content="Decompile" HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToBuildCommand}" Content="Build" HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToAnalyserCommand}" Content="Analyser" HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToSettingsCommand}" Content="Settings" HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToAboutCommand}" Content="About" HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToDecompileCommand}"
+                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuDecompile]}"
+                        HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToBuildCommand}"
+                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"
+                        HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToAnalyserCommand}"
+                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"
+                        HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToSettingsCommand}"
+                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuSettings]}"
+                        HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToAboutCommand}"
+                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAbout]}"
+                        HorizontalAlignment="Stretch"/>
             </StackPanel>
         </Border>
 

--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.AboutView"
+             x:DataType="vm:AboutViewModel">
+    <StackPanel Spacing="12" Margin="20" HorizontalAlignment="Center">
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
+                   FontSize="36"
+                   FontWeight="Bold"
+                   HorizontalAlignment="Center" />
+        <TextBlock Text="{Binding AppVersion}"
+                   FontSize="16"
+                   HorizontalAlignment="Center" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
+            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DevelopedBy]}"
+                       FontSize="14" />
+            <TextBlock Text="{Binding DeveloperName}"
+                       FontSize="14"
+                       FontWeight="SemiBold" />
+        </StackPanel>
+
+        <TextBlock Text="{Binding Year}"
+                   FontSize="14"
+                   HorizontalAlignment="Center" />
+
+        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_ProjectPage]}"
+                Command="{Binding OpenProjectPageCommand}"
+                Width="200" />
+        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DeveloperPage]}"
+                Command="{Binding OpenDeveloperPageCommand}"
+                Width="200" />
+    </StackPanel>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class AboutView : UserControl
+{
+    public AboutView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -1,0 +1,68 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.AnalyserView"
+             x:DataType="vm:AnalyserViewModel">
+    <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16" Margin="20">
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AnalyserHeader]}"
+                   FontSize="24"
+                   FontWeight="SemiBold" />
+
+        <Border Grid.Row="1"
+                Background="#1B1B1B"
+                BorderBrush="#3C3C3C"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12"
+                AllowDrop="True"
+                DragDrop.DragOver="OnDragOver"
+                DragDrop.Drop="OnDrop">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
+                               FontWeight="SemiBold" />
+                    <TextBox Text="{Binding ProjectPath}"
+                             Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
+                             IsReadOnly="True" />
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DragDropFolderHint]}"
+                               FontSize="12"
+                               Opacity="0.7"
+                               IsVisible="{Binding IsHintVisible}" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseProjectCommand}"
+                            Width="120" />
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[RunAnalysis]}"
+                            Command="{Binding RunAnalysisCommand}"
+                            Width="120" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="2"
+                Background="#121212"
+                BorderBrush="#2E2E2E"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12">
+            <StackPanel Spacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         Height="240" />
+            </StackPanel>
+        </Border>
+
+        <Button Grid.Row="3"
+                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SaveReport]}"
+                Command="{Binding SaveReportCommand}"
+                HorizontalAlignment="Right"
+                Width="140" />
+    </Grid>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.ViewModels;
+using Properties = PulseAPK.Core.Properties;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class AnalyserView : UserControl
+{
+    public AnalyserView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            e.DragEffects = DragDropEffects.Copy;
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+
+        e.Handled = true;
+    }
+
+    private async void OnDrop(object? sender, DragEventArgs e)
+    {
+        if (!e.Data.Contains(DataFormats.Files))
+        {
+            return;
+        }
+
+        var storageItems = e.Data.GetFiles();
+        var item = storageItems?.FirstOrDefault();
+        var path = item?.TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(path))
+        {
+            await ShowWarningAsync(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.AnalyserHeader);
+            return;
+        }
+
+        var smaliFiles = Directory.EnumerateFiles(path, "*.smali", SearchOption.AllDirectories);
+        if (!smaliFiles.Any())
+        {
+            await ShowWarningAsync(Properties.Resources.Error_InvalidSmaliProject, Properties.Resources.AnalyserHeader);
+            return;
+        }
+
+        if (DataContext is AnalyserViewModel viewModel)
+        {
+            viewModel.ProjectPath = path;
+        }
+    }
+
+    private static async Task ShowWarningAsync(string message, string title)
+    {
+        if (Application.Current is App app && app.Services != null)
+        {
+            var dialogService = app.Services.GetService<IDialogService>();
+            if (dialogService != null)
+            {
+                await dialogService.ShowWarningAsync(message, title);
+            }
+        }
+    }
+}

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -1,0 +1,86 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.BuildView"
+             x:DataType="vm:BuildViewModel">
+    <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="16" Margin="20">
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BuildHeader]}"
+                   FontSize="24"
+                   FontWeight="SemiBold" />
+
+        <Border Grid.Row="1"
+                Background="#1B1B1B"
+                BorderBrush="#3C3C3C"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12"
+                AllowDrop="True"
+                DragDrop.DragOver="OnDragOver"
+                DragDrop.Drop="OnDrop">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
+                               FontWeight="SemiBold" />
+                    <TextBox Text="{Binding ProjectPath}"
+                             Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
+                             IsReadOnly="True" />
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DragDropFolderHint]}"
+                               FontSize="12"
+                               Opacity="0.7"
+                               IsVisible="{Binding IsHintVisible}" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseProjectCommand}"
+                            Width="120" />
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[RunBuild]}"
+                            Command="{Binding RunBuildCommand}"
+                            Width="120" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
+            <StackPanel Spacing="8">
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
+                          IsChecked="{Binding UseAapt2}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SignApk]}"
+                          IsChecked="{Binding SignApk}" />
+            </StackPanel>
+            <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApkName]}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding OutputApkName}"
+                         IsEnabled="{Binding HasProject}" />
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[OutputApkLabel]}"
+                           FontWeight="SemiBold" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBox Text="{Binding OutputFolderPath}" />
+                    <Button Grid.Column="1"
+                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseOutputApkCommand}"
+                            Width="100" />
+                </Grid>
+            </StackPanel>
+        </Grid>
+
+        <Border Grid.Row="3"
+                Background="#121212"
+                BorderBrush="#2E2E2E"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12">
+            <StackPanel Spacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         Height="220" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml.cs
@@ -1,0 +1,81 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Utils;
+using PulseAPK.Core.ViewModels;
+using Properties = PulseAPK.Core.Properties;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class BuildView : UserControl
+{
+    public BuildView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            e.DragEffects = DragDropEffects.Copy;
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+
+        e.Handled = true;
+    }
+
+    private async void OnDrop(object? sender, DragEventArgs e)
+    {
+        if (!e.Data.Contains(DataFormats.Files))
+        {
+            return;
+        }
+
+        var storageItems = e.Data.GetFiles();
+        var item = storageItems?.FirstOrDefault();
+        var path = item?.TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        if (!System.IO.Directory.Exists(path))
+        {
+            await ShowWarningAsync(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.BuildHeader);
+            return;
+        }
+
+        var (isValid, message) = FileSanitizer.ValidateProjectFolder(path);
+        if (!isValid)
+        {
+            await ShowWarningAsync(message, Properties.Resources.Warning_InvalidProjectFolder);
+            return;
+        }
+
+        if (DataContext is BuildViewModel viewModel)
+        {
+            viewModel.ProjectPath = path;
+        }
+    }
+
+    private static async Task ShowWarningAsync(string message, string title)
+    {
+        if (Application.Current is App app && app.Services != null)
+        {
+            var dialogService = app.Services.GetService<IDialogService>();
+            if (dialogService != null)
+            {
+                await dialogService.ShowWarningAsync(message, title);
+            }
+        }
+    }
+}

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.DecompileView"
+             x:DataType="vm:DecompileViewModel">
+    <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="16" Margin="20">
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecompileHeader]}"
+                   FontSize="24"
+                   FontWeight="SemiBold" />
+
+        <Border Grid.Row="1"
+                Background="#1B1B1B"
+                BorderBrush="#3C3C3C"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12"
+                AllowDrop="True"
+                DragDrop.DragOver="OnDragOver"
+                DragDrop.Drop="OnDrop">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
+                               FontWeight="SemiBold" />
+                    <TextBox Text="{Binding ApkPath}"
+                             Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
+                             IsReadOnly="True" />
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DragDropHint]}"
+                               FontSize="12"
+                               Opacity="0.7"
+                               IsVisible="{Binding IsHintVisible}" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseApkCommand}"
+                            Width="120" />
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
+                            Command="{Binding RunDecompileCommand}"
+                            Width="120" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
+            <StackPanel Spacing="8">
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
+                          IsChecked="{Binding DecodeResources}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
+                          IsChecked="{Binding DecodeSources}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[KeepOriginalManifest]}"
+                          IsChecked="{Binding KeepOriginalManifest}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ExtractToApkFolder]}"
+                          IsChecked="{Binding ExtractToApkFolder}" />
+            </StackPanel>
+            <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[OutputFolder]}"
+                           FontWeight="SemiBold" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBox Text="{Binding OutputFolder}" />
+                    <StackPanel Grid.Column="1" Spacing="6">
+                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                                Command="{Binding BrowseOutputFolderCommand}"
+                                Width="100" />
+                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Open]}"
+                                Command="{Binding OpenOutputFolderCommand}"
+                                Width="100" />
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </Grid>
+
+        <Border Grid.Row="3"
+                Background="#121212"
+                BorderBrush="#2E2E2E"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12">
+            <StackPanel Spacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                           FontWeight="SemiBold" />
+                <TextBox Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         VerticalScrollBarVisibility="Auto"
+                         Height="220" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml.cs
@@ -1,0 +1,75 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Utils;
+using PulseAPK.Core.ViewModels;
+using Properties = PulseAPK.Core.Properties;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class DecompileView : UserControl
+{
+    public DecompileView()
+    {
+        InitializeComponent();
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        if (e.Data.Contains(DataFormats.Files))
+        {
+            e.DragEffects = DragDropEffects.Copy;
+        }
+        else
+        {
+            e.DragEffects = DragDropEffects.None;
+        }
+
+        e.Handled = true;
+    }
+
+    private async void OnDrop(object? sender, DragEventArgs e)
+    {
+        if (!e.Data.Contains(DataFormats.Files))
+        {
+            return;
+        }
+
+        var storageItems = e.Data.GetFiles();
+        var item = storageItems?.FirstOrDefault();
+        var path = item?.TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        var (isValid, message) = FileSanitizer.ValidateApk(path);
+        if (!isValid)
+        {
+            await ShowWarningAsync(message, Properties.Resources.Error_InvalidApkFile);
+            return;
+        }
+
+        if (DataContext is DecompileViewModel viewModel)
+        {
+            viewModel.ApkPath = path;
+        }
+    }
+
+    private static async Task ShowWarningAsync(string message, string title)
+    {
+        if (Application.Current is App app && app.Services != null)
+        {
+            var dialogService = app.Services.GetService<IDialogService>();
+            if (dialogService != null)
+            {
+                await dialogService.ShowWarningAsync(message, title);
+            }
+        }
+    }
+}

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -1,0 +1,44 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.SettingsView"
+             x:DataType="vm:SettingsViewModel">
+    <StackPanel Spacing="12" Margin="20">
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SettingsHeader]}"
+                   FontSize="24"
+                   FontWeight="SemiBold" />
+
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[LanguageLabel]}"
+                   FontWeight="SemiBold" />
+        <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                  SelectedItem="{Binding SelectedLanguage}"
+                  Width="260">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}" />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
+                   FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <TextBox Text="{Binding ApktoolPath}" />
+            <Button Grid.Column="1"
+                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                    Command="{Binding BrowseApktoolCommand}"
+                    Width="110" />
+        </Grid>
+
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UbersignPath]}"
+                   FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <TextBox Text="{Binding UbersignPath}" />
+            <Button Grid.Column="1"
+                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                    Command="{Binding BrowseUbersignCommand}"
+                    Width="110" />
+        </Grid>
+    </StackPanel>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class SettingsView : UserControl
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using PulseAPK.Core.Services;
@@ -23,6 +24,7 @@ public partial class AnalyserViewModel : ObservableObject
     
     private readonly SmaliAnalyserService _analyserService;
     private readonly ReportService _reportService;
+    private readonly IFilePickerService _filePickerService;
     private readonly IDialogService _dialogService;
     private readonly IDispatcherService _dispatcherService;
 
@@ -45,11 +47,13 @@ public partial class AnalyserViewModel : ObservableObject
     public AnalyserViewModel(
         SmaliAnalyserService analyserService,
         ReportService reportService,
+        IFilePickerService filePickerService,
         IDialogService dialogService,
         IDispatcherService dispatcherService)
     {
         _analyserService = analyserService;
         _reportService = reportService;
+        _filePickerService = filePickerService;
         _dialogService = dialogService;
         _dispatcherService = dispatcherService;
         
@@ -59,6 +63,32 @@ public partial class AnalyserViewModel : ObservableObject
     partial void OnProjectPathChanged(string value)
     {
         RunAnalysisCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private async Task BrowseProject()
+    {
+        var folder = await _filePickerService.OpenFolderAsync(ProjectPath);
+
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            return;
+        }
+
+        if (!Directory.Exists(folder))
+        {
+            await _dialogService.ShowWarningAsync(Properties.Resources.Error_InvalidProjectSelection, Properties.Resources.AnalyserHeader);
+            return;
+        }
+
+        var smaliFiles = Directory.EnumerateFiles(folder, "*.smali", SearchOption.AllDirectories);
+        if (!smaliFiles.Any())
+        {
+            await _dialogService.ShowWarningAsync(Properties.Resources.Error_InvalidSmaliProject, Properties.Resources.AnalyserHeader);
+            return;
+        }
+
+        ProjectPath = folder;
     }
 
     [RelayCommand(CanExecute = nameof(CanRunAnalysis))]


### PR DESCRIPTION
### Motivation
- Port the WPF application's views to Avalonia so the app can run as a functional desktop UI on Linux and be ready for Windows and macOS later.
- Reuse existing `Core` viewmodels and localization so the Avalonia UI mirrors WPF behavior and strings.
- Provide drag-and-drop and folder browsing UX parity for Decompile, Build and Analyser workflows.

### Description
- Added Avalonia user controls for Decompile, Build, Analyser, Settings and About (`src/PulseAPK.Avalonia/Views/*.{axaml,axaml.cs}`) with localized labels referencing `LocalizationService.Instance` and console/output areas. 
- Wired `MainWindow.axaml` to use new view types via `Window.DataTemplates`, localized menu text and adjusted sidebar layout and sizing. 
- Implemented Avalonia drag-and-drop handlers in view code-behinds using `DataFormats.Files` and `TryGetLocalPath()` and hooked them into the existing `FileSanitizer` validations and dialog service calls. 
- Extended `AnalyserViewModel` to accept `IFilePickerService`, added a `BrowseProject` command and `System.IO` checks to validate and set the analyser project folder from the platform file picker.

### Testing
- No automated tests were executed for this change (UI-only changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f26ca884c832287d9011134b38125)