### PR TITLE
Fix decompile output path in AppImage environments

### DIFF
--- a/src/PulseAPK.Core/Utils/PathUtils.cs
+++ b/src/PulseAPK.Core/Utils/PathUtils.cs
@@ -7,7 +7,25 @@ namespace PulseAPK.Core.Utils
     {
         public static string GetDefaultDecompilePath()
         {
-            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "decompiled");
+            var writableRoot = GetWritableAppDataRoot();
+            return Path.Combine(writableRoot, "decompiled");
+        }
+
+        private static string GetWritableAppDataRoot()
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrWhiteSpace(localAppData))
+            {
+                return Path.Combine(localAppData, "PulseAPK");
+            }
+
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (!string.IsNullOrWhiteSpace(userProfile))
+            {
+                return Path.Combine(userProfile, ".pulseapk");
+            }
+
+            return Path.Combine(Path.GetTempPath(), "PulseAPK");
         }
     }
 }


### PR DESCRIPTION
### Motivation
- AppImage and similar runtimes mount application binaries under read-only/ephemeral directories (e.g. `/tmp/.mount_*`), causing decompilation to fail when the default output uses `AppDomain.CurrentDomain.BaseDirectory`; the default should use a user-writable location instead.

### Description
- Updated `GetDefaultDecompilePath` in `src/PulseAPK.Core/Utils/PathUtils.cs` to return a user-writable path that prefers `Environment.SpecialFolder.LocalApplicationData/PulseAPK`, falls back to `UserProfile/.pulseapk`, and finally to `Path.GetTempPath()/PulseAPK`.

### Testing
- Attempted `dotnet build PulseAPK.sln -v minimal` to validate the change but the `dotnet` CLI is not available in this environment so the build could not be executed; no automated tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06eb35c6083228bedf1835d5a6a37)