### PR TITLE
Fix sandbox-safe report save location

### DIFF
--- a/src/PulseAPK.Core/Services/ReportService.cs
+++ b/src/PulseAPK.Core/Services/ReportService.cs
@@ -1,25 +1,17 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using PulseAPK.Core.Utils;
 
 namespace PulseAPK.Core.Services
 {
     public class ReportService
     {
-        private const string ReportsDirectoryName = "reports";
-
         public async Task<string> SaveReportAsync(string reportContent, string folderName)
         {
             try
             {
-                // Create reports directory if it doesn't exist
-                string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                string reportsDirectory = Path.Combine(appDirectory, ReportsDirectoryName);
-
-                if (!Directory.Exists(reportsDirectory))
-                {
-                    Directory.CreateDirectory(reportsDirectory);
-                }
+                var reportsDirectory = EnsureReportsDirectory();
 
                 // Format filename: [date]-[time]-[folder name].txt
                 // Using a safe date format for filenames
@@ -37,6 +29,50 @@ namespace PulseAPK.Core.Services
             {
                 throw new Exception($"Failed to save report: {ex.Message}", ex);
             }
+        }
+
+        private static string EnsureReportsDirectory()
+        {
+            var preferredReportsDir = PathUtils.GetDefaultReportsPath();
+            if (TryEnsureDirectory(preferredReportsDir, out var ensuredReportsDir))
+            {
+                return ensuredReportsDir;
+            }
+
+            var fallbackReportsDir = Path.Combine(GetApplicationRootPath(), "reports");
+            if (TryEnsureDirectory(fallbackReportsDir, out var ensuredFallbackDir))
+            {
+                return ensuredFallbackDir;
+            }
+
+            return Directory.GetCurrentDirectory();
+        }
+
+        private static bool TryEnsureDirectory(string path, out string ensuredPath)
+        {
+            ensuredPath = path;
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                Directory.CreateDirectory(path);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string GetApplicationRootPath()
+        {
+            return string.IsNullOrWhiteSpace(AppDomain.CurrentDomain.BaseDirectory)
+                ? Directory.GetCurrentDirectory()
+                : AppDomain.CurrentDomain.BaseDirectory;
         }
 
         private string GetSafeFilename(string filename)

--- a/src/PulseAPK.Core/Utils/PathUtils.cs
+++ b/src/PulseAPK.Core/Utils/PathUtils.cs
@@ -17,6 +17,12 @@ namespace PulseAPK.Core.Utils
             return Path.Combine(writableRoot, "compiled");
         }
 
+        public static string GetDefaultReportsPath()
+        {
+            var writableRoot = GetWritableAppDataRoot();
+            return Path.Combine(writableRoot, "reports");
+        }
+
         private static string GetWritableAppDataRoot()
         {
             var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);

--- a/tests/unit/PulseAPK.Tests/Utils/PathUtilsTests.cs
+++ b/tests/unit/PulseAPK.Tests/Utils/PathUtilsTests.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using PulseAPK.Core.Utils;
+using Xunit;
+
+namespace PulseAPK.Tests.Utils
+{
+    public class PathUtilsTests
+    {
+        [Fact]
+        public void GetDefaultReportsPath_ShouldEndWithReportsDirectory()
+        {
+            var path = PathUtils.GetDefaultReportsPath();
+
+            Assert.False(string.IsNullOrWhiteSpace(path));
+            Assert.EndsWith($"PulseAPK{Path.DirectorySeparatorChar}reports", path, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Saving analysis reports previously wrote into `AppDomain.CurrentDomain.BaseDirectory`, which can be read-only in sandboxed environments and caused save failures. 
- Reports need to be persisted to a writable, user-scoped location and fall back safely when that location isn't available.

### Description
- Updated `ReportService.SaveReportAsync` to use a new `EnsureReportsDirectory()` that prefers a writable app-data reports directory and falls back to the app root `reports` folder and then to the current working directory. 
- Added `PathUtils.GetDefaultReportsPath()` to centralize generation of the preferred reports path under `LocalApplicationData/PulseAPK/reports` (with user-profile and temp fallbacks). 
- Implemented safe directory creation via `TryEnsureDirectory` and `GetApplicationRootPath()` helpers in `ReportService`. 
- Added unit test `PathUtilsTests.GetDefaultReportsPath_ShouldEndWithReportsDirectory` to validate the default reports path behavior.

### Testing
- Added unit test `tests/unit/PulseAPK.Tests/Utils/PathUtilsTests.cs` which was created and staged. 
- Attempted to run `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj` but the environment lacks `dotnet`, so automated tests could not be executed here (failure: `dotnet` not found). 
- Changes committed locally with message `Fix report save path for sandboxed environments`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07524bdcc8322a83aaa41603131c9)