### PR TITLE
Fix sidebar localization updates

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -4,7 +4,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:PulseAPK"
-        xmlns:utils="clr-namespace:PulseAPK.Utils"
         xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
         xmlns:views="clr-namespace:PulseAPK.Views"
         xmlns:properties="clr-namespace:PulseAPK.Core.Properties;assembly=PulseAPK.Core"
@@ -50,10 +49,10 @@
                                 <DropShadowEffect Color="{StaticResource Color.NeonCyan}" BlurRadius="10" ShadowDepth="0" Opacity="0.8"/>
                             </Image.Effect>
                         </Image>
-                        <TextBlock Text="{utils:Localization Key=AppTitle}" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" VerticalAlignment="Center"/>
+                        <TextBlock Text="{Binding WindowTitle}" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" VerticalAlignment="Center"/>
                     </StackPanel>
 
-                    <Button Content="{utils:Localization Key=MenuDecompile}" Command="{Binding NavigateToDecompileCommand}">
+                    <Button Content="{Binding MenuDecompileLabel}" Command="{Binding NavigateToDecompileCommand}">
                         <Button.Style>
                             <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
                                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -67,7 +66,7 @@
                             </Style>
                         </Button.Style>
                     </Button>
-                    <Button Content="{utils:Localization Key=MenuBuild}" Command="{Binding NavigateToBuildCommand}">
+                    <Button Content="{Binding MenuBuildLabel}" Command="{Binding NavigateToBuildCommand}">
                         <Button.Style>
                             <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
                                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -81,7 +80,7 @@
                             </Style>
                         </Button.Style>
                     </Button>
-                    <Button Content="{utils:Localization Key=MenuAnalyser}" Command="{Binding NavigateToAnalyserCommand}">
+                    <Button Content="{Binding MenuAnalyserLabel}" Command="{Binding NavigateToAnalyserCommand}">
                         <Button.Style>
                             <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
                                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -95,7 +94,7 @@
                             </Style>
                         </Button.Style>
                     </Button>
-                    <Button Content="{utils:Localization Key=MenuSettings}" Command="{Binding NavigateToSettingsCommand}">
+                    <Button Content="{Binding MenuSettingsLabel}" Command="{Binding NavigateToSettingsCommand}">
                         <Button.Style>
                             <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
                                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -109,7 +108,7 @@
                             </Style>
                         </Button.Style>
                     </Button>
-                    <Button Content="{utils:Localization Key=MenuAbout}" Command="{Binding NavigateToAboutCommand}">
+                    <Button Content="{Binding MenuAboutLabel}" Command="{Binding NavigateToAboutCommand}">
                         <Button.Style>
                             <Style TargetType="Button" BasedOn="{StaticResource CyberButtonStyle}">
                                 <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.ComponentModel;
 using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Services;
 using Properties = PulseAPK.Core.Properties;
 
 namespace PulseAPK.Core.ViewModels;
@@ -8,6 +10,7 @@ namespace PulseAPK.Core.ViewModels;
 public partial class MainViewModel : ObservableObject
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly LocalizationService _localizationService;
 
     [ObservableProperty]
     private object _currentView;
@@ -18,9 +21,18 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private string _selectedMenu = "Decompile";
 
-    public MainViewModel(IServiceProvider serviceProvider)
+    public string MenuDecompileLabel => _localizationService["MenuDecompile"];
+    public string MenuBuildLabel => _localizationService["MenuBuild"];
+    public string MenuAnalyserLabel => _localizationService["MenuAnalyser"];
+    public string MenuSettingsLabel => _localizationService["MenuSettings"];
+    public string MenuAboutLabel => _localizationService["MenuAbout"];
+
+    public MainViewModel(IServiceProvider serviceProvider, LocalizationService localizationService)
     {
         _serviceProvider = serviceProvider;
+        _localizationService = localizationService;
+        WindowTitle = _localizationService["AppTitle"];
+        _localizationService.PropertyChanged += HandleLocalizationChanged;
         // Initial view
         CurrentView = Resolve<DecompileViewModel>();
     }
@@ -66,5 +78,20 @@ public partial class MainViewModel : ObservableObject
         if (service == null)
             throw new InvalidOperationException($"Could not resolve service of type {typeof(T).Name}");
         return (T)service;
+    }
+
+    private void HandleLocalizationChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != "Item[]")
+        {
+            return;
+        }
+
+        WindowTitle = _localizationService["AppTitle"];
+        OnPropertyChanged(nameof(MenuDecompileLabel));
+        OnPropertyChanged(nameof(MenuBuildLabel));
+        OnPropertyChanged(nameof(MenuAnalyserLabel));
+        OnPropertyChanged(nameof(MenuSettingsLabel));
+        OnPropertyChanged(nameof(MenuAboutLabel));
     }
 }


### PR DESCRIPTION
### Motivation
- The left sidebar (app title and menu labels) stayed in English after switching languages, so the UI needs to observe localization changes and update the displayed strings automatically.

### Description
- MainViewModel now depends on `LocalizationService`, exposes localized label properties `MenuDecompileLabel`, `MenuBuildLabel`, `MenuAnalyserLabel`, `MenuSettingsLabel`, and `MenuAboutLabel`, and initializes `WindowTitle` from the localization service.
- MainViewModel subscribes to `LocalizationService.PropertyChanged` and raises property change notifications to refresh the sidebar labels and `WindowTitle` when the language changes via the `HandleLocalizationChanged` handler.
- `MainWindow.xaml` bindings were switched from the static localization markup to the view model properties by binding the title to `WindowTitle` and each menu button to the new `Menu*Label` properties, and the unused `utils` namespace was removed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809884808c8322b630fd60f29d33fb)