### PR TITLE
Fix Windows message-box sizing so analysis completion text is fully visible

### DIFF
--- a/src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs
+++ b/src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs
@@ -1,4 +1,6 @@
+using Avalonia.Controls;
 using MsBox.Avalonia;
+using MsBox.Avalonia.Dto;
 using MsBox.Avalonia.Enums;
 using PulseAPK.Core.Abstractions;
 using System.Threading.Tasks;
@@ -9,26 +11,41 @@ public class AvaloniaDialogService : IDialogService
 {
     public async Task ShowInfoAsync(string message, string? title = null)
     {
-        var box = MessageBoxManager.GetMessageBoxStandard(title ?? "Info", message, ButtonEnum.Ok, Icon.Info);
+        var box = MessageBoxManager.GetMessageBoxStandard(BuildParameters(title ?? "Info", message, ButtonEnum.Ok, Icon.Info));
         await box.ShowAsync();
     }
 
     public async Task ShowWarningAsync(string message, string? title = null)
     {
-        var box = MessageBoxManager.GetMessageBoxStandard(title ?? "Warning", message, ButtonEnum.Ok, Icon.Warning);
+        var box = MessageBoxManager.GetMessageBoxStandard(BuildParameters(title ?? "Warning", message, ButtonEnum.Ok, Icon.Warning));
         await box.ShowAsync();
     }
 
     public async Task ShowErrorAsync(string message, string? title = null)
     {
-        var box = MessageBoxManager.GetMessageBoxStandard(title ?? "Error", message, ButtonEnum.Ok, Icon.Error);
+        var box = MessageBoxManager.GetMessageBoxStandard(BuildParameters(title ?? "Error", message, ButtonEnum.Ok, Icon.Error));
         await box.ShowAsync();
     }
 
     public async Task<bool> ShowQuestionAsync(string message, string? title = null)
     {
-        var box = MessageBoxManager.GetMessageBoxStandard(title ?? "Question", message, ButtonEnum.YesNo, Icon.Question);
+        var box = MessageBoxManager.GetMessageBoxStandard(BuildParameters(title ?? "Question", message, ButtonEnum.YesNo, Icon.Question));
         var result = await box.ShowAsync();
         return result == ButtonResult.Yes;
+    }
+
+    private static MessageBoxStandardParams BuildParameters(string title, string message, ButtonEnum buttons, Icon icon)
+    {
+        return new MessageBoxStandardParams
+        {
+            ContentTitle = title,
+            ContentMessage = message,
+            ButtonDefinitions = buttons,
+            Icon = icon,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = true,
+            Width = 420,
+            MaxWidth = 720
+        };
     }
 }


### PR DESCRIPTION
### Motivation
- Windows message-box popups created via `MessageBox.Avalonia` could produce a too-small content area and clip status text such as the "Analysis complete" message, so the dialog construction needs explicit layout hints for Windows.

### Description
- Reworked `AvaloniaDialogService` to build message boxes via `MessageBoxStandardParams` instead of the short overload and added `using Avalonia.Controls` and `using MsBox.Avalonia.Dto` to support the new parameters, in `src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs`.
- Added a shared parameter builder used by Info/Warning/Error/Question dialogs and set explicit options: `WindowStartupLocation = CenterOwner`, `CanResize = true`, `Width = 420`, and `MaxWidth = 720` to ensure longer messages render without being clipped.

### Testing
- Attempted to run `dotnet restore PulseAPK.sln` to validate the change, but the environment does not have the .NET SDK installed so the build/compile could not be executed (command failed: `dotnet: command not found`).
- Verified the source file was updated locally and that the new dialog parameter builder is used for all dialog types by inspecting `src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e60e5ec88322903be783cf6a3cfe)