### PR TITLE
Use PulseAPK as published/launch app name

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -6,7 +6,7 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 project_relpath="src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 app_name="PulseAPK"
-entry_exe="PulseAPK.Avalonia"
+entry_exe="PulseAPK"
 config="${CONFIGURATION:-Release}"
 rid="${RID:-linux-x64}"
 
@@ -93,7 +93,7 @@ cat > "${appdir}/AppRun" <<'EOF'
 #!/usr/bin/env bash
 set -e
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${here}/usr/bin/PulseAPK.Avalonia" "$@"
+exec "${here}/usr/bin/PulseAPK" "$@"
 EOF
 chmod +x "${appdir}/AppRun"
 

--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -14,7 +14,7 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
 rid="${RID:-osx-x64}"
-app_name="${APP_NAME:-PulseAPK.Avalonia}"
+app_name="${APP_NAME:-PulseAPK}"
 bundle_name="${APP_BUNDLE_NAME:-PulseAPK}"
 app_exe="${app_name}"
 
@@ -73,7 +73,7 @@ if [[ ! -f "${publish_dir}/${app_exe}" ]]; then
   fi
 
   app_exe="$(basename "${executable_candidates[0]}")"
-  echo "Expected '${APP_NAME:-PulseAPK.Avalonia}' was not found; using discovered executable '${app_exe}'."
+  echo "Expected '${APP_NAME:-PulseAPK}' was not found; using discovered executable '${app_exe}'."
 fi
 
 if ! file "${publish_dir}/${app_exe}" | grep -Eq 'Mach-O'; then

--- a/scripts/build-windows-exe.ps1
+++ b/scripts/build-windows-exe.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$Configuration = $(if ($env:CONFIGURATION) { $env:CONFIGURATION } else { "Release" }),
     [string]$Rid = $(if ($env:RID) { $env:RID } else { "win-x64" }),
-    [string]$AppName = $(if ($env:APP_NAME) { $env:APP_NAME } else { "PulseAPK.Avalonia" })
+    [string]$AppName = $(if ($env:APP_NAME) { $env:APP_NAME } else { "PulseAPK" })
 )
 
 $ErrorActionPreference = "Stop"

--- a/scripts/build-windows-exe.sh
+++ b/scripts/build-windows-exe.sh
@@ -6,7 +6,7 @@ project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
 rid="${RID:-win-x64}"
-app_name="${APP_NAME:-PulseAPK.Avalonia}"
+app_name="${APP_NAME:-PulseAPK}"
 app_exe="${app_name}.exe"
 output_exe_name="${OUTPUT_EXE_NAME:-${app_exe}}"
 create_zip="${CREATE_ZIP:-true}"
@@ -48,7 +48,7 @@ if [[ ! -f "${publish_dir}/${app_exe}" ]]; then
   fi
 
   app_exe="$(basename "${exe_candidates[0]}")"
-  echo "Expected '${APP_NAME:-PulseAPK.Avalonia}.exe' was not found; using discovered executable '${app_exe}'."
+  echo "Expected '${APP_NAME:-PulseAPK}.exe' was not found; using discovered executable '${app_exe}'."
 fi
 
 if ! file "${publish_dir}/${app_exe}" | grep -Eq 'PE32\+?|MS Windows'; then

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -11,6 +11,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <PathMap>$(MSBuildProjectDirectory)=/src</PathMap>
     <ApplicationIcon>..\..\Resources\CyberUnpack.ico</ApplicationIcon>
+    <AssemblyName>PulseAPK</AssemblyName>
+    <Product>PulseAPK</Product>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- The launched application artifact and packaging should use the user-facing name `PulseAPK` instead of the project-qualified name `PulseAPK.Avalonia` so published binaries and installers launch with the correct app name.

### Description
- Set `<AssemblyName>PulseAPK</AssemblyName>` and `<Product>PulseAPK</Product>` in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` so published outputs use `PulseAPK` as the binary name.
- Update Linux AppImage generation in `scripts/build-appimage.sh` so the `AppRun` launcher and `entry_exe` target `PulseAPK` instead of `PulseAPK.Avalonia`.
- Update macOS packaging defaults in `scripts/build-macos-binary.sh` to expect `PulseAPK` as the default `APP_NAME` and adjust the fallback message accordingly.
- Update Windows packaging defaults in `scripts/build-windows-exe.sh` and `scripts/build-windows-exe.ps1` to default to `PulseAPK` (and update fallback messaging) while keeping the project path targeting the Avalonia project.

### Testing
- Attempted `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj -c Release`, which could not be executed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5601df6b88322a65476cddef5e320)