### PR TITLE
Bump version to 1.2.1

### DIFF
--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PulseAPK.Core</RootNamespace>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
### Motivation
- Publish a new patch release by incrementing the project version from `1.2.0` to `1.2.1` in the build metadata.

### Description
- Updated the `<Version>` property to `1.2.1` in `src/PulseAPK.Core/PulseAPK.Core.csproj` and `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.

### Testing
- Attempted to run `dotnet build PulseAPK.sln`, which failed in this environment due to `dotnet: command not found` so a full build could not be performed.
- Verified the file updates locally with `git diff` and by printing the modified files (`nl`), confirming the `<Version>` changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43daacb348322924aba1e181e8831)