### PR TITLE
Fix localization updates on language change

### DIFF
--- a/src/PulseAPK.Core/Services/LocalizationService.cs
+++ b/src/PulseAPK.Core/Services/LocalizationService.cs
@@ -74,6 +74,7 @@ public class LocalizationService : INotifyPropertyChanged
                 _currentCulture = value;
                 Thread.CurrentThread.CurrentUICulture = value;
                 Thread.CurrentThread.CurrentCulture = value;
+                Resources.Culture = value;
                 
                 if (_settingsService != null)
                 {
@@ -81,7 +82,9 @@ public class LocalizationService : INotifyPropertyChanged
                     _settingsService.Save();
                 }
                 
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentLanguage)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentCulture)));
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Changing the language in Settings did not immediately refresh UI strings because the resource culture and bound-property notifications were not fully updated.
- The behavior should match the WPF app where switching language updates displayed text immediately without restarting.

### Description
- Set the resource culture by assigning `Resources.Culture = value` when `CurrentCulture` changes so resource lookups use the new culture.
- Raise `PropertyChanged` for the indexer (`"Item[]"`) and for `CurrentLanguage` and `CurrentCulture` so bindings refresh immediately.
- Retain saving the selected language to settings via the existing settings service save logic.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f37a31b2c8322b61343101ceb299f)