### PR TITLE
Add tool downloader and Settings UI buttons for Apktool and Ubersigner

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -51,6 +51,8 @@ public partial class App : Application
     {
         // Core Services
         services.AddSingleton<ISettingsService, SettingsService>();
+        services.AddSingleton<IToolRepository, ToolRepository>();
+        services.AddHttpClient<IToolDownloadService, ToolDownloadService>();
         services.AddSingleton(LocalizationService.Instance);
         services.AddTransient<ApktoolRunner>();
         services.AddTransient<UbersignRunner>();

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -23,22 +23,30 @@
 
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
                    FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
             <TextBox Text="{Binding ApktoolPath}" />
             <Button Grid.Column="1"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
                     Command="{Binding BrowseApktoolCommand}"
                     Width="110" />
+            <Button Grid.Column="2"
+                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadApktoolButton]}"
+                    Command="{Binding DownloadApktoolCommand}"
+                    Width="150" />
         </Grid>
 
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UbersignPath]}"
                    FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
             <TextBox Text="{Binding UbersignPath}" />
             <Button Grid.Column="1"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
                     Command="{Binding BrowseUbersignCommand}"
                     Width="110" />
+            <Button Grid.Column="2"
+                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadUbersignerButton]}"
+                    Command="{Binding DownloadUbersignerCommand}"
+                    Width="150" />
         </Grid>
     </StackPanel>
 </UserControl>

