### PR TITLE
Harden AppImage publishing to prevent shipping path-leaking artifacts

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -55,11 +55,21 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  -p:DebugType=None \
+  -p:DebugSymbols=false \
   /p:PublishSingleFile=false \
   -o "${publish_dir}"
 
+log "Removing non-runtime artifacts from publish output..."
+find "${publish_dir}" -type f \( -name '*.pdb' -o -name '*.xml' \) -delete
+
 log "Copying publish output into AppDir..."
 cp -a "${publish_dir}/." "${appdir}/usr/bin/"
+
+log "Verifying AppDir does not include forbidden debug artifacts..."
+if find "${appdir}/usr/bin" -type f -name '*.pdb' -print -quit | grep -q .; then
+  fail "Forbidden symbol files (*.pdb) were found in ${appdir}/usr/bin."
+fi
 
 if [[ ! -f "${appdir}/usr/bin/${entry_exe}" ]]; then
   fail "Expected executable '${entry_exe}' was not found in ${publish_dir}."

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -7,6 +7,9 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <Version>1.2.0</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <PathMap>$(MSBuildProjectDirectory)=/src</PathMap>
     <ApplicationIcon>..\..\Resources\CyberUnpack.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -7,6 +7,9 @@
     <RootNamespace>PulseAPK.Core</RootNamespace>
     <Version>1.2.0</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <PathMap>$(MSBuildProjectDirectory)=/src</PathMap>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Reduce the chance that packaged AppImages include build artifacts that contain local machine paths or debug symbols.
- Ensure the release packaging path produces deterministic outputs and enforces a policy that prevents accidental inclusion of symbol files.

### Description
- Updated `scripts/build-appimage.sh` to disable symbol generation during the publish step by adding `-p:DebugType=None` and `-p:DebugSymbols=false` to the `dotnet publish` invocation.
- Added an explicit cleanup step after publish that removes non-runtime artifacts with `find "${publish_dir}" -type f \( -name '*.pdb' -o -name '*.xml' \) -delete` before copying into the `AppDir`.
- Added a post-copy verification gate that scans `"${appdir}/usr/bin"` for `*.pdb` and fails the build if any are found to prevent shipping forbidden debug artifacts.
- Enabled deterministic/path-mapped build properties in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` and `src/PulseAPK.Core/PulseAPK.Core.csproj` by adding `<Deterministic>true</Deterministic>`, `<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>`, and `<PathMap>$(MSBuildProjectDirectory)=/src</PathMap>`.

### Testing
- Ran a syntax check of the script with `bash -n scripts/build-appimage.sh`, which completed successfully.
- Attempted `dotnet publish` with the same flags to validate publish behavior, but the environment lacks the `dotnet` runtime so the publish validation could not be executed (`dotnet` command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07a0e3bdc83228301d5abcd3b37cd)