### PR TITLE
Fix WPF Settings language ComboBox binding

### DIFF
--- a/Views/SettingsView.xaml
+++ b/Views/SettingsView.xaml
@@ -3,22 +3,18 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:properties="clr-namespace:PulseAPK.Properties"
              xmlns:utils="clr-namespace:PulseAPK.Utils"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="800">
-    <UserControl.Resources>
-        <utils:EnumDescriptionConverter x:Key="EnumDescriptionConverter"/>
-    </UserControl.Resources>
     <Grid Margin="20">
         <StackPanel>
             <TextBlock Text="{utils:Localization SettingsHeader}" Foreground="{StaticResource Brush.TextPrimary}" FontSize="24" FontWeight="Bold" Margin="0,0,0,20"/>
 
             <TextBlock Text="{utils:Localization LanguageLabel}" Foreground="{StaticResource Brush.TextSecondary}" Margin="0,0,0,5"/>
-            <ComboBox ItemsSource="{Binding Languages}" SelectedItem="{Binding SelectedLanguage}" Width="200" HorizontalAlignment="Left" Margin="0,0,0,10">
+            <ComboBox ItemsSource="{Binding AvailableLanguages}" SelectedItem="{Binding SelectedLanguage}" Width="200" HorizontalAlignment="Left" Margin="0,0,0,10">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}"/>
+                        <TextBlock Text="{Binding Name}"/>
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>


### PR DESCRIPTION
### Motivation
- The WPF Settings view ComboBox was bound to an outdated source (`Languages` + `EnumDescriptionConverter`) which prevented `SelectedLanguage` changes from propagating and left the left panel untranslated.

### Description
- Update `Views/SettingsView.xaml` to bind the ComboBox `ItemsSource` to the view model's `AvailableLanguages` and `SelectedItem` to `SelectedLanguage` so selection updates the `LocalizationService`.
- Replace the enum converter usage with a direct `Text` binding to each language `Name` and remove the unused `EnumDescriptionConverter` hookup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69809d13a6808322b94c29009efbed3b)