### PR TITLE
Keep decompile Run command enabled between runs

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -290,9 +290,7 @@ public partial class DecompileViewModel : ObservableObject
 
     private bool CanRunDecompile()
     {
-        return !IsRunning
-            && !string.IsNullOrWhiteSpace(ApkPath)
-            && !string.IsNullOrWhiteSpace(_settingsService.Settings.ApktoolPath);
+        return !IsRunning;
     }
 
     private string BuildCommandPreview()

--- a/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
+++ b/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Services;
+using PulseAPK.Core.ViewModels;
+using Xunit;
+
+namespace PulseAPK.Tests.ViewModels;
+
+public class DecompileViewModelTests
+{
+    [Fact]
+    public void RunCommand_CanExecute_WithoutApkPathOrApktoolPath()
+    {
+        var viewModel = CreateViewModel(apktoolPath: string.Empty);
+
+        Assert.True(viewModel.RunDecompileCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void RunCommand_CanExecute_OnlyDependsOnIsRunning()
+    {
+        var viewModel = CreateViewModel(apktoolPath: string.Empty);
+
+        viewModel.IsRunning = true;
+        Assert.False(viewModel.RunDecompileCommand.CanExecute(null));
+
+        viewModel.IsRunning = false;
+        Assert.True(viewModel.RunDecompileCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task RunCommand_RemainsEnabled_AfterValidationFailure()
+    {
+        var dialogService = new TestDialogService();
+        var viewModel = CreateViewModel(apktoolPath: string.Empty, dialogService: dialogService);
+
+        await viewModel.RunDecompileCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.RunDecompileCommand.CanExecute(null));
+        Assert.Contains(dialogService.Warnings, warning => warning.message.Contains("apktool", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static DecompileViewModel CreateViewModel(string apktoolPath, TestDialogService? dialogService = null)
+    {
+        return new DecompileViewModel(
+            new TestFilePickerService(),
+            new TestSettingsService(apktoolPath),
+            new ApktoolRunner(new TestSettingsService(apktoolPath)),
+            dialogService ?? new TestDialogService(),
+            new ImmediateDispatcherService(),
+            new TestSystemService());
+    }
+
+    private sealed class TestFilePickerService : IFilePickerService
+    {
+        public Task<string?> OpenFileAsync(string filter) => Task.FromResult<string?>(null);
+        public Task<string?> OpenFolderAsync(string? initialDirectory = null) => Task.FromResult<string?>(null);
+    }
+
+    private sealed class TestSettingsService : ISettingsService
+    {
+        public TestSettingsService(string apktoolPath)
+        {
+            Settings = new AppSettings { ApktoolPath = apktoolPath };
+        }
+
+        public AppSettings Settings { get; }
+        public void Save() { }
+    }
+
+    private sealed class TestDialogService : IDialogService
+    {
+        public List<(string message, string? title)> Warnings { get; } = new();
+
+        public Task ShowInfoAsync(string message, string? title = null) => Task.CompletedTask;
+
+        public Task ShowWarningAsync(string message, string? title = null)
+        {
+            Warnings.Add((message, title));
+            return Task.CompletedTask;
+        }
+
+        public Task ShowErrorAsync(string message, string? title = null) => Task.CompletedTask;
+
+        public Task<bool> ShowQuestionAsync(string message, string? title = null) => Task.FromResult(false);
+    }
+
+    private sealed class ImmediateDispatcherService : IDispatcherService
+    {
+        public Task InvokeAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task<T> InvokeAsync<T>(Func<T> func) => Task.FromResult(func());
+
+        public bool CheckAccess() => true;
+    }
+
+    private sealed class TestSystemService : ISystemService
+    {
+        public void OpenFolder(string folderPath) { }
+        public void OpenUrl(string url) { }
+    }
+}


### PR DESCRIPTION
### Motivation
- The Run button for decompilation should remain enabled whenever a decompile is not currently executing so users can retry quickly; current gating also depended on `ApkPath` and configured `ApktoolPath` which caused the button to stay disabled after a round.
- The recent "output to the same folder" changes update `OutputFolder` and the command preview and made the stricter gating more visible, so the UX needed to be aligned with in-command validation dialogs.

### Description
- Simplified `CanRunDecompile` in `DecompileViewModel` to only return `!IsRunning`, removing `ApkPath` and apktool path checks so the Run command is enabled when not actively running.
- Kept runtime validation inside `RunDecompile` intact so missing/invalid `apktool` or `apk` still surface the same dialogs and do not permit the process to proceed.
- Added unit tests in `tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs` that assert the Run command is executable without an APK path or apktool path, that enablement only depends on `IsRunning`, and that the command remains enabled after validation-only failures.

### Testing
- Added automated unit tests at `tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs` to cover the changed behavior.
- Attempted to run the test suite with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj` in this environment but it failed because `dotnet` is not installed here. Tests were therefore not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43b903ef48322a93a9c1a1812b1b6)