--- a/src/PulseAPK.Core/Abstractions/IToolDownloadService.cs
+++ b/src/PulseAPK.Core/Abstractions/IToolDownloadService.cs
@@ -1,0 +1,9 @@
+namespace PulseAPK.Core.Abstractions;
+
+public interface IToolDownloadService
+{
+    Task<ToolDownloadResult> DownloadApktoolAsync(CancellationToken cancellationToken = default);
+    Task<ToolDownloadResult> DownloadUbersignerAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record ToolDownloadResult(string Path, bool Downloaded);

--- a/src/PulseAPK.Core/Abstractions/IToolRepository.cs
+++ b/src/PulseAPK.Core/Abstractions/IToolRepository.cs
@@ -1,0 +1,8 @@
+namespace PulseAPK.Core.Abstractions;
+
+public interface IToolRepository
+{
+    string ToolsDirectory { get; }
+    string GetToolPath(string fileName);
+    bool TryGetCachedToolPath(string fileName, out string path);
+}

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -14,6 +14,7 @@ namespace PulseAPK.Core.Services
     public interface ISettingsService
     {
         AppSettings Settings { get; }
+        string SettingsDirectory { get; }
         void Save();
     }
 
@@ -26,11 +27,13 @@ namespace PulseAPK.Core.Services
         private readonly string _legacySettingsFilePath;
 
         public AppSettings Settings { get; private set; }
+        public string SettingsDirectory { get; }
 
         public SettingsService()
         {
             var baseDirectory = AppContext.BaseDirectory;
             var settingsFolder = ResolveSettingsFolder(baseDirectory);
+            SettingsDirectory = settingsFolder;
             _settingsFilePath = Path.Combine(settingsFolder, SettingsFileName);
             _legacySettingsFilePath = Path.Combine(baseDirectory, SettingsFileName);
             Settings = LoadSettings();

--- a/src/PulseAPK.Core/Services/ToolDownloadService.cs
+++ b/src/PulseAPK.Core/Services/ToolDownloadService.cs
@@ -1,0 +1,205 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PulseAPK.Core.Abstractions;
+
+namespace PulseAPK.Core.Services;
+
+public sealed class ToolDownloadService : IToolDownloadService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IToolRepository _toolRepository;
+
+    public ToolDownloadService(HttpClient httpClient, IToolRepository toolRepository)
+    {
+        _httpClient = httpClient;
+        _toolRepository = toolRepository;
+
+        if (_httpClient.DefaultRequestHeaders.UserAgent.Count == 0)
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PulseAPK", "1.0"));
+        }
+    }
+
+    public Task<ToolDownloadResult> DownloadApktoolAsync(CancellationToken cancellationToken = default)
+    {
+        return DownloadFromLatestReleaseAsync(
+            owner: "iBotPeaches",
+            repo: "Apktool",
+            artifactFileName: "apktool.jar",
+            assetPredicate: static name => name.Equals("apktool.jar", StringComparison.OrdinalIgnoreCase),
+            checksumFileName: null,
+            checksumAssetPredicate: null,
+            checksumValueSelector: null,
+            cancellationToken);
+    }
+
+    public Task<ToolDownloadResult> DownloadUbersignerAsync(CancellationToken cancellationToken = default)
+    {
+        return DownloadFromLatestReleaseAsync(
+            owner: "patrickfav",
+            repo: "uber-apk-signer",
+            artifactFileName: "ubersigner.jar",
+            assetPredicate: static name => name.EndsWith(".jar", StringComparison.OrdinalIgnoreCase)
+                                         && name.Contains("uber-apk-signer", StringComparison.OrdinalIgnoreCase),
+            checksumFileName: "ubersigner.sha256",
+            checksumAssetPredicate: static name => name.Contains("sha256", StringComparison.OrdinalIgnoreCase)
+                                                   || name.Contains("checksum", StringComparison.OrdinalIgnoreCase),
+            checksumValueSelector: static (checksumContent, assetName) => ExtractSha256FromChecksumFile(checksumContent, assetName),
+            cancellationToken);
+    }
+
+    private async Task<ToolDownloadResult> DownloadFromLatestReleaseAsync(
+        string owner,
+        string repo,
+        string artifactFileName,
+        Func<string, bool> assetPredicate,
+        string? checksumFileName,
+        Func<string, bool>? checksumAssetPredicate,
+        Func<string, string, string?>? checksumValueSelector,
+        CancellationToken cancellationToken)
+    {
+        if (_toolRepository.TryGetCachedToolPath(artifactFileName, out var cachedPath))
+        {
+            return new ToolDownloadResult(cachedPath, Downloaded: false);
+        }
+
+        var release = await GetLatestReleaseAsync(owner, repo, cancellationToken);
+
+        var artifactAsset = release.Assets.FirstOrDefault(a => assetPredicate(a.Name))
+            ?? throw new InvalidOperationException($"Could not find expected tool asset for {owner}/{repo} latest release.");
+
+        var artifactPath = _toolRepository.GetToolPath(artifactFileName);
+        await DownloadAssetToFileAsync(artifactAsset.BrowserDownloadUrl, artifactPath, cancellationToken);
+
+        if (checksumFileName is null || checksumAssetPredicate is null || checksumValueSelector is null)
+        {
+            return new ToolDownloadResult(artifactPath, Downloaded: true);
+        }
+
+        var checksumAsset = release.Assets.FirstOrDefault(a => checksumAssetPredicate(a.Name))
+            ?? throw new InvalidOperationException($"Could not find checksum asset for {owner}/{repo} latest release.");
+
+        var checksumPath = _toolRepository.GetToolPath(checksumFileName);
+        await DownloadAssetToFileAsync(checksumAsset.BrowserDownloadUrl, checksumPath, cancellationToken);
+
+        var checksumContent = await File.ReadAllTextAsync(checksumPath, cancellationToken);
+        var expectedSha256 = checksumValueSelector(checksumContent, artifactAsset.Name);
+
+        if (string.IsNullOrWhiteSpace(expectedSha256))
+        {
+            File.Delete(artifactPath);
+            throw new InvalidOperationException("Could not parse SHA256 checksum value for downloaded tool.");
+        }
+
+        var actualSha256 = await ComputeSha256Async(artifactPath, cancellationToken);
+        if (!actualSha256.Equals(expectedSha256, StringComparison.OrdinalIgnoreCase))
+        {
+            File.Delete(artifactPath);
+            throw new InvalidOperationException("SHA256 verification failed for downloaded tool.");
+        }
+
+        return new ToolDownloadResult(artifactPath, Downloaded: true);
+    }
+
+    private async Task<GitHubReleaseResponse> GetLatestReleaseAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync($"https://api.github.com/repos/{owner}/{repo}/releases/latest", cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var release = await JsonSerializer.DeserializeAsync(stream, ToolDownloadJsonContext.Default.GitHubReleaseResponse, cancellationToken);
+
+        if (release is null)
+        {
+            throw new InvalidOperationException($"GitHub API returned an unexpected payload for {owner}/{repo} latest release.");
+        }
+
+        return release;
+    }
+
+    private async Task DownloadAssetToFileAsync(string downloadUrl, string destinationPath, CancellationToken cancellationToken)
+    {
+        using var response = await _httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var tempPath = destinationPath + ".download";
+        await using (var source = await response.Content.ReadAsStreamAsync(cancellationToken))
+        await using (var target = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920, useAsync: true))
+        {
+            await source.CopyToAsync(target, cancellationToken);
+            await target.FlushAsync(cancellationToken);
+        }
+
+        File.Move(tempPath, destinationPath, overwrite: true);
+    }
+
+    private static async Task<string> ComputeSha256Async(string filePath, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, useAsync: true);
+        var hash = await SHA256.HashDataAsync(stream, cancellationToken);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string? ExtractSha256FromChecksumFile(string checksumContent, string assetName)
+    {
+        var lines = checksumContent.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var line in lines)
+        {
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length == 0)
+            {
+                continue;
+            }
+
+            if (parts.Length == 1)
+            {
+                return NormalizeSha(parts[0]);
+            }
+
+            var fileName = parts[^1].TrimStart('*');
+            if (fileName.Equals(assetName, StringComparison.OrdinalIgnoreCase))
+            {
+                return NormalizeSha(parts[0]);
+            }
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeSha(string candidate)
+    {
+        var value = candidate.Trim().ToLowerInvariant();
+        if (value.Length != 64)
+        {
+            return null;
+        }
+
+        foreach (var ch in value)
+        {
+            if (!Uri.IsHexDigit(ch))
+            {
+                return null;
+            }
+        }
+
+        return value;
+    }
+}
+
+public sealed class GitHubReleaseResponse
+{
+    public required List<GitHubReleaseAssetResponse> Assets { get; init; }
+}
+
+public sealed class GitHubReleaseAssetResponse
+{
+    public required string Name { get; init; }
+    public required string BrowserDownloadUrl { get; init; }
+}
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(GitHubReleaseResponse))]
+internal partial class ToolDownloadJsonContext : JsonSerializerContext;

