### PR TITLE
Fix About version resolution

### DIFF
--- a/src/PulseAPK.Core/ViewModels/AboutViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/AboutViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using System.Diagnostics;
+using System;
+using System.Linq;
 using System.Reflection;
 using PulseAPK.Core.Abstractions;
 using Properties = PulseAPK.Core.Properties;
@@ -22,9 +23,8 @@ public partial class AboutViewModel : ObservableObject
 
     private string GetAppVersion()
     {
-        var informationalVersion = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly())
-                                            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                                            .InformationalVersion;
+        var versionAssembly = ResolveVersionAssembly();
+        var informationalVersion = GetInformationalVersion(versionAssembly);
 
         if (!string.IsNullOrWhiteSpace(informationalVersion))
         {
@@ -42,10 +42,38 @@ public partial class AboutViewModel : ObservableObject
         }
 
         var version = string.IsNullOrWhiteSpace(informationalVersion)
-            ? (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).GetName().Version?.ToString(3) ?? "1.2.1"
+            ? versionAssembly.GetName().Version?.ToString(3) ?? "1.2.1"
             : informationalVersion;
 
         return string.Format(Properties.Resources.About_Version, version);
+    }
+
+    private static Assembly ResolveVersionAssembly()
+    {
+        var entryAssembly = Assembly.GetEntryAssembly();
+        if (entryAssembly != null)
+        {
+            return entryAssembly;
+        }
+
+        return AppDomain.CurrentDomain
+                   .GetAssemblies()
+                   .FirstOrDefault(assembly => assembly.EntryPoint != null)
+               ?? Assembly.GetExecutingAssembly();
+    }
+
+    private static string? GetInformationalVersion(Assembly assembly)
+    {
+        var informationalVersion = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(informationalVersion))
+        {
+            return informationalVersion;
+        }
+
+        return assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
     }
 
     [RelayCommand]


### PR DESCRIPTION
### Motivation

- The About page sometimes showed no version because the previous lookup relied on `Assembly.GetEntryAssembly()` which can be null in some hosting scenarios.

### Description

- Resolve a reliable assembly for version lookup by adding `ResolveVersionAssembly()` which prefers `Assembly.GetEntryAssembly()` then an assembly with `EntryPoint` and finally `Assembly.GetExecutingAssembly()`.
- Add `GetInformationalVersion(Assembly)` to prefer `AssemblyInformationalVersionAttribute` and fall back to `AssemblyFileVersionAttribute` when informational version is missing.
- Use the resolved assembly for both informational and `Version` fallback and keep existing trimming of metadata (`+`) and prerelease (`-`) segments.
- Add required `using` directives (`System` and `System.Linq`) and update `AboutViewModel` accordingly.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698091ed64888322bb7ad74b0dcbefad)