### PR TITLE
Fix AppImage APK build output path to writable directory

### DIFF
--- a/src/PulseAPK.Core/Utils/PathUtils.cs
+++ b/src/PulseAPK.Core/Utils/PathUtils.cs
@@ -11,6 +11,12 @@ namespace PulseAPK.Core.Utils
             return Path.Combine(writableRoot, "decompiled");
         }
 
+        public static string GetDefaultCompiledPath()
+        {
+            var writableRoot = GetWritableAppDataRoot();
+            return Path.Combine(writableRoot, "compiled");
+        }
+
         private static string GetWritableAppDataRoot()
         {
             var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);

--- a/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
@@ -280,16 +280,42 @@ public partial class BuildViewModel : ObservableObject
 
     private string EnsureCompiledDirectory()
     {
-        var compiledDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "compiled");
+        var preferredCompiledDir = PathUtils.GetDefaultCompiledPath();
 
-        if (!Directory.Exists(compiledDir))
+        if (TryEnsureDirectory(preferredCompiledDir, out var ensuredCompiledDir))
         {
-            try { Directory.CreateDirectory(compiledDir); } catch { }
+            return ensuredCompiledDir;
         }
 
-        return compiledDir;
+        var fallbackCompiledDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "compiled");
+        if (TryEnsureDirectory(fallbackCompiledDir, out var ensuredFallbackDir))
+        {
+            return ensuredFallbackDir;
+        }
+
+        return Directory.GetCurrentDirectory();
     }
 
+
+    private static bool TryEnsureDirectory(string path, out string ensuredPath)
+    {
+        ensuredPath = path;
+
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(path);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
     private string GetApplicationRootPath()
     {
         return string.IsNullOrWhiteSpace(AppDomain.CurrentDomain.BaseDirectory)


### PR DESCRIPTION
### Motivation
- The APK build default output used `AppDomain.CurrentDomain.BaseDirectory` which can point inside a read-only AppImage mount (e.g. `/tmp/.mount_.../usr/bin`), causing `apktool b -o` to fail with `NoSuchFileException` for paths like `/tmp/.mount_.../usr/bin/compiled/fd.apk`.
- We need compiled APK outputs to land in a per-user writable location by default to avoid write errors when running from AppImage or other read-only installs.

### Description
- Added `PathUtils.GetDefaultCompiledPath()` to resolve a writable per-user app-data `compiled` folder alongside the existing decompile path in `src/PulseAPK.Core/Utils/PathUtils.cs`.
- Updated `BuildViewModel.EnsureCompiledDirectory()` to prefer the writable app-data compiled folder, fall back to `AppDomain.CurrentDomain.BaseDirectory` only if creation succeeds, and finally fall back to the current working directory; the change is in `src/PulseAPK.Core/ViewModels/BuildViewModel.cs`.
- Introduced `TryEnsureDirectory(...)` helper to safely attempt directory creation without throwing and to make the fallback logic explicit in `BuildViewModel`.

### Testing
- Attempted an automated build with `dotnet build PulseAPK.sln -c Release`, which failed in this environment because `dotnet` is not installed (`command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0705ff5d88322a977f9387810446d)