### PR TITLE
Fix immediate localization refresh for menu labels

### DIFF
--- a/src/PulseAPK.Core/Services/LocalizationService.cs
+++ b/src/PulseAPK.Core/Services/LocalizationService.cs
@@ -85,6 +85,8 @@ public class LocalizationService : INotifyPropertyChanged
                 }
                 
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item"));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentLanguage)));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentCulture)));
             }


### PR DESCRIPTION
### Motivation
- Sidebar/menu labels were not updating immediately after a language change because some bindings were not being notified when the culture changed.

### Description
- Updated `LocalizationService.CurrentCulture` to raise additional `PropertyChanged` notifications (`"Item[]"`, `"Item"`, and `string.Empty`) so all bindings (including menu/sidebar labels) refresh immediately; change is in `src/PulseAPK.Core/Services/LocalizationService.cs`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980a162e790832285efd901808be0a5)