### PR TITLE
Use ArgumentList to fix apktool argument quoting on Windows

### DIFF
--- a/src/PulseAPK.Core/Services/ApktoolRunner.cs
+++ b/src/PulseAPK.Core/Services/ApktoolRunner.cs
@@ -110,15 +110,24 @@ namespace PulseAPK.Core.Services
 
             if (isJar)
             {
-                return new ProcessStartInfo
+                var startInfo = new ProcessStartInfo
                 {
                     FileName = "java",
-                    Arguments = $"-jar {QuoteArgument(apktoolPath)} {JoinArguments(arguments)}",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
+
+                startInfo.ArgumentList.Add("-jar");
+                startInfo.ArgumentList.Add(apktoolPath);
+
+                foreach (var argument in arguments)
+                {
+                    startInfo.ArgumentList.Add(argument);
+                }
+
+                return startInfo;
             }
 
             if (isBatchFile && OperatingSystem.IsWindows())
@@ -134,15 +143,21 @@ namespace PulseAPK.Core.Services
                 };
             }
 
-            return new ProcessStartInfo
+            var defaultStartInfo = new ProcessStartInfo
             {
                 FileName = apktoolPath,
-                Arguments = JoinArguments(arguments),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
+
+            foreach (var argument in arguments)
+            {
+                defaultStartInfo.ArgumentList.Add(argument);
+            }
+
+            return defaultStartInfo;
         }
 
         private static string SanitizePathArgument(string? path)

--- a/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
@@ -26,7 +26,7 @@ public class ApktoolRunnerTests
         File.WriteAllText(fakeApktoolPath, "fake apktool");
 
         var escapedCapturePath = capturedArgsPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        var script = $"#!/usr/bin/env bash\nprintf '%s' \"$*\" > \"{escapedCapturePath}\"\nexit 0\n";
+        var script = $"#!/usr/bin/env bash\nprintf '%s\n' \"$@\" > \"{escapedCapturePath}\"\nexit 0\n";
         File.WriteAllText(fakeJavaPath, script);
         MakeExecutable(fakeJavaPath);
 
@@ -43,12 +43,9 @@ public class ApktoolRunnerTests
             Assert.Equal(0, exitCode);
             Assert.True(File.Exists(capturedArgsPath));
 
-            var args = File.ReadAllText(capturedArgsPath);
+            var args = File.ReadAllLines(capturedArgsPath);
 
-            Assert.Contains($"-jar \"{fakeApktoolPath}\"", args, StringComparison.Ordinal);
-            Assert.Contains($"b \"{projectDir}\"", args, StringComparison.Ordinal);
-            Assert.Contains($"-o \"{outputApk}\"", args, StringComparison.Ordinal);
-            Assert.DoesNotContain("\"\"", args, StringComparison.Ordinal);
+            Assert.Equal(new[] { "-jar", fakeApktoolPath, "b", projectDir, "-o", outputApk }, args);
         }
         finally
         {
@@ -80,7 +77,7 @@ public class ApktoolRunnerTests
         Directory.CreateDirectory(Path.GetDirectoryName(outputApk)!);
 
         var escapedCapturePath = capturedArgsPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        var script = $"#!/usr/bin/env bash\nprintf '%s' \"$*\" > \"{escapedCapturePath}\"\nexit 0\n";
+        var script = $"#!/usr/bin/env bash\nprintf '%s\n' \"$@\" > \"{escapedCapturePath}\"\nexit 0\n";
         File.WriteAllText(fakeApktoolPath, script);
         MakeExecutable(fakeApktoolPath);
 
@@ -94,12 +91,9 @@ public class ApktoolRunnerTests
             Assert.Equal(0, exitCode);
             Assert.True(File.Exists(capturedArgsPath));
 
-            var args = File.ReadAllText(capturedArgsPath);
+            var args = File.ReadAllLines(capturedArgsPath);
 
-            Assert.Contains($"b \"{projectDir}\"", args, StringComparison.Ordinal);
-            Assert.Contains($"-o \"{outputApk}\"", args, StringComparison.Ordinal);
-            Assert.Contains("--use-aapt2", args, StringComparison.Ordinal);
-            Assert.DoesNotContain("-jar", args, StringComparison.Ordinal);
+            Assert.Equal(new[] { "b", projectDir, "-o", outputApk, "--use-aapt2" }, args);
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- Windows runs showed `apktool` receiving malformed combined arguments (e.g. paths with trailing `" -o ...`) due to command-line quoting and parsing, so arguments must be passed as discrete tokens to avoid `InvalidPathException` in downstream Java code.

### Description
- Changed `CreateStartInfo` in `src/PulseAPK.Core/Services/ApktoolRunner.cs` to populate `ProcessStartInfo.ArgumentList` for `.jar` invocations (`java -jar ...`) so the jar path and subsequent arguments are passed as separate arguments. 
- Also populate `ArgumentList` for direct executable invocations so non-jar apktool binaries receive properly tokenized arguments. 
- Kept the existing `cmd.exe` branch for `.bat`/`.cmd` on Windows unchanged to preserve existing behavior for batch wrappers. 
- Updated `tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs` to capture arguments with `printf "$@"` (one-per-line) and assert exact token order using `File.ReadAllLines`, making the tests verify tokenized argument passing.

### Testing
- Updated unit tests in `tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs` to reflect the new argument tokenization behavior and validate exact argument order. 
- Attempted to run `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter ApktoolRunnerTests` but the environment lacks `dotnet` so automated tests could not be executed here (test run skipped due to missing `dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43301a9348322a28972ed8ca94f5b)