### PR TITLE
Fix AppImage icon handling for invalid PNG assets

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -29,6 +29,13 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "'$1' is required but was not found in PATH."
 }
 
+is_png_file() {
+  local icon_path="$1"
+  local signature
+  signature="$(head -c 8 "${icon_path}" | xxd -p -c 256)"
+  [[ "${signature}" == "89504e470d0a1a0a" ]]
+}
+
 require_cmd dotnet
 require_cmd appimagetool
 
@@ -82,13 +89,17 @@ Categories=Development;
 Terminal=false
 EOF
 
-if [[ -f "${icon_src}" ]]; then
-  log "Icon found: ${icon_src}"
+if [[ -f "${icon_src}" ]] && is_png_file "${icon_src}"; then
+  log "Icon found and valid PNG: ${icon_src}"
   cp "${icon_src}" "${appdir}/${app_name}.png"
   cp "${icon_src}" "${appdir}/usr/share/icons/hicolor/256x256/apps/${app_name}.png"
   cp "${icon_src}" "${appdir}/.DirIcon"
 else
-  log "Icon not found, generating fallback SVG icon."
+  if [[ -f "${icon_src}" ]]; then
+    log "Icon exists but is not a valid PNG: ${icon_src}. Generating fallback SVG icon."
+  else
+    log "Icon not found, generating fallback SVG icon."
+  fi
 
   cat > "${appdir}/${app_name}.svg" <<'EOF'
 <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">


### PR DESCRIPTION
### Motivation
- The AppImage build uses `Resources/CyberUnpack.png` as the desktop/icon asset but the file on disk is actually a JPEG, which can break icon tooling and produce unpredictable desktop behavior. 
- The build should detect malformed/mislabeled icon files and fall back to a known-good SVG to make the packaging deterministic and easier to diagnose.

### Description
- Added an `is_png_file` helper to `scripts/build-appimage.sh` that validates the PNG signature bytes before using the icon. 
- Updated the icon copy conditional to only use the `Resources/CyberUnpack.png` when it exists and passes the PNG signature check. 
- Improved logging to explicitly report when the icon file exists but is not a valid PNG and preserved the existing SVG fallback behavior.

### Testing
- Ran `bash -n scripts/build-appimage.sh` to verify the script syntax, which succeeded. 
- Ran a Python header check that confirmed `Resources/CyberUnpack.png` and `src/PulseAPK.Avalonia/Assets/CyberUnpack.png` start with a JPEG header (`FFD8FFE0`) rather than the PNG signature (`89504E470D0A1A0A`). 
- Attempted `dotnet publish`/`dotnet build` in this environment but it could not be executed because `dotnet` is not installed here (tooling check failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b066dfe97c8322879f4217582737af)