### PR TITLE
Add macOS app bundle output to build script

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -7,11 +7,13 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 config="${CONFIGURATION:-Release}"
 rid="${RID:-osx-x64}"
 app_name="${APP_NAME:-PulseAPK.Avalonia}"
+bundle_name="${APP_BUNDLE_NAME:-PulseAPK}"
 app_exe="${app_name}"
 
 out_root="${repo_root}/artifacts/macos/${rid}"
 publish_dir="${out_root}/publish"
-archive_path="${out_root}/PulseAPK-${rid}.tar.gz"
+bundle_dir="${out_root}/${bundle_name}.app"
+archive_path="${out_root}/${bundle_name}-${rid}.tar.gz"
 
 if ! command -v dotnet >/dev/null 2>&1; then
   echo "dotnet is required but was not found in PATH." >&2
@@ -23,7 +25,7 @@ if [[ "${rid}" != osx-* ]]; then
   exit 1
 fi
 
-rm -rf "${publish_dir}"
+rm -rf "${publish_dir}" "${bundle_dir}"
 mkdir -p "${publish_dir}"
 
 dotnet publish "${project_path}" \
@@ -61,23 +63,61 @@ if ! file "${publish_dir}/${app_exe}" | grep -Eq 'Mach-O'; then
   exit 1
 fi
 
+bundle_contents="${bundle_dir}/Contents"
+bundle_macos="${bundle_contents}/MacOS"
+bundle_resources="${bundle_contents}/Resources"
+
+mkdir -p "${bundle_macos}" "${bundle_resources}"
+cp -a "${publish_dir}/." "${bundle_macos}/"
+chmod +x "${bundle_macos}/${app_exe}"
+
+cat > "${bundle_contents}/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleExecutable</key>
+  <string>${app_exe}</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.pulseapk.${bundle_name,,}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${bundle_name}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1.0.0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
 if command -v tar >/dev/null 2>&1; then
   rm -f "${archive_path}"
   (
-    cd "${publish_dir}"
-    tar -czf "${archive_path}" .
+    cd "${out_root}"
+    tar -czf "${archive_path}" "${bundle_name}.app"
   )
-  echo "macOS archive created: ${archive_path}"
+  echo "macOS app bundle archive created: ${archive_path}"
 elif command -v zip >/dev/null 2>&1; then
   zip_path="${archive_path%.tar.gz}.zip"
   rm -f "${zip_path}"
   (
-    cd "${publish_dir}"
-    zip -r "${zip_path}" .
+    cd "${out_root}"
+    zip -r "${zip_path}" "${bundle_name}.app"
   )
-  echo "macOS archive created: ${zip_path}"
+  echo "macOS app bundle archive created: ${zip_path}"
 else
   echo "tar/zip not found. Skipping archive creation."
 fi
 
-echo "macOS binary created: ${publish_dir}/${app_exe}"
+echo "macOS app bundle created: ${bundle_dir}"
+echo "Executable entry point: ${bundle_macos}/${app_exe}"


### PR DESCRIPTION
### Motivation
- The macOS publish flow previously only produced raw publish files, which are not immediately usable as a macOS application bundle; the script should produce a ready-to-run `.app` bundle.
- Packaging as a proper `.app` and archiving that bundle improves distribution and makes the output consistent with the Linux `AppImage` and Windows zip flows.

### Description
- Added a configurable `APP_BUNDLE_NAME` (default `PulseAPK`) and new `bundle_dir`/bundle path variables to `scripts/build-macos-binary.sh` so the bundle name and archive are configurable.
- After validating the published executable (existing executable detection + Mach-O check), the script assembles a standard `.app` structure by copying publish output into `Contents/MacOS`, marking the entry executable as executable, and creating `Contents/Resources`.
- Generated a minimal `Contents/Info.plist` containing `CFBundleExecutable`, `CFBundleIdentifier`, `CFBundleName` and basic metadata so the bundle is a proper macOS app.
- Changed archive creation to compress the `.app` bundle (`tar.gz` or `zip` fallback) and updated cleanup/console messages to report the bundle path and executable entry point.

### Testing
- Performed a shell syntax check with `bash -n scripts/build-macos-binary.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1741ba75c8322ba2127b382caae71)