### PR TITLE
Add GitHub Actions workflows to build Linux AppImage and Windows binaries (draft release + artifacts-only)

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -1,0 +1,45 @@
+name: Build Binaries (Draft Release)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-draft-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install AppImage tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2 file zip
+          curl -L https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -o appimagetool
+          chmod +x appimagetool
+          sudo mv appimagetool /usr/local/bin/appimagetool
+
+      - name: Build Linux AppImage
+        run: ./scripts/build-appimage.sh
+
+      - name: Build Windows binaries
+        run: ./scripts/build-windows-exe.sh
+
+      - name: Create draft release with binary assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ci-build-${{ github.run_id }}
+          name: CI Build ${{ github.run_number }}
+          draft: true
+          files: |
+            artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
+            artifacts/windows/win-x64/publish/*.exe
+            artifacts/windows/win-x64/PulseAPK-win-x64.zip

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,47 @@
+name: Build Binaries
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Install AppImage tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2 file zip
+          curl -L https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -o appimagetool
+          chmod +x appimagetool
+          sudo mv appimagetool /usr/local/bin/appimagetool
+
+      - name: Build Linux AppImage
+        run: ./scripts/build-appimage.sh
+
+      - name: Build Windows binaries
+        run: ./scripts/build-windows-exe.sh
+
+      - name: Upload Linux AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-linux-x64-appimage
+          path: artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
+          if-no-files-found: error
+
+      - name: Upload Windows binaries artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-win-x64-binaries
+          path: |
+            artifacts/windows/win-x64/publish/*.exe
+            artifacts/windows/win-x64/PulseAPK-win-x64.zip
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide CI jobs to produce distributable Linux AppImage and Windows binaries using the repository's existing build scripts.
- Enable creating a draft GitHub Release that attaches built binaries for easy inspection and download.
- Offer an artifacts-only workflow for CI runs that should not publish a release.

### Description
- Add `.github/workflows/build-binaries-draft-release.yml` which runs on `workflow_dispatch`, installs AppImage tooling, runs `./scripts/build-appimage.sh` and `./scripts/build-windows-exe.sh`, and creates a draft release using `softprops/action-gh-release@v2` attaching the AppImage and Windows artifacts.
- Add `.github/workflows/build-binaries.yml` which runs on `workflow_dispatch`, installs AppImage tooling, runs the same build scripts, and uploads outputs as workflow artifacts via `actions/upload-artifact@v4`.
- Both workflows reuse the existing `scripts/build-appimage.sh` and `scripts/build-windows-exe.sh` and target outputs under `artifacts/linux/...` and `artifacts/windows/...`.

### Testing
- Verified the new workflow files are present and inspected their contents with `sed`/`nl` to ensure the expected steps are defined.
- Ran `git status --short` to confirm the two workflow files were created and visible to version control.
- Ran `git diff --check` which returned no formatting or whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d24cd0788322ba3d2e18ada7e23b)