--- a/src/PulseAPK.Core/Services/ToolRepository.cs
+++ b/src/PulseAPK.Core/Services/ToolRepository.cs
@@ -1,0 +1,30 @@
+using PulseAPK.Core.Abstractions;
+
+namespace PulseAPK.Core.Services;
+
+public sealed class ToolRepository : IToolRepository
+{
+    public string ToolsDirectory { get; }
+
+    public ToolRepository(ISettingsService settingsService)
+    {
+        ToolsDirectory = Path.Combine(settingsService.SettingsDirectory, "tools");
+    }
+
+    public string GetToolPath(string fileName)
+    {
+        EnsureToolsDirectory();
+        return Path.Combine(ToolsDirectory, fileName);
+    }
+
+    public bool TryGetCachedToolPath(string fileName, out string path)
+    {
+        path = Path.Combine(ToolsDirectory, fileName);
+        return File.Exists(path);
+    }
+
+    private void EnsureToolsDirectory()
+    {
+        Directory.CreateDirectory(ToolsDirectory);
+    }
+}

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -10,6 +10,9 @@ public partial class SettingsViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
     private readonly IFilePickerService _filePickerService;
+    private readonly IDialogService _dialogService;
+    private readonly IToolRepository _toolRepository;
+    private readonly IToolDownloadService _toolDownloadService;
     private readonly LocalizationService _localizationService;
 
     [ObservableProperty]
@@ -17,6 +20,9 @@ public partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private string _ubersignPath;
+
+    [ObservableProperty]
+    private bool _isDownloadingTools;
     
     [ObservableProperty]
     private LanguageItem _selectedLanguage;
@@ -24,17 +30,25 @@ public partial class SettingsViewModel : ObservableObject
     public List<LanguageItem> AvailableLanguages => _localizationService.AvailableLanguages;
 
     public SettingsViewModel(
-        ISettingsService settingsService, 
+        ISettingsService settingsService,
         IFilePickerService filePickerService,
+        IDialogService dialogService,
+        IToolRepository toolRepository,
+        IToolDownloadService toolDownloadService,
         LocalizationService localizationService)
     {
         _settingsService = settingsService;
         _filePickerService = filePickerService;
+        _dialogService = dialogService;
+        _toolRepository = toolRepository;
+        _toolDownloadService = toolDownloadService;
         _localizationService = localizationService;
 
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
         _selectedLanguage = _localizationService.CurrentLanguage;
+
+        NormalizeManagedToolPathsIfMissing();
     }
 
     partial void OnApktoolPathChanged(string value)
@@ -77,5 +91,100 @@ public partial class SettingsViewModel : ObservableObject
         {
             UbersignPath = file;
         }
