### PR TITLE
Align project version metadata to 1.2.0

### DIFF
--- a/PulseAPK.csproj
+++ b/PulseAPK.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
-    <Version>1.2.1</Version>
+    <Version>1.2.0</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ApplicationIcon>Resources\CyberUnpack.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <Version>1.2.0</Version>
+    <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PulseAPK.Core</RootNamespace>
+    <Version>1.2.0</Version>
+    <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Fix mismatches between the shipped/displayed app version and the intended release version so runtime version resolution reports the correct value.
- Ensure all front-end app projects and the core library expose consistent version metadata so `InformationalVersion`/file version lookups return the same release string.

### Description
- Updated `PulseAPK.csproj` to set `<Version>1.2.0</Version>` (was `1.2.1`).
- Added `<Version>1.2.0</Version>` and `<InformationalVersion>$(Version)</InformationalVersion>` to `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` so the Avalonia app reports the release version.
- Added `<Version>1.2.0</Version>` and `<InformationalVersion>$(Version)</InformationalVersion>` to `src/PulseAPK.Core/PulseAPK.Core.csproj` so the core library provides the same informational version.

### Testing
- No automated tests were executed for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698094e4c27c8322ab7bb5d6a46ca7ff)