### PR TITLE
Fix Windows APK build failure caused by quoted path arguments

### DIFF
--- a/src/PulseAPK.Core/Services/ApktoolRunner.cs
+++ b/src/PulseAPK.Core/Services/ApktoolRunner.cs
@@ -25,9 +25,12 @@ namespace PulseAPK.Core.Services
 
         public async Task<int> RunDecompileAsync(string apkPath, string outputDir, bool decodeResources, bool decodeSources, bool keepOriginalManifest, bool forceOverwrite = false, CancellationToken cancellationToken = default)
         {
+            var sanitizedApkPath = SanitizePathArgument(apkPath);
+            var sanitizedOutputDir = SanitizePathArgument(outputDir);
+
             var args = new StringBuilder("d");
-            args.Append($" \"{apkPath}\"");
-            args.Append($" -o \"{outputDir}\"");
+            args.Append($" \"{sanitizedApkPath}\"");
+            args.Append($" -o \"{sanitizedOutputDir}\"");
 
             if (!decodeResources) args.Append(" -r");
             if (!decodeSources) args.Append(" -s");
@@ -43,9 +46,12 @@ namespace PulseAPK.Core.Services
 
         public async Task<int> RunBuildAsync(string projectPath, string outputApk, bool useAapt2, CancellationToken cancellationToken = default)
         {
+            var sanitizedProjectPath = SanitizePathArgument(projectPath);
+            var sanitizedOutputApk = SanitizePathArgument(outputApk);
+
             var args = new StringBuilder("b");
-            args.Append($" \"{projectPath}\"");
-            args.Append($" -o \"{outputApk}\"");
+            args.Append($" \"{sanitizedProjectPath}\"");
+            args.Append($" -o \"{sanitizedOutputApk}\"");
 
             if (useAapt2) args.Append(" --use-aapt2");
 
@@ -54,7 +60,7 @@ namespace PulseAPK.Core.Services
 
         private async Task<int> RunProcessAsync(string arguments, CancellationToken cancellationToken)
         {
-            var apktoolPath = _settingsService.Settings.ApktoolPath;
+            var apktoolPath = SanitizePathArgument(_settingsService.Settings.ApktoolPath);
 
             if (string.IsNullOrWhiteSpace(apktoolPath))
             {
@@ -103,6 +109,13 @@ namespace PulseAPK.Core.Services
             await process.WaitForExitAsync(cancellationToken);
 
             return process.ExitCode;
+        }
+
+        private static string SanitizePathArgument(string? path)
+        {
+            return string.IsNullOrWhiteSpace(path)
+                ? string.Empty
+                : path.Trim().Trim('"');
         }
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using PulseAPK.Core.Services;
+using Xunit;
+
+namespace PulseAPK.Tests.Services;
+
+public class ApktoolRunnerTests
+{
+    [Fact]
+    public async Task RunBuildAsync_StripsWrappingQuotesFromConfiguredAndArgumentPaths()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"pulseapk-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        var fakeJavaPath = Path.Combine(tempRoot, "java");
+        var capturedArgsPath = Path.Combine(tempRoot, "captured-args.txt");
+        var fakeApktoolPath = Path.Combine(tempRoot, "apktool.jar");
+        var projectDir = Path.Combine(tempRoot, "decompiled");
+        var outputApk = Path.Combine(tempRoot, "compiled", "decompiled.apk");
+
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputApk)!);
+        File.WriteAllText(fakeApktoolPath, "fake apktool");
+
+        var escapedCapturePath = capturedArgsPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var script = $"#!/usr/bin/env bash\nprintf '%s' \"$*\" > \"{escapedCapturePath}\"\nexit 0\n";
+        File.WriteAllText(fakeJavaPath, script);
+        MakeExecutable(fakeJavaPath);
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH", $"{tempRoot}{Path.PathSeparator}{originalPath}");
+
+        try
+        {
+            var settings = new TestSettingsService($"\"{fakeApktoolPath}\"");
+            var runner = new ApktoolRunner(settings);
+
+            var exitCode = await runner.RunBuildAsync($"\"{projectDir}\"", $"\"{outputApk}\"", useAapt2: false);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(capturedArgsPath));
+
+            var args = File.ReadAllText(capturedArgsPath);
+
+            Assert.Contains($"-jar \"{fakeApktoolPath}\"", args, StringComparison.Ordinal);
+            Assert.Contains($"b \"{projectDir}\"", args, StringComparison.Ordinal);
+            Assert.Contains($"-o \"{outputApk}\"", args, StringComparison.Ordinal);
+            Assert.DoesNotContain("\"\"", args, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private static void MakeExecutable(string path)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var mode = File.GetUnixFileMode(path);
+        mode |= UnixFileMode.UserExecute;
+        mode |= UnixFileMode.GroupExecute;
+        mode |= UnixFileMode.OtherExecute;
+        File.SetUnixFileMode(path, mode);
+    }
+
+    private sealed class TestSettingsService : ISettingsService
+    {
+        public TestSettingsService(string apktoolPath)
+        {
+            Settings = new AppSettings
+            {
+                ApktoolPath = apktoolPath
+            };
+        }
+
+        public AppSettings Settings { get; }
+
+        public void Save()
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent apktool on Windows from receiving malformed path tokens like `C:\...\decompiled" -o C:\...` which produced `InvalidPathException` due to embedded quotes. 
- Normalize user/configured paths so the Java command line receives well-formed, single-quoted paths.

### Description
- Strip surrounding quotes and trim whitespace from all apktool-related paths via a new helper `SanitizePathArgument` in `ApktoolRunner`.
- Apply sanitization to configured `ApktoolPath` and the argument paths used by `RunDecompileAsync` and `RunBuildAsync` before composing the `java -jar` arguments. (file: `src/PulseAPK.Core/Services/ApktoolRunner.cs`)
- Add a unit test `ApktoolRunnerTests.RunBuildAsync_StripsWrappingQuotesFromConfiguredAndArgumentPaths` that injects a fake `java` binary, captures the runtime arguments and asserts there are no doubled/embedded quote artifacts. (file: `tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs`)

### Testing
- Added an automated unit test that verifies quoted configured and argument paths are normalized and emitted as valid arguments (test file: `tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs`).
- Attempted to run `dotnet test`, but the execution environment does not have the `dotnet` SDK installed so tests could not be executed here (test run unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ecdf00c483229cd78d57509168f8)