### PR TITLE
Support non-jar apktool paths (bat/cmd/exe) for build/signing

### DIFF
--- a/src/PulseAPK.Core/Services/ApktoolRunner.cs
+++ b/src/PulseAPK.Core/Services/ApktoolRunner.cs
@@ -72,15 +72,7 @@ namespace PulseAPK.Core.Services
                 throw new FileNotFoundException($"Apktool path '{apktoolPath}' does not exist.");
             }
 
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "java",
-                Arguments = $"-jar \"{apktoolPath}\" {arguments}",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
+            var startInfo = CreateStartInfo(apktoolPath, arguments);
 
             using var process = new Process { StartInfo = startInfo };
 
@@ -109,6 +101,50 @@ namespace PulseAPK.Core.Services
             await process.WaitForExitAsync(cancellationToken);
 
             return process.ExitCode;
+        }
+
+        private static ProcessStartInfo CreateStartInfo(string apktoolPath, string arguments)
+        {
+            var extension = Path.GetExtension(apktoolPath);
+            var isJar = string.Equals(extension, ".jar", StringComparison.OrdinalIgnoreCase);
+            var isBatchFile = string.Equals(extension, ".bat", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".cmd", StringComparison.OrdinalIgnoreCase);
+
+            if (isJar)
+            {
+                return new ProcessStartInfo
+                {
+                    FileName = "java",
+                    Arguments = $"-jar \"{apktoolPath}\" {arguments}",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+            }
+
+            if (isBatchFile && OperatingSystem.IsWindows())
+            {
+                return new ProcessStartInfo
+                {
+                    FileName = "cmd.exe",
+                    Arguments = $"/c \"\"{apktoolPath}\" {arguments}\"",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+            }
+
+            return new ProcessStartInfo
+            {
+                FileName = apktoolPath,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
         }
 
         private static string SanitizePathArgument(string? path)

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -62,7 +62,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private async Task BrowseApktool()
     {
-        var file = await _filePickerService.OpenFileAsync("Jar Files (*.jar)|*.jar|All Files (*.*)|*.*");
+        var file = await _filePickerService.OpenFileAsync("Apktool files (*.jar;*.bat;*.cmd;*.exe)|*.jar;*.bat;*.cmd;*.exe|All Files (*.*)|*.*");
         if (file != null)
         {
             ApktoolPath = file;

--- a/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
@@ -60,6 +60,56 @@ public class ApktoolRunnerTests
         }
     }
 
+    [Fact]
+    public async Task RunBuildAsync_UsesExecutableDirectlyWhenApktoolPathIsNotJar()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"pulseapk-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        var fakeApktoolPath = Path.Combine(tempRoot, "apktool");
+        var capturedArgsPath = Path.Combine(tempRoot, "captured-args.txt");
+        var projectDir = Path.Combine(tempRoot, "decompiled");
+        var outputApk = Path.Combine(tempRoot, "compiled", "decompiled.apk");
+
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputApk)!);
+
+        var escapedCapturePath = capturedArgsPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var script = $"#!/usr/bin/env bash\nprintf '%s' \"$*\" > \"{escapedCapturePath}\"\nexit 0\n";
+        File.WriteAllText(fakeApktoolPath, script);
+        MakeExecutable(fakeApktoolPath);
+
+        try
+        {
+            var settings = new TestSettingsService(fakeApktoolPath);
+            var runner = new ApktoolRunner(settings);
+
+            var exitCode = await runner.RunBuildAsync(projectDir, outputApk, useAapt2: true);
+
+            Assert.Equal(0, exitCode);
+            Assert.True(File.Exists(capturedArgsPath));
+
+            var args = File.ReadAllText(capturedArgsPath);
+
+            Assert.Contains($"b \"{projectDir}\"", args, StringComparison.Ordinal);
+            Assert.Contains($"-o \"{outputApk}\"", args, StringComparison.Ordinal);
+            Assert.Contains("--use-aapt2", args, StringComparison.Ordinal);
+            Assert.DoesNotContain("-jar", args, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     private static void MakeExecutable(string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
### Motivation
- Building APKs on Windows fails when users configure `apktool.bat` or an executable because the runner always used `java -jar <path>`.
- The intent is to detect the configured apktool type and invoke it correctly so builds work on Windows and with non-jar tool shims.

### Description
- Added `CreateStartInfo` helper in `ApktoolRunner` to choose process startup behavior based on the configured path extension, where `.jar` runs via `java -jar`, `.bat`/`.cmd` on Windows runs via `cmd.exe /c`, and other executable files are launched directly. (`src/PulseAPK.Core/Services/ApktoolRunner.cs`).
- Replaced the hard-coded `java -jar` start logic with a call to `CreateStartInfo` so the runner can handle different apktool file types. (`src/PulseAPK.Core/Services/ApktoolRunner.cs`).
- Broadened the APKTool file picker filter to include `.bat`, `.cmd`, and `.exe` options in `SettingsViewModel`. (`src/PulseAPK.Core/ViewModels/SettingsViewModel.cs`).
- Added a unit test `RunBuildAsync_UsesExecutableDirectlyWhenApktoolPathIsNotJar` to verify the runner invokes non-jar apktool paths directly (no `-jar`). (`tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs`).

### Testing
- A unit test was added: `RunBuildAsync_UsesExecutableDirectlyWhenApktoolPathIsNotJar` and existing `RunBuildAsync_StripsWrappingQuotesFromConfiguredAndArgumentPaths` remain in the test suite; they were not executed locally here due to environment constraints.
- Attempted to run tests with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj` but the container lacks the .NET SDK, so the command failed with `bash: command not found: dotnet` and no automated tests were run successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f294fa888322b5e613be9e8e8008)