### PR TITLE
CI: Name Windows artifact `PulseAPK-win-x64.exe` in build and draft-release workflow

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./scripts/build-appimage.sh
 
       - name: Build Windows binaries
-        run: OUTPUT_EXE_NAME=PulseAPK.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
+        run: OUTPUT_EXE_NAME=PulseAPK-win-x64.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
 
       - name: Create draft release with binary assets
         uses: softprops/action-gh-release@v2
@@ -41,4 +41,4 @@ jobs:
           draft: true
           files: |
             artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
-            artifacts/windows/win-x64/publish/PulseAPK.exe
+            artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe


### PR DESCRIPTION
### Motivation
- Clarify the Windows binary name to include platform and ensure the release workflow references match the produced artifact by renaming `PulseAPK.exe` to `PulseAPK-win-x64.exe`.

### Description
- Updated `.github/workflows/build-binaries-draft-release.yml` to set `OUTPUT_EXE_NAME=PulseAPK-win-x64.exe` when running `./scripts/build-windows-exe.sh` and to reference `artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe` as the release asset.

### Testing
- No automated tests were run as part of this change; CI will validate the updated workflow on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b561cfb1348322ad4402c99c8c4b4a)