### PR TITLE
Fix drag-and-drop handling in Decompile view

### DIFF
--- a/Views/DecompileView.xaml
+++ b/Views/DecompileView.xaml
@@ -31,10 +31,7 @@
         <Border Grid.Row="1" Style="{StaticResource CyberPanelStyle}" Height="150" Margin="0,0,0,20" AllowDrop="True"
                 DragEnter="Border_DragEnter"
                 DragOver="Border_DragOver"
-                Drop="Border_Drop"
-                PreviewDragEnter="Border_DragEnter"
-                PreviewDragOver="Border_DragOver"
-                PreviewDrop="Border_Drop">
+                Drop="Border_Drop">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>

--- a/Views/DecompileView.xaml.cs
+++ b/Views/DecompileView.xaml.cs
@@ -21,8 +21,6 @@ namespace PulseAPK.Views
             {
                 e.Effects = DragDropEffects.None;
             }
-
-            e.Handled = true;
         }
 
         private void Border_DragOver(object sender, DragEventArgs e)
@@ -35,8 +33,6 @@ namespace PulseAPK.Views
             {
                 e.Effects = DragDropEffects.None;
             }
-
-            e.Handled = true;
         }
 
         private void Border_Drop(object sender, DragEventArgs e)
@@ -62,8 +58,6 @@ namespace PulseAPK.Views
                     }
                 }
             }
-
-            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Drag-and-drop in the Decompile view was not routing correctly because preview handlers and explicit `e.Handled = true` calls intercepted routed events and prevented normal bubbling and handling.

### Description
- Remove preview drag event attributes from `Views/DecompileView.xaml` and remove `e.Handled = true` from `Border_DragEnter`, `Border_DragOver`, and `Border_Drop` in `Views/DecompileView.xaml.cs` to allow standard routed drag events to bubble while keeping existing APK validation and assignment logic intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b55db3f08322b456832837774705)