### PR TITLE
Fix Avalonia drag-drop and scroll bindings

### DIFF
--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -15,7 +15,7 @@
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12"
-                AllowDrop="True"
+                DragDrop.AllowDrop="True"
                 DragDrop.DragOver="OnDragOver"
                 DragDrop.Drop="OnDrop">
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
@@ -54,7 +54,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
-                         VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                          Height="240" />
             </StackPanel>
         </Border>

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -15,7 +15,7 @@
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12"
-                AllowDrop="True"
+                DragDrop.AllowDrop="True"
                 DragDrop.DragOver="OnDragOver"
                 DragDrop.Drop="OnDrop">
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
@@ -78,7 +78,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
-                         VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                          Height="220" />
             </StackPanel>
         </Border>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -15,7 +15,7 @@
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12"
-                AllowDrop="True"
+                DragDrop.AllowDrop="True"
                 DragDrop.DragOver="OnDragOver"
                 DragDrop.Drop="OnDrop">
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
@@ -82,7 +82,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
-                         VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
                          Height="220" />
             </StackPanel>
         </Border>


### PR DESCRIPTION
### Motivation
- Fix Avalonia XAML runtime errors where `AllowDrop` and `VerticalScrollBarVisibility` properties could not be resolved (AVLN2000) in the views `AnalyserView.axaml`, `BuildView.axaml`, and `DecompileView.axaml`.

### Description
- Replace `AllowDrop="True"` with the attached property `DragDrop.AllowDrop="True"` on the `Border` elements in `src/PulseAPK.Avalonia/Views/AnalyserView.axaml`, `BuildView.axaml`, and `DecompileView.axaml`.
- Replace `VerticalScrollBarVisibility="Auto"` with `ScrollViewer.VerticalScrollBarVisibility="Auto"` on the console log `TextBox` controls in the same views.
- These edits update the XAML to use Avalonia-compatible attached property syntax and consistent scroll viewer property names.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2cc9f100832299e0feb02e1b921e)