### PR TITLE
Apply culture globally and add localized resource files

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>تفكيك</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>الإعدادات</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>حول</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>تفكيك</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>اختيار APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>مجلد الإخراج</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>مسار APK الناتج</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>استعراض</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>فتح</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>اسحب وأسقط ملفًا</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>فك ترميز الموارد</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>الاحتفاظ بالبيان الأصلي</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>استخراج إلى المجلد الذي يحتوي على APK</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>فك ترميز المصادر</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>تشغيل التفكيك</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>في انتظار الأمر...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>بدء apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>فشل التفكيك</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>نجح التفكيك</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>لم يتم تعيين مجلد الإخراج.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>المجلد '{0}' غير موجود.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>تعذر فتح المجلد: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>يرجى ضبط مسار apktool في الإعدادات قبل التفكيك.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>مسار apktool '{0}' غير موجود. يرجى تحديثه في الإعدادات.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>ملف APK غير صالح</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>ملف JAR غير صالح</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>ملف Ubersign غير صالح</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>قم بإسقاط مجلد مشروع صالح يحتوي على apktool.yml و AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>ملفات APK (*.apk)|*.apk|كل الملفات (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>ملفات JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>ملفات Ubersign JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>الإعدادات</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>مسار Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>مسار Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>مسار JAVA: غير موجود</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>مسار JAVA: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>تم التطوير بواسطة</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>صفحة المشروع</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>صفحة المطور</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>الإصدار: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>تنزيل Apktool: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>تنزيل JAVA: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>بناء APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>بناء APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>اختيار مجلد المشروع</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>توقيع APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>استخدام AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>تشغيل البناء</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>تم إنشاء ملف APK بنجاح.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>فشل إنشاء ملف APK</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>المجلد المحدد لا يبدو مشروع apktool صالحًا (apktool.yml أو AndroidManifest.xml مفقود).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>اسحب وأسقط مجلدًا</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>محلل APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>محلل APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>تشغيل التحليل</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>بدء التحليل...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>اكتمل التحليل</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>فشل التحليل</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>تحقق الجذر: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>تحقق الجذر: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>تحقق المحاكي: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>تحقق المحاكي: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>اسم المستخدم/كلمة المرور المضمنة: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>اسم المستخدم/كلمة المرور المضمنة: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>استعلامات SQL: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>استعلامات SQL: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>مسارات HTTP/HTTPS: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>مسارات HTTP/HTTPS: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  تم العثور في:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>المجلد المحدد لا يحتوي على ملفات Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>تنزيل ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>تنزيل JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>تنزيل Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>اللغة</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>حفظ التقرير</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>تشغيل</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>اسم APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>سجل وحدة التحكم</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Dekompilieren</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Dekompilierung</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>APK auswählen</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Ausgabeordner</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Ausgabe-APK-Pfad</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Durchsuchen</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Öffnen</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Datei hierher ziehen</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Ressourcen dekodieren</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Ursprüngliches Manifest beibehalten</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>In den Ordner extrahieren, in dem sich das APK befindet</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Quellcode dekodieren</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Dekompilierung starten</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>Warten auf Befehl...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>apktool wird gestartet...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>Dekompilierung fehlgeschlagen</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Dekompilierung erfolgreich</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>Ausgabeordner ist nicht gesetzt.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>Der Ordner '{0}' existiert nicht.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>Ordner konnte nicht geöffnet werden: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Bitte konfiguriere den apktool-Pfad in den Einstellungen, bevor du dekompilierst.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>Der apktool-Pfad '{0}' existiert nicht. Bitte in den Einstellungen aktualisieren.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Ungültige APK-Datei</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Ungültige JAR-Datei</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Ungültige Ubersign-Datei</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Lege einen gültigen Projektordner ab, der apktool.yml und AndroidManifest.xml enthält.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>APK-Dateien (*.apk)|*.apk|Alle Dateien (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>JAR-Dateien (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Ubersign-JAR-Dateien (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Apktool-Pfad</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Ubersign-Pfad</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>JAVA-Pfad: nicht gefunden</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>JAVA-Pfad: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Entwickelt von</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Projektseite</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Entwicklerseite</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Version: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Apktool herunterladen: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>JAVA herunterladen: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>APK erstellen</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>APK erstellen</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Projektordner auswählen</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>APK signieren</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>AAPT2 verwenden</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Build starten</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>APK-Datei erfolgreich erstellt.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>Erstellung der APK-Datei fehlgeschlagen</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>Der ausgewählte Ordner scheint kein gültiges apktool-Projekt zu sein (apktool.yml oder AndroidManifest.xml fehlt).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Ordner hierher ziehen</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>APK-Analysator</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>APK-Analysator</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Analyse starten</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Analyse wird gestartet...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Analyse abgeschlossen</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>Analyse fehlgeschlagen</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Root-Prüfung: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Root-Prüfung: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Emulator-Prüfung: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Emulator-Prüfung: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Fest kodierter Benutzername/Passwort: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Fest kodierter Benutzername/Passwort: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>SQL-Abfragen: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>SQL-Abfragen: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>HTTP/HTTPS-Pfade: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>HTTP/HTTPS-Pfade: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Gefunden in:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>Der ausgewählte Ordner enthält keine Smali-Dateien.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>ApkTool herunterladen</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>JAVA herunterladen</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Ubersigner herunterladen</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Bericht speichern</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Starten</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>APK-Name</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Konsolenprotokoll</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Descompilar</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>Acerca de</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Descompilación</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>Seleccionar APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Carpeta de salida</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Ruta del APK de salida</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Explorar</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Arrastra y suelta un archivo</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Decodificar recursos</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Mantener el manifiesto original</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Extraer a la carpeta donde está el APK</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Decodificar fuentes</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Ejecutar descompilación</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>Esperando comando...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>Iniciando apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>La descompilación falló</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Descompilación exitosa</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>La carpeta de salida no está configurada.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>La carpeta '{0}' no existe.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>No se pudo abrir la carpeta: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Configura la ruta de apktool en Configuración antes de descompilar.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>La ruta de apktool '{0}' no existe. Actualízala en Configuración.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Archivo APK no válido</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Archivo JAR no válido</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Archivo Ubersign no válido</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Suelta una carpeta de proyecto válida que contenga apktool.yml y AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>Archivos APK (*.apk)|*.apk|Todos los archivos (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>Archivos JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Archivos JAR de Ubersign (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Ruta de Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Ruta de Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>Ruta de JAVA: no encontrada</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>Ruta de JAVA: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Desarrollado por</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Página del proyecto</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Página del desarrollador</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Versión: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Descargar Apktool: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>Descargar JAVA: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>Compilar APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>Compilar APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Seleccionar carpeta del proyecto</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>Firmar APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>Usar AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Ejecutar compilación</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>Archivo APK creado correctamente.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>La creación del APK falló</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>La carpeta seleccionada no parece un proyecto apktool válido (falta apktool.yml o AndroidManifest.xml).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Arrastra y suelta una carpeta</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>Analizador de APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>Analizador de APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Ejecutar análisis</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Iniciando análisis...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Análisis completado</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>El análisis falló</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Comprobación de root: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Comprobación de root: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Comprobación de emulador: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Comprobación de emulador: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Usuario/contraseña hardcodeados: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Usuario/contraseña hardcodeados: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>Consultas SQL: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>Consultas SQL: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>Rutas HTTP/HTTPS: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>Rutas HTTP/HTTPS: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Encontrado en:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>La carpeta seleccionada no contiene archivos Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>Descargar ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>Descargar JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Descargar Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Guardar informe</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Ejecutar</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>Nombre del APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Registro de consola</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Décompiler</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>À propos</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Décompilation</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>Sélectionner un APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Dossier de sortie</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Chemin de l'APK de sortie</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Parcourir</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Ouvrir</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Glisser-déposer un fichier</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Décoder les ressources</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Conserver le manifeste d'origine</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Extraire dans le dossier où se trouve l'APK</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Décoder les sources</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Lancer la décompilation</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>En attente d'une commande...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>Démarrage d'apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>La décompilation a échoué</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Décompilation réussie</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>Le dossier de sortie n'est pas défini.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>Le dossier '{0}' n'existe pas.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>Impossible d'ouvrir le dossier : {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Veuillez configurer le chemin apktool dans les paramètres avant de lancer une décompilation.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>Le chemin apktool '{0}' n'existe pas. Veuillez le mettre à jour dans les paramètres.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Fichier APK invalide</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Fichier JAR invalide</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Fichier Ubersign invalide</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Déposez un dossier de projet valide contenant apktool.yml et AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>Fichiers APK (*.apk)|*.apk|Tous les fichiers (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>Fichiers JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Fichiers JAR Ubersign (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Chemin Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Chemin Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>Chemin JAVA : introuvable</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>Chemin JAVA : {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Développé par</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Page du projet</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Page du développeur</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Version : {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Télécharger Apktool : </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>Télécharger JAVA : </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>Compiler l'APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>Compiler l'APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Sélectionner le dossier du projet</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>Signer l'APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>Utiliser AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Lancer la compilation</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>Fichier APK créé avec succès.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>Échec de la création du fichier APK</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>Le dossier sélectionné ne semble pas être un projet apktool valide (apktool.yml ou AndroidManifest.xml manquant).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Glisser-déposer un dossier</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>Analyseur APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>Analyseur APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Lancer l'analyse</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Démarrage de l'analyse...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Analyse terminée</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>Échec de l'analyse</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Vérification root : True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Vérification root : False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Vérification émulateur : True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Vérification émulateur : False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Nom d'utilisateur/mot de passe codés en dur : True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Nom d'utilisateur/mot de passe codés en dur : False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>Requêtes SQL : True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>Requêtes SQL : False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>Chemins HTTP/HTTPS : True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>Chemins HTTP/HTTPS : False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Trouvé dans :</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>Le dossier sélectionné ne contient pas de fichiers Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>Télécharger ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>Télécharger JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Télécharger Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Langue</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Enregistrer le rapport</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Exécuter</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>Nom de l'APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Journal de console</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Descompilar</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>Sobre</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Descompilação</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>Selecionar APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Pasta de saída</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Caminho do APK de saída</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Procurar</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Abrir</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Arraste e solte um arquivo</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Decodificar recursos</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Manter manifesto original</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Extrair para a pasta onde o APK está localizado</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Decodificar fontes</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Executar descompilação</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>Aguardando comando...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>Iniciando apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>Descompilação falhou</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Descompilação bem-sucedida</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>A pasta de saída não está definida.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>A pasta '{0}' não existe.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>Não foi possível abrir a pasta: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Configure o caminho do apktool em Configurações antes de descompilar.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>O caminho do apktool '{0}' não existe. Atualize em Configurações.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Arquivo APK inválido</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Arquivo JAR inválido</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Arquivo Ubersign inválido</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Solte uma pasta de projeto válida que contenha apktool.yml e AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>Arquivos APK (*.apk)|*.apk|Todos os arquivos (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>Arquivos JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Arquivos JAR do Ubersign (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Caminho do Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Caminho do Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>Caminho do JAVA: não encontrado</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>Caminho do JAVA: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Desenvolvido por</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Página do projeto</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Página do desenvolvedor</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Versão: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Baixar Apktool: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>Baixar JAVA: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>Compilar APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>Compilar APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Selecionar pasta do projeto</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>Assinar APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>Usar AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Executar compilação</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>Arquivo APK criado com sucesso.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>Falha ao criar o arquivo APK</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>A pasta selecionada não parece ser um projeto apktool válido (apktool.yml ou AndroidManifest.xml ausente).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Arraste e solte uma pasta</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>Analisador de APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>Analisador de APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Executar análise</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Iniciando análise...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Análise concluída</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>A análise falhou</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Verificação de root: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Verificação de root: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Verificação de emulador: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Verificação de emulador: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Usuário/senha hardcoded: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Usuário/senha hardcoded: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>Consultas SQL: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>Consultas SQL: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>Caminhos HTTP/HTTPS: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>Caminhos HTTP/HTTPS: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Encontrado em:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>A pasta selecionada não contém arquivos Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>Baixar ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>Baixar JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Baixar Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Idioma</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Salvar relatório</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Executar</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>Nome do APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Registro do console</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Декомпиляция</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Настройки</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>О программе</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Декомпиляция</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>Выбрать APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Папка вывода</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Путь к выходному APK</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Обзор</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Открыть</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Перетащите файл</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Декодировать ресурсы</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Сохранить исходный манифест</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Извлечь в папку, где находится APK</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Декодировать исходники</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Запустить декомпиляцию</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>Ожидание команды...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>Запуск apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>Декомпиляция не удалась</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Декомпиляция успешна</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>Папка вывода не указана.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>Папка '{0}' не существует.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>Не удалось открыть папку: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Перед декомпиляцией укажите путь к apktool в настройках.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>Путь к apktool '{0}' не существует. Обновите его в настройках.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Недопустимый файл APK</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Недопустимый файл JAR</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Недопустимый файл Ubersign</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Перетащите корректную папку проекта с apktool.yml и AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>Файлы APK (*.apk)|*.apk|Все файлы (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>Файлы JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Файлы Ubersign JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Настройки</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Путь к Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Путь к Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>Путь к JAVA: не найден</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>Путь к JAVA: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Разработано</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Страница проекта</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Страница разработчика</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Версия: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Скачать Apktool: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>Скачать JAVA: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>Сборка APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>Сборка APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Выбрать папку проекта</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>Подписать APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>Использовать AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Запустить сборку</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>APK файл успешно создан.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>Создание APK не удалось</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>Выбранная папка не похожа на проект apktool (нет apktool.yml или AndroidManifest.xml).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Перетащите папку</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>Анализатор APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>Анализатор APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Запустить анализ</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Запуск анализа...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Анализ завершен</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>Анализ не удался</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Проверка root: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Проверка root: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Проверка эмулятора: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Проверка эмулятора: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Жестко заданные логин/пароль: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Жестко заданные логин/пароль: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>SQL запросы: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>SQL запросы: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>HTTP/HTTPS пути: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>HTTP/HTTPS пути: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Найдено в:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>Выбранная папка не содержит файлы Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>Скачать ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>Скачать JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Скачать Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Язык</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Сохранить отчет</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Запустить</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>Имя APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Консольный журнал</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>Декомпіляція</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>Про програму</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>Декомпіляція</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>Вибрати APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>Папка виводу</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>Шлях до вихідного APK</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Огляд</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>Відкрити</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>Перетягніть файл</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>Декодувати ресурси</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>Зберегти оригінальний маніфест</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>Витягти до папки, де знаходиться APK</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>Декодувати вихідні коди</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>Запустити декомпіляцію</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>Очікування команди...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>Запуск apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>Декомпіляція не вдалася</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>Декомпіляція успішна</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>Папку виводу не вказано.</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>Папка '{0}' не існує.</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>Не вдалося відкрити папку: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>Перед декомпіляцією налаштуйте шлях до apktool у налаштуваннях.</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>Шлях до apktool '{0}' не існує. Оновіть його в налаштуваннях.</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>Неприпустимий файл APK</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>Неприпустимий файл JAR</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>Неприпустимий файл Ubersign</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>Перетягніть коректну папку проєкту з apktool.yml та AndroidManifest.xml.</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>Файли APK (*.apk)|*.apk|Усі файли (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>Файли JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Файли Ubersign JAR (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Шлях до Apktool</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Шлях до Ubersign</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>Шлях до JAVA: не знайдено</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>Шлях до JAVA: {0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>Розроблено</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>Сторінка проєкту</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>Сторінка розробника</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>Версія: {0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>Завантажити Apktool: </value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>Завантажити JAVA: </value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>Збірка APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>Збірка APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>Вибрати папку проєкту</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>Підписати APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>Використовувати AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>Запустити збірку</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>APK файл успішно створено.</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>Створення APK не вдалося</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>Вибрана папка не схожа на дійсний проєкт apktool (відсутній apktool.yml або AndroidManifest.xml).</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>Перетягніть папку</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>Аналізатор APK</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>Аналізатор APK</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>Запустити аналіз</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>Запуск аналізу...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>Аналіз завершено</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>Аналіз не вдався</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Перевірка root: True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Перевірка root: False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>Перевірка емулятора: True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>Перевірка емулятора: False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>Жорстко задані логін/пароль: True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Жорстко задані логін/пароль: False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>SQL запити: True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>SQL запити: False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>HTTP/HTTPS шляхи: True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>HTTP/HTTPS шляхи: False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  Знайдено в:</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>Вибрана папка не містить файлів Smali.</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>Завантажити ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>Завантажити JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>Завантажити Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>Мова</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>Зберегти звіт</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>Запустити</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>Назва APK</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>Журнал консолі</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppTitle" xml:space="preserve">
+    <value>PulseAPK</value>
+  </data>
+  <data name="MenuDecompile" xml:space="preserve">
+    <value>反编译</value>
+  </data>
+  <data name="MenuSettings" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="MenuAbout" xml:space="preserve">
+    <value>关于</value>
+  </data>
+  <data name="DecompileHeader" xml:space="preserve">
+    <value>反编译</value>
+  </data>
+  <data name="SelectApk" xml:space="preserve">
+    <value>选择 APK</value>
+  </data>
+  <data name="OutputFolder" xml:space="preserve">
+    <value>输出文件夹</value>
+  </data>
+  <data name="OutputApkLabel" xml:space="preserve">
+    <value>输出 APK 路径</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>浏览</value>
+  </data>
+  <data name="Open" xml:space="preserve">
+    <value>打开</value>
+  </data>
+  <data name="DragDropHint" xml:space="preserve">
+    <value>拖放文件</value>
+  </data>
+  <data name="DecodeResources" xml:space="preserve">
+    <value>解码资源</value>
+  </data>
+  <data name="KeepOriginalManifest" xml:space="preserve">
+    <value>保留原始清单</value>
+  </data>
+  <data name="ExtractToApkFolder" xml:space="preserve">
+    <value>解压到 APK 所在文件夹</value>
+  </data>
+  <data name="DecodeSources" xml:space="preserve">
+    <value>解码源码</value>
+  </data>
+  <data name="RunDecompile" xml:space="preserve">
+    <value>开始反编译</value>
+  </data>
+  <data name="WaitingForCommand" xml:space="preserve">
+    <value>等待命令...</value>
+  </data>
+  <data name="StartingApktool" xml:space="preserve">
+    <value>正在启动 apktool...</value>
+  </data>
+  <data name="DecompileFailed" xml:space="preserve">
+    <value>反编译失败</value>
+  </data>
+  <data name="DecompileSuccessful" xml:space="preserve">
+    <value>反编译成功</value>
+  </data>
+  <data name="Error_OutputFolderNotSet" xml:space="preserve">
+    <value>未设置输出文件夹。</value>
+  </data>
+  <data name="Error_FolderNotFound" xml:space="preserve">
+    <value>文件夹 '{0}' 不存在。</value>
+  </data>
+  <data name="Error_CouldNotOpenFolder" xml:space="preserve">
+    <value>无法打开文件夹: {0}</value>
+  </data>
+  <data name="Error_MissingApktool" xml:space="preserve">
+    <value>请先在设置中配置 apktool 路径再开始反编译。</value>
+  </data>
+  <data name="Error_InvalidApktoolPath" xml:space="preserve">
+    <value>apktool 路径 '{0}' 不存在。请在设置中更新。</value>
+  </data>
+  <data name="Error_InvalidApkFile" xml:space="preserve">
+    <value>无效的 APK 文件</value>
+  </data>
+  <data name="Error_InvalidJarFile" xml:space="preserve">
+    <value>无效的 JAR 文件</value>
+  </data>
+  <data name="Error_InvalidUbersignFile" xml:space="preserve">
+    <value>无效的 Ubersign 文件</value>
+  </data>
+  <data name="Error_InvalidProjectSelection" xml:space="preserve">
+    <value>请拖入包含 apktool.yml 和 AndroidManifest.xml 的有效项目文件夹。</value>
+  </data>
+  <data name="FileFilter_Apk" xml:space="preserve">
+    <value>APK 文件 (*.apk)|*.apk|所有文件 (*.*)|*.*</value>
+  </data>
+  <data name="FileFilter_Jar" xml:space="preserve">
+    <value>JAR 文件 (*.jar)|*.jar</value>
+  </data>
+  <data name="FileFilter_Ubersign" xml:space="preserve">
+    <value>Ubersign JAR 文件 (*.jar)|*.jar</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="ApktoolPath" xml:space="preserve">
+    <value>Apktool 路径</value>
+  </data>
+  <data name="UbersignPath" xml:space="preserve">
+    <value>Ubersign 路径</value>
+  </data>
+  <data name="JavaPathNotFound" xml:space="preserve">
+    <value>JAVA 路径：未找到</value>
+  </data>
+  <data name="JavaPathFound" xml:space="preserve">
+    <value>JAVA 路径：{0}</value>
+  </data>
+  <data name="About_DevelopedBy" xml:space="preserve">
+    <value>开发者</value>
+  </data>
+  <data name="About_ProjectPage" xml:space="preserve">
+    <value>项目页面</value>
+  </data>
+  <data name="About_DeveloperPage" xml:space="preserve">
+    <value>开发者页面</value>
+  </data>
+  <data name="About_Version" xml:space="preserve">
+    <value>版本：{0}</value>
+  </data>
+  <data name="DownloadApktool" xml:space="preserve">
+    <value>下载 Apktool：</value>
+  </data>
+  <data name="DownloadJava" xml:space="preserve">
+    <value>下载 JAVA：</value>
+  </data>
+  <data name="MenuBuild" xml:space="preserve">
+    <value>构建 APK</value>
+  </data>
+  <data name="BuildHeader" xml:space="preserve">
+    <value>构建 APK</value>
+  </data>
+  <data name="SelectProjectFolder" xml:space="preserve">
+    <value>选择项目文件夹</value>
+  </data>
+  <data name="SignApk" xml:space="preserve">
+    <value>签名 APK</value>
+  </data>
+  <data name="UseAapt2" xml:space="preserve">
+    <value>使用 AAPT2</value>
+  </data>
+  <data name="RunBuild" xml:space="preserve">
+    <value>开始构建</value>
+  </data>
+  <data name="BuildSuccessful" xml:space="preserve">
+    <value>APK 文件创建成功。</value>
+  </data>
+  <data name="BuildFailed" xml:space="preserve">
+    <value>APK 文件创建失败</value>
+  </data>
+  <data name="Warning_InvalidProjectFolder" xml:space="preserve">
+    <value>所选文件夹似乎不是有效的 apktool 项目（缺少 apktool.yml 或 AndroidManifest.xml）。</value>
+  </data>
+  <data name="DragDropFolderHint" xml:space="preserve">
+    <value>拖放文件夹</value>
+  </data>
+  <data name="MenuAnalyser" xml:space="preserve">
+    <value>APK 分析器</value>
+  </data>
+  <data name="AnalyserHeader" xml:space="preserve">
+    <value>APK 分析器</value>
+  </data>
+  <data name="RunAnalysis" xml:space="preserve">
+    <value>开始分析</value>
+  </data>
+  <data name="AnalysisStarting" xml:space="preserve">
+    <value>开始分析...</value>
+  </data>
+  <data name="AnalysisComplete" xml:space="preserve">
+    <value>分析完成</value>
+  </data>
+  <data name="AnalysisFailed" xml:space="preserve">
+    <value>分析失败</value>
+  </data>
+  <data name="RootCheckFound" xml:space="preserve">
+    <value>Root 检测：True</value>
+  </data>
+  <data name="RootCheckNotFound" xml:space="preserve">
+    <value>Root 检测：False</value>
+  </data>
+  <data name="EmulatorCheckFound" xml:space="preserve">
+    <value>模拟器检测：True</value>
+  </data>
+  <data name="EmulatorCheckNotFound" xml:space="preserve">
+    <value>模拟器检测：False</value>
+  </data>
+  <data name="CredentialsFound" xml:space="preserve">
+    <value>硬编码用户名/密码：True</value>
+  </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>硬编码用户名/密码：False</value>
+  </data>
+  <data name="SqlQueriesFound" xml:space="preserve">
+    <value>SQL 查询：True</value>
+  </data>
+  <data name="SqlQueriesNotFound" xml:space="preserve">
+    <value>SQL 查询：False</value>
+  </data>
+  <data name="HttpUrlsFound" xml:space="preserve">
+    <value>HTTP/HTTPS 路径：True</value>
+  </data>
+  <data name="HttpUrlsNotFound" xml:space="preserve">
+    <value>HTTP/HTTPS 路径：False</value>
+  </data>
+  <data name="FoundIn" xml:space="preserve">
+    <value>  发现于：</value>
+  </data>
+  <data name="Error_InvalidSmaliProject" xml:space="preserve">
+    <value>所选文件夹不包含 Smali 文件。</value>
+  </data>
+  <data name="DownloadApktoolButton" xml:space="preserve">
+    <value>下载 ApkTool</value>
+  </data>
+  <data name="DownloadJavaButton" xml:space="preserve">
+    <value>下载 JAVA</value>
+  </data>
+  <data name="DownloadUbersignerButton" xml:space="preserve">
+    <value>下载 Ubersigner</value>
+  </data>
+  <data name="LanguageLabel" xml:space="preserve">
+    <value>语言</value>
+  </data>
+  <data name="SaveReport" xml:space="preserve">
+    <value>保存报告</value>
+  </data>
+  <data name="Run" xml:space="preserve">
+    <value>运行</value>
+  </data>
+  <data name="ApkName" xml:space="preserve">
+    <value>APK 名称</value>
+  </data>
+  <data name="ConsoleLog" xml:space="preserve">
+    <value>控制台日志</value>
+  </data>
+</root>

--- a/src/PulseAPK.Core/Services/LocalizationService.cs
+++ b/src/PulseAPK.Core/Services/LocalizationService.cs
@@ -74,6 +74,8 @@ public class LocalizationService : INotifyPropertyChanged
                 _currentCulture = value;
                 Thread.CurrentThread.CurrentUICulture = value;
                 Thread.CurrentThread.CurrentCulture = value;
+                CultureInfo.DefaultThreadCurrentCulture = value;
+                CultureInfo.DefaultThreadCurrentUICulture = value;
                 Resources.Culture = value;
                 
                 if (_settingsService != null)


### PR DESCRIPTION
### Motivation

- Changing language in Settings did not update UI strings because the default thread cultures were not being changed so bindings kept using the previous culture. 
- The project also lacked localized resource files for the supported languages so translations were not available for many locales.

### Description

- Update `LocalizationService.CurrentCulture` to set `CultureInfo.DefaultThreadCurrentCulture` and `CultureInfo.DefaultThreadCurrentUICulture` in addition to `Thread.CurrentThread` and `Resources.Culture` so the selected culture applies application-wide.
- Add localized resource files under `src/PulseAPK.Core/Properties/` for the supported languages: `Resources.ru-RU.resx`, `Resources.uk-UA.resx`, `Resources.es-ES.resx`, `Resources.zh-CN.resx`, `Resources.de-DE.resx`, `Resources.fr-FR.resx`, `Resources.pt-BR.resx`, and `Resources.ar-SA.resx` containing translated UI strings.
- Existing persistence of `SelectedLanguage` via the settings service remains in place so chosen language is saved and re-applied on startup.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f38ff9c0083228ee099ac58db6d07)