### PR TITLE
Fix AppImage icon detection when xxd is unavailable

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -32,7 +32,7 @@ require_cmd() {
 is_png_file() {
   local icon_path="$1"
   local signature
-  signature="$(head -c 8 "${icon_path}" | xxd -p -c 256)"
+  signature="$(od -An -tx1 -N8 "${icon_path}" | tr -d ' \n')"
   [[ "${signature}" == "89504e470d0a1a0a" ]]
 }
 


### PR DESCRIPTION
### Motivation
- The AppImage build script relied on `xxd` to read the PNG signature in `scripts/build-appimage.sh` but never required it, causing valid PNG icons to be treated as invalid in minimal environments and forcing the fallback SVG-only path.

### Description
- Update `is_png_file()` to read the first 8 bytes using `od -An -tx1 -N8 "${icon_path}" | tr -d ' \n'` instead of `head | xxd`, so PNG validation works even when `xxd` is not installed.

### Testing
- Verified script syntax with `bash -n scripts/build-appimage.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b069f8ec60832292a98eac57c9e10d)