### PR TITLE
Add Browse button to WPF Decompile view

### DIFF
--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -54,12 +54,19 @@
                     <TextBlock Text="{utils:Localization DragDropHint}" Foreground="{StaticResource Brush.TextSecondary}" FontSize="14" HorizontalAlignment="Center" Margin="0,5,0,0" Visibility="{Binding IsHintVisible, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 </StackPanel>
 
-                <Button Grid.Column="1"
-                        Content="{utils:Localization Run}"
-                        Style="{StaticResource RunButtonStyle}"
-                        Command="{Binding RunDecompileCommand}"
-                        Width="140" Height="110" Margin="20"
-                        VerticalAlignment="Center"/>
+                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="20,0,0,0">
+                    <Button Content="{utils:Localization Browse}"
+                            Style="{StaticResource CyberButtonStyle}"
+                            Command="{Binding BrowseApkCommand}"
+                            Width="140"
+                            Height="42"
+                            Margin="0,0,0,12"/>
+                    <Button Content="{utils:Localization Run}"
+                            Style="{StaticResource RunButtonStyle}"
+                            Command="{Binding RunDecompileCommand}"
+                            Width="140"
+                            Height="56"/>
+                </StackPanel>
             </Grid>
         </Border>
 


### PR DESCRIPTION
### Motivation
- Add a `Browse` button to the WPF Decompile view for parity with the Avalonia UI and to allow selecting an APK without drag-and-drop.

### Description
- Update `Views/DecompileView.xaml` to replace the single large Run button with a vertical `StackPanel` containing a `Browse` button (bound to `BrowseApkCommand`) above the `Run` button and adjusted sizing/margins.

### Testing
- No automated tests were run because this is a UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2e9675288322937204391426110d)