### PR TITLE
Harden analyser flow for sandboxed/inaccessible directories

### DIFF
--- a/src/PulseAPK.Core/Services/SmaliAnalyserService.cs
+++ b/src/PulseAPK.Core/Services/SmaliAnalyserService.cs
@@ -30,8 +30,8 @@ namespace PulseAPK.Core.Services
                 rules = (AnalysisRuleSet)AnalysisRulesLoader.InitializeRules();
             }
 
-            // Find all .smali files recursively
-            var smaliFiles = Directory.GetFiles(projectPath, "*.smali", SearchOption.AllDirectories);
+            // Find all .smali files recursively, skipping inaccessible directories (sandbox/container safe)
+            var smaliFiles = GetSmaliFiles(projectPath, logCallback);
 
             if (smaliFiles.Length == 0)
             {
@@ -83,6 +83,27 @@ namespace PulseAPK.Core.Services
             });
 
             return result;
+        }
+
+        private string[] GetSmaliFiles(string projectPath, Action<string> logCallback)
+        {
+            try
+            {
+                var options = new EnumerationOptions
+                {
+                    RecurseSubdirectories = true,
+                    IgnoreInaccessible = true,
+                    ReturnSpecialDirectories = false,
+                    AttributesToSkip = FileAttributes.ReparsePoint
+                };
+
+                return Directory.GetFiles(projectPath, "*.smali", options);
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
+            {
+                logCallback?.Invoke($"Warning: Unable to enumerate some folders due to sandbox/file-system restrictions: {ex.Message}");
+                return Array.Empty<string>();
+            }
         }
 
         private void AnalyzeFile(

--- a/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
@@ -81,7 +81,15 @@ public partial class AnalyserViewModel : ObservableObject
             return;
         }
 
-        var smaliFiles = Directory.EnumerateFiles(folder, "*.smali", SearchOption.AllDirectories);
+        var options = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+            ReturnSpecialDirectories = false,
+            AttributesToSkip = FileAttributes.ReparsePoint
+        };
+
+        var smaliFiles = Directory.EnumerateFiles(folder, "*.smali", options);
         if (!smaliFiles.Any())
         {
             await _dialogService.ShowWarningAsync(Properties.Resources.Error_InvalidSmaliProject, Properties.Resources.AnalyserHeader);


### PR DESCRIPTION
### Motivation
- Recursive discovery using `SearchOption.AllDirectories` could throw on inaccessible subfolders and abort analysis in sandboxed or mounted environments. 
- The analyser and project-folder validation must tolerate permission-restricted trees so analysis can continue rather than fail hard.

### Description
- Replaced `Directory.GetFiles(projectPath, "*.smali", SearchOption.AllDirectories)` with a new helper `GetSmaliFiles(projectPath, logCallback)` that uses `EnumerationOptions` and returns `string[]` safely. 
- Enabled `IgnoreInaccessible = true` and set `AttributesToSkip = FileAttributes.ReparsePoint` so enumeration skips inaccessible directories and reparse points. 
- Added a warning log when enumeration fails due to `UnauthorizedAccessException` or `IOException`, and updated `AnalyserViewModel.BrowseProject` to use the same safe `EnumerationOptions`.

### Testing
- Attempted to run `dotnet build PulseAPK.sln`, but the `dotnet` SDK is not available in this environment so compilation could not be executed (failed). 
- Verified changes via repository diff and committed the updates successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b073507544832291c6ba56535c37aa)