### PR TITLE
Fix drag-and-drop handling in Decompile view

### DIFF
--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -28,7 +28,7 @@
         </TextBlock>
 
         <!-- Drop zone -->
-        <Border Grid.Row="1" Style="{StaticResource CyberPanelStyle}" Height="150" Margin="0,0,0,20" AllowDrop="True" DragEnter="Border_DragEnter" Drop="Border_Drop">
+        <Border Grid.Row="1" Style="{StaticResource CyberPanelStyle}" Height="150" Margin="0,0,0,20" AllowDrop="True" DragEnter="Border_DragEnter" DragOver="Border_DragOver" Drop="Border_Drop">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/Views/DecompileView.xaml.cs
+++ b/Views/DecompileView.xaml.cs
@@ -21,6 +21,22 @@ namespace PulseAPK.Views
             {
                 e.Effects = DragDropEffects.None;
             }
+
+            e.Handled = true;
+        }
+
+        private void Border_DragOver(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                e.Effects = DragDropEffects.Copy;
+            }
+            else
+            {
+                e.Effects = DragDropEffects.None;
+            }
+
+            e.Handled = true;
         }
 
         private void Border_Drop(object sender, DragEventArgs e)
@@ -46,6 +62,8 @@ namespace PulseAPK.Views
                     }
                 }
             }
+
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Drag-and-drop of APK files into the Decompile view was unreliable because the drop zone did not handle `DragOver` events and drag/drop events were not marked handled, preventing proper file acceptance.

### Description
- Wire up the `DragOver` event on the drop `Border` in `Views/DecompileView.xaml` by adding `DragOver="Border_DragOver"`.
- Implement `Border_DragOver` in `Views/DecompileView.xaml.cs` to mirror `DragEnter` behavior and set `e.Effects` appropriately.
- Mark drag event handlers as handled by setting `e.Handled = true` in `Border_DragEnter`, `Border_DragOver`, and `Border_Drop` to ensure the drop target processes the file drop reliably.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ad275d6c8322a26328126b30bc2a)