### PR TITLE
Force dark theme on Windows to fix low-contrast text

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -1,12 +1,14 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
 using Microsoft.Extensions.DependencyInjection;
 using PulseAPK.Avalonia.Services;
 using PulseAPK.Core.Abstractions;
 using PulseAPK.Core.Services;
 using PulseAPK.Core.ViewModels;
 using System;
+using System.Runtime.InteropServices;
 
 namespace PulseAPK.Avalonia;
 
@@ -28,6 +30,13 @@ public partial class App : Application
         // Initialize settings/localization
         var settingsService = Services.GetRequiredService<ISettingsService>();
         LocalizationService.Instance.Initialize(settingsService);
+
+        // The app layout uses a dark visual palette; force dark mode on Windows to
+        // avoid low-contrast dark text when the OS is set to light mode.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            RequestedThemeVariant = ThemeVariant.Dark;
+        }
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {


### PR DESCRIPTION
### Motivation
- Windows users reported text appearing too dark / low-contrast because the app's dark UI surfaces were rendered while the OS or controls used light-theme foregrounds.
- The change should address the Windows-specific issue without altering theme behavior on macOS/Linux.

### Description
- Added imports for `Avalonia.Styling` and `System.Runtime.InteropServices` and updated `src/PulseAPK.Avalonia/App.axaml.cs` to perform platform detection. 
- Detect Windows at startup with `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` and set `RequestedThemeVariant = ThemeVariant.Dark` when running on Windows. 
- No theme changes are applied on non-Windows platforms, preserving existing `RequestedThemeVariant="Default"` behavior.

### Testing
- Attempted to run unit tests with `dotnet test`, but the environment does not have the .NET SDK/CLI and the command failed (`command not found`).
- No automated tests were executed successfully in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e31284348322abd3af10ff9857b5)