### PR TITLE
Fix macOS build script executable resolution and validation

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -6,7 +6,8 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
 rid="${RID:-osx-x64}"
-app_exe="PulseAPK.Avalonia"
+app_name="${APP_NAME:-PulseAPK.Avalonia}"
+app_exe="${app_name}"
 
 out_root="${repo_root}/artifacts/macos/${rid}"
 publish_dir="${out_root}/publish"
@@ -17,6 +18,11 @@ if ! command -v dotnet >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ "${rid}" != osx-* ]]; then
+  echo "RID must target macOS (for example 'osx-x64' or 'osx-arm64'). Received '${rid}'." >&2
+  exit 1
+fi
+
 rm -rf "${publish_dir}"
 mkdir -p "${publish_dir}"
 
@@ -24,13 +30,34 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  /p:UseAppHost=true \
   /p:PublishSingleFile=true \
   /p:IncludeNativeLibrariesForSelfExtract=true \
   /p:EnableCompressionInSingleFile=true \
   -o "${publish_dir}"
 
 if [[ ! -f "${publish_dir}/${app_exe}" ]]; then
-  echo "Expected executable '${app_exe}' was not found in ${publish_dir}." >&2
+  file_candidates=("${publish_dir}"/*)
+  executable_candidates=()
+
+  for candidate in "${file_candidates[@]}"; do
+    [[ -f "${candidate}" && -x "${candidate}" ]] || continue
+    executable_candidates+=("${candidate}")
+  done
+
+  if [[ ${#executable_candidates[@]} -ne 1 ]]; then
+    echo "Expected executable '${app_exe}' was not found in ${publish_dir}." >&2
+    echo "Detected executable files:"
+    find "${publish_dir}" -maxdepth 1 -type f -perm -111 -print
+    exit 1
+  fi
+
+  app_exe="$(basename "${executable_candidates[0]}")"
+  echo "Expected '${APP_NAME:-PulseAPK.Avalonia}' was not found; using discovered executable '${app_exe}'."
+fi
+
+if ! file "${publish_dir}/${app_exe}" | grep -Eq 'Mach-O'; then
+  echo "Published file '${app_exe}' is not a valid macOS executable (Mach-O format)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- The macOS build script assumed a fixed executable name and could fail silently when `.NET` publish produced a different host name or when invoked for non-macOS RIDs.
- The publish step did not guarantee an app host binary was produced, which prevented packaging a native macOS executable for distribution.
- Packaging needed a validation step to ensure the produced artifact is a Mach-O binary before creating archives.

### Description
- Use a configurable `APP_NAME` (`app_name`) and derive `app_exe` from it to avoid hard-coded assumptions about the output binary name.
- Fail fast when `RID` is not a macOS target by enforcing `rid` matches `osx-*`.
- Enable app host generation for macOS publish by adding `/p:UseAppHost=true` to the `dotnet publish` invocation.
- Improve executable discovery by scanning the publish directory for executable files, requiring exactly one candidate if the expected file is missing, and selecting it as the artifact to package.
- Validate the selected publish artifact is a Mach-O binary using `file` before creating archives.

### Testing
- Ran shell syntax check with `bash -n scripts/build-macos-binary.sh`, which succeeded.
- Executed `scripts/build-macos-binary.sh` in the CI environment to exercise the dependency guard, which correctly failed due to `dotnet` not being installed (expected dependency check path).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16edce2388322a923d44c2869a75a)