### PR TITLE
Fix decompile drag-and-drop handling (WPF & Avalonia)

### DIFF
--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -28,7 +28,13 @@
         </TextBlock>
 
         <!-- Drop zone -->
-        <Border Grid.Row="1" Style="{StaticResource CyberPanelStyle}" Height="150" Margin="0,0,0,20" AllowDrop="True" DragEnter="Border_DragEnter" DragOver="Border_DragOver" Drop="Border_Drop">
+        <Border Grid.Row="1" Style="{StaticResource CyberPanelStyle}" Height="150" Margin="0,0,0,20" AllowDrop="True"
+                DragEnter="Border_DragEnter"
+                DragOver="Border_DragOver"
+                Drop="Border_Drop"
+                PreviewDragEnter="Border_DragEnter"
+                PreviewDragOver="Border_DragOver"
+                PreviewDrop="Border_Drop">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -4,7 +4,12 @@
              xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.DecompileView"
              x:DataType="vm:DecompileViewModel">
-    <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="16" Margin="20">
+    <Grid RowDefinitions="Auto,Auto,Auto,*"
+          RowSpacing="16"
+          Margin="20"
+          DragDrop.AllowDrop="True"
+          DragDrop.DragOver="OnDragOver"
+          DragDrop.Drop="OnDrop">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecompileHeader]}"
                    FontSize="24"
                    FontWeight="SemiBold" />

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml.cs
@@ -59,6 +59,8 @@ public partial class DecompileView : UserControl
         {
             viewModel.ApkPath = path;
         }
+
+        e.Handled = true;
     }
 
     private static async Task ShowWarningAsync(string message, string title)


### PR DESCRIPTION
### Motivation
- Drag-and-drop on the Decompile view was unreliable because child controls could capture events or the root view wasn't set to accept drops, preventing files from being received. 
- The Avalonia view did not mark drop events as handled, which could allow event fallthrough and unexpected behavior. 
- Make the drop zone more robust across both WPF and Avalonia implementations so users can reliably drag APKs into the Decompile view.

### Description
- WPF: added `PreviewDragEnter`, `PreviewDragOver`, and `PreviewDrop` handlers to the Decompile drop `Border` so preview routed events are handled and not swallowed by child elements (`Views/DecompileView.xaml`).
- Avalonia view: enabled drag-and-drop handling on the root `Grid` by setting `DragDrop.AllowDrop="True"` and wiring `DragDrop.DragOver`/`DragDrop.Drop` to `OnDragOver`/`OnDrop` so the entire view can accept files (`src/PulseAPK.Avalonia/Views/DecompileView.axaml`).
- Avalonia code-behind: marked the drop event as handled by setting `e.Handled = true;` after successfully assigning `ApkPath` to prevent further event processing (`src/PulseAPK.Avalonia/Views/DecompileView.axaml.cs`).
- Changed formatting of event attributes in WPF XAML for clarity; adjusted Avalonia XAML to attach handlers at the root for broader coverage.

### Testing
- No automated tests were executed as part of this change.
- Manual verification is recommended for both WPF and Avalonia UI builds to confirm drag-and-drop now reliably sets the APK path and shows error dialogs for invalid files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b07ad6b083229d322890f48dfb66)