### PR TITLE
Add application icon asset and reference for Avalonia UI

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -8,7 +8,8 @@
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PulseAPK.Avalonia.MainWindow"
         x:DataType="vm:MainViewModel"
-        Title="{Binding WindowTitle}">
+        Title="{Binding WindowTitle}"
+        Icon="/Assets/CyberUnpack.ico">
 
     <Window.DataTemplates>
         <DataTemplate DataType="{x:Type vm:DecompileViewModel}">

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -7,6 +7,7 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <Version>1.2.0</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
+    <ApplicationIcon>..\..\Resources\CyberUnpack.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +23,10 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AvaloniaResource Include="..\..\Resources\CyberUnpack.ico" Link="Assets\CyberUnpack.ico" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Embed and display the application icon for the Avalonia-based UI so the window shows the intended `CyberUnpack.ico` icon in builds and at runtime.

### Description
- Added `Icon="/Assets/CyberUnpack.ico"` to `MainWindow.axaml`, introduced `<ApplicationIcon>` and added an `<AvaloniaResource Include="..\..\Resources\CyberUnpack.ico" Link="Assets\CyberUnpack.ico" />` entry in `PulseAPK.Avalonia.csproj` to include the ICO in the build output.

### Testing
- Ran `dotnet build src/PulseAPK.Avalonia` and `dotnet build` for the solution and both builds completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b063267dac83228582329764c3d11f)