### PR TITLE
Fix Decompile view drag-and-drop handling

### DIFF
--- a/Views/DecompileView.xaml.cs
+++ b/Views/DecompileView.xaml.cs
@@ -21,6 +21,8 @@ namespace PulseAPK.Views
             {
                 e.Effects = DragDropEffects.None;
             }
+
+            e.Handled = true;
         }
 
         private void Border_DragOver(object sender, DragEventArgs e)
@@ -33,6 +35,8 @@ namespace PulseAPK.Views
             {
                 e.Effects = DragDropEffects.None;
             }
+
+            e.Handled = true;
         }
 
         private void Border_Drop(object sender, DragEventArgs e)
@@ -58,6 +62,8 @@ namespace PulseAPK.Views
                     }
                 }
             }
+
+            e.Handled = true;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Drag-and-drop in the Decompile view was not reliably accepted because the drag event handlers did not mark events as handled, allowing parent controls to intercept them.

### Description
- Set `e.Handled = true` in `Border_DragEnter`, `Border_DragOver`, and `Border_Drop` in `Views/DecompileView.xaml.cs` so the Decompile view fully consumes file drag/drop events.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b6cc887c8322b6b5b0c69e570cf9)