### PR TITLE
Sync OutputFolder UI with "Extract to a folder where APK is located" toggle

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -74,6 +74,15 @@ public partial class DecompileViewModel : ObservableObject
 
     partial void OnApkPathChanged(string value)
     {
+        if (ExtractToApkFolder)
+        {
+            var apkDerivedOutputFolder = GetApkDerivedOutputFolder(value);
+            if (!string.IsNullOrWhiteSpace(apkDerivedOutputFolder))
+            {
+                OutputFolder = apkDerivedOutputFolder;
+            }
+        }
+
         UpdateCommandPreview();
         RunDecompileCommand.NotifyCanExecuteChanged();
     }
@@ -81,7 +90,25 @@ public partial class DecompileViewModel : ObservableObject
     partial void OnDecodeResourcesChanged(bool value) => UpdateCommandPreview();
     partial void OnDecodeSourcesChanged(bool value) => UpdateCommandPreview();
     partial void OnKeepOriginalManifestChanged(bool value) => UpdateCommandPreview();
-    partial void OnExtractToApkFolderChanged(bool value) => UpdateCommandPreview();
+
+    partial void OnExtractToApkFolderChanged(bool value)
+    {
+        if (value)
+        {
+            var apkDerivedOutputFolder = GetApkDerivedOutputFolder(ApkPath);
+            if (!string.IsNullOrWhiteSpace(apkDerivedOutputFolder))
+            {
+                OutputFolder = apkDerivedOutputFolder;
+            }
+        }
+        else
+        {
+            OutputFolder = PathUtils.GetDefaultDecompilePath();
+        }
+
+        UpdateCommandPreview();
+    }
+
     partial void OnOutputFolderChanged(string? value) => UpdateCommandPreview();
 
     [RelayCommand]


### PR DESCRIPTION
### Motivation
- The decompile screen did not update the visible `OutputFolder` textbox when the "Extract to a folder where APK is located" option was toggled or when the APK path changed, causing a UI mismatch even though extraction logic worked.
- The change is a visual fix so the textbox reflects the actual resolved output path when the option is enabled or reverts to the default when disabled.

### Description
- Update `DecompileViewModel` to set `OutputFolder` to the APK-derived folder when `ExtractToApkFolder` becomes `true` and to `PathUtils.GetDefaultDecompilePath()` when it becomes `false` (file: `src/PulseAPK.Core/ViewModels/DecompileViewModel.cs`).
- Update `OnApkPathChanged` to refresh the visible `OutputFolder` immediately when the APK path changes and `ExtractToApkFolder` is enabled.
- Keep existing preview/command update behavior by invoking `UpdateCommandPreview()` after changes so the command preview and UI remain consistent.

### Testing
- Attempted to run unit tests with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj`, but `dotnet` is not available in the environment so tests could not be executed (failed).
- Attempted an automated UI capture with Playwright against a local instance, but no running app was reachable at `http://localhost:5000` so the visual verification step could not complete (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4383269808322b3410b77ed13b5df)