### PR TITLE
Adjust draft release CI to ship PulseAPK.exe and AppImage only

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install AppImage tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2 file zip
+          sudo apt-get install -y libfuse2 file
           curl -L https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -o appimagetool
           chmod +x appimagetool
           sudo mv appimagetool /usr/local/bin/appimagetool
@@ -31,7 +31,7 @@ jobs:
         run: ./scripts/build-appimage.sh
 
       - name: Build Windows binaries
-        run: ./scripts/build-windows-exe.sh
+        run: OUTPUT_EXE_NAME=PulseAPK.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
 
       - name: Create draft release with binary assets
         uses: softprops/action-gh-release@v2
@@ -41,5 +41,4 @@ jobs:
           draft: true
           files: |
             artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
-            artifacts/windows/win-x64/publish/*.exe
-            artifacts/windows/win-x64/PulseAPK-win-x64.zip
+            artifacts/windows/win-x64/publish/PulseAPK.exe

--- a/scripts/build-windows-exe.sh
+++ b/scripts/build-windows-exe.sh
@@ -8,6 +8,8 @@ config="${CONFIGURATION:-Release}"
 rid="${RID:-win-x64}"
 app_name="${APP_NAME:-PulseAPK.Avalonia}"
 app_exe="${app_name}.exe"
+output_exe_name="${OUTPUT_EXE_NAME:-${app_exe}}"
+create_zip="${CREATE_ZIP:-true}"
 
 out_root="${repo_root}/artifacts/windows/${rid}"
 publish_dir="${out_root}/publish"
@@ -54,15 +56,23 @@ if ! file "${publish_dir}/${app_exe}" | grep -Eq 'PE32\+?|MS Windows'; then
   exit 1
 fi
 
-if command -v zip >/dev/null 2>&1; then
+if [[ "${output_exe_name}" != "${app_exe}" ]]; then
+  mv -f "${publish_dir}/${app_exe}" "${publish_dir}/${output_exe_name}"
+  app_exe="${output_exe_name}"
+  echo "Windows executable renamed to: ${publish_dir}/${app_exe}"
+fi
+
+if [[ "${create_zip}" == "true" ]] && command -v zip >/dev/null 2>&1; then
   rm -f "${zip_path}"
   (
     cd "${publish_dir}"
     zip -r "${zip_path}" .
   )
   echo "Windows package created: ${zip_path}"
-else
+elif [[ "${create_zip}" == "true" ]]; then
   echo "zip not found. Skipping archive creation."
+else
+  echo "CREATE_ZIP=${create_zip}; skipping archive creation."
 fi
 
 echo "Windows executable created: ${publish_dir}/${app_exe}"


### PR DESCRIPTION
### Motivation
- Ensure the draft-release workflow publishes a plain `PulseAPK.exe` (not `PulseAPK.Avalonia.exe`) alongside the Linux AppImage and remove the ZIP artifact from draft releases.

### Description
- Updated `.github/workflows/build-binaries-draft-release.yml` to stop installing `zip`, to invoke the Windows build with `OUTPUT_EXE_NAME=PulseAPK.exe CREATE_ZIP=false`, and to attach only `artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage` and `artifacts/windows/win-x64/publish/PulseAPK.exe` to the draft release.
- Enhanced `scripts/build-windows-exe.sh` to add `OUTPUT_EXE_NAME` (rename published exe) and `CREATE_ZIP` (control archive creation) environment variables.
- Implemented logic in `scripts/build-windows-exe.sh` to rename the discovered executable to `OUTPUT_EXE_NAME` and to conditionally skip creating the ZIP when `CREATE_ZIP=false`.

### Testing
- Ran `bash -n scripts/build-windows-exe.sh` to validate script syntax, which succeeded.
- Ran `git diff --check` to ensure no whitespace or diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4402e03908322bcdc88d7ffa2bac0)