+    }
+
+    [RelayCommand]
+    private async Task DownloadApktool()
+    {
+        await DownloadToolAsync(
+            () => _toolDownloadService.DownloadApktoolAsync(),
+            path => ApktoolPath = path,
+            Properties.Resources.DownloadApktoolButton);
+    }
+
+    [RelayCommand]
+    private async Task DownloadUbersigner()
+    {
+        await DownloadToolAsync(
+            () => _toolDownloadService.DownloadUbersignerAsync(),
+            path => UbersignPath = path,
+            Properties.Resources.DownloadUbersignerButton);
+    }
+
+    private async Task DownloadToolAsync(
+        Func<Task<ToolDownloadResult>> action,
+        Action<string> applyPath,
+        string toolDisplayName)
+    {
+        if (IsDownloadingTools)
+        {
+            return;
+        }
+
+        try
+        {
+            IsDownloadingTools = true;
+            var result = await action();
+            applyPath(result.Path);
+
+            if (result.Downloaded)
+            {
+                await _dialogService.ShowInfoAsync($"{toolDisplayName} downloaded successfully.", Properties.Resources.SettingsHeader);
+            }
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowErrorAsync($"Failed to download {toolDisplayName}: {ex.Message}", Properties.Resources.SettingsHeader);
+        }
+        finally
+        {
+            IsDownloadingTools = false;
+        }
+    }
+
+    private void NormalizeManagedToolPathsIfMissing()
+    {
+        var changed = false;
+
+        if (IsManagedToolMissing(ApktoolPath))
+        {
+            _apktoolPath = string.Empty;
+            _settingsService.Settings.ApktoolPath = string.Empty;
+            changed = true;
+        }
+
+        if (IsManagedToolMissing(UbersignPath))
+        {
+            _ubersignPath = string.Empty;
+            _settingsService.Settings.UbersignPath = string.Empty;
+            changed = true;
+        }
+
+        if (changed)
+        {
+            _settingsService.Save();
+            OnPropertyChanged(nameof(ApktoolPath));
+            OnPropertyChanged(nameof(UbersignPath));
+        }
+    }
+
+    private bool IsManagedToolMissing(string? configuredPath)
+    {
+        if (string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return false;
+        }
+
+        if (File.Exists(configuredPath))
+        {
+            return false;
+        }
+
+        var normalizedToolFolder = Path.GetFullPath(_toolRepository.ToolsDirectory)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        var normalizedConfiguredPath = Path.GetFullPath(configuredPath);
+
+        return normalizedConfiguredPath.StartsWith(normalizedToolFolder, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a built-in mechanism to download and manage `apktool` and `ubersigner` from GitHub releases and expose simple Download buttons in Settings. 
- Ensure downloads are secure and robust with cache-first lookup, streamed downloads to temporary `.download` files and atomic moves to final location. 
- Place managed artifacts inside the same PulseAPK user folder as settings (a `tools` directory) while preserving manual path selection by the user. 
- For security-sensitive tools, verify integrity with SHA256 and remove artifacts on mismatch.

### Description
- Added `IToolRepository` / `ToolRepository` which resolves and exposes the managed `tools` folder under `ISettingsService.SettingsDirectory` and provides cached-path checks and path construction. 
- Added `IToolDownloadService` / `ToolDownloadService` that implements cache-first lookup, calls GitHub `releases/latest`, selects assets by filename predicate, streams into a `.download` temp file then atomically moves to final path, and implements SHA256 checksum download+verification for ubersigner (deleting the artifact if verification fails), returning `ToolDownloadResult(Path, Downloaded)`. 
- Exposed `SettingsDirectory` on `ISettingsService`/`SettingsService` and wired `ToolRepository` + typed `HttpClient` for `ToolDownloadService` into DI in `App.axaml.cs`, and added `Microsoft.Extensions.Http` package reference. 
- Updated `SettingsViewModel` to add `DownloadApktoolCommand` and `DownloadUbersignerCommand` (which apply the resolved paths back into settings) and to clear managed paths when the managed `tools` artifact is missing; updated `SettingsView.axaml` to place Download buttons next to the Apktool/Ubersigner path inputs. 

### Testing
- Attempted to build the solution with `dotnet build PulseAPK.sln`, but the build could not run in this environment because `dotnet` is not available (`bash: command not found: dotnet`).
- Attempted an automated UI capture via a Playwright script, but the target was not available and the capture failed with `ERR_EMPTY_RESPONSE` (this is outside the Avalonia desktop scope).
- No other automated tests or unit tests were executed in this environment due to the missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b57a4c48908322a10e9520e0c091fe)