### PR TITLE
Harden Windows publish script to ensure a valid .exe is produced

### DIFF
--- a/scripts/build-windows-exe.sh
+++ b/scripts/build-windows-exe.sh
@@ -6,7 +6,8 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
 rid="${RID:-win-x64}"
-app_exe="PulseAPK.Avalonia.exe"
+app_name="${APP_NAME:-PulseAPK.Avalonia}"
+app_exe="${app_name}.exe"
 
 out_root="${repo_root}/artifacts/windows/${rid}"
 publish_dir="${out_root}/publish"
@@ -17,6 +18,11 @@ if ! command -v dotnet >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ "${rid}" != win-* ]]; then
+  echo "RID must target Windows (for example 'win-x64'). Received '${rid}'." >&2
+  exit 1
+fi
+
 rm -rf "${publish_dir}"
 mkdir -p "${publish_dir}"
 
@@ -24,13 +30,27 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  /p:UseAppHost=true \
   /p:PublishSingleFile=true \
   /p:IncludeNativeLibrariesForSelfExtract=true \
   /p:EnableCompressionInSingleFile=true \
   -o "${publish_dir}"
 
 if [[ ! -f "${publish_dir}/${app_exe}" ]]; then
-  echo "Expected executable '${app_exe}' was not found in ${publish_dir}." >&2
+  exe_candidates=("${publish_dir}"/*.exe)
+  if [[ ${#exe_candidates[@]} -ne 1 || ! -f "${exe_candidates[0]}" ]]; then
+    echo "Expected executable '${app_exe}' was not found in ${publish_dir}." >&2
+    echo "Detected executables:"
+    find "${publish_dir}" -maxdepth 1 -type f -name '*.exe' -print
+    exit 1
+  fi
+
+  app_exe="$(basename "${exe_candidates[0]}")"
+  echo "Expected '${APP_NAME:-PulseAPK.Avalonia}.exe' was not found; using discovered executable '${app_exe}'."
+fi
+
+if ! file "${publish_dir}/${app_exe}" | grep -Eq 'PE32\+?|MS Windows'; then
+  echo "Published file '${app_exe}' is not a valid Windows executable (PE format)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Improve robustness of `scripts/build-windows-exe.sh` so it reliably produces and validates a Windows executable before packaging.
- Allow configurable application name and handle cases where publish produces an unexpected exe filename.
- Prevent accidental runs for non-Windows RIDs and ensure the apphost (native exe) is created during publish.
- No external skills were used for this change.

### Description
- Introduced `APP_NAME` support and derive `app_exe` from `app_name`, defaulting to `PulseAPK.Avalonia` so the expected executable name is configurable.
- Added a guard to require `RID` to match `win-*` and fail fast if it does not target Windows.
- Enabled `/p:UseAppHost=true` in the `dotnet publish` invocation to force generation of the native apphost executable for Windows.
- Improved executable discovery by auto-detecting a single `.exe` in the publish folder when the expected name is missing and failing with diagnostics otherwise, and added a PE-format check using `file` to validate the produced artifact.

### Testing
- Ran `bash -n scripts/build-windows-exe.sh` to verify syntax and it succeeded.
- Executed the script in this environment with `RID=linux-x64` which failed at runtime because `dotnet` is not installed, so full publish validation could not be performed.
- The script was additionally validated with a no-op syntax check and basic discovery logic validation via local dry-runs, and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16bb5dc30832295da675b944d1e7b)