### PR TITLE
Fix core compile errors blocking build-appimage

### DIFF
--- a/src/PulseAPK.Core/Services/ToolDownloadService.cs
+++ b/src/PulseAPK.Core/Services/ToolDownloadService.cs
@@ -144,7 +144,7 @@ public sealed class ToolDownloadService : IToolDownloadService
 
     private static string? ExtractSha256FromChecksumFile(string checksumContent, string assetName)
     {
-        var lines = checksumContent.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var lines = checksumContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         foreach (var line in lines)
         {

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -99,7 +99,7 @@ public partial class SettingsViewModel : ObservableObject
         await DownloadToolAsync(
             () => _toolDownloadService.DownloadApktoolAsync(),
             path => ApktoolPath = path,
-            Properties.Resources.DownloadApktoolButton);
+            Properties.Resources.ResourceManager.GetString("DownloadApktoolButton") ?? Properties.Resources.DownloadApktool);
     }
 
     [RelayCommand]
@@ -108,7 +108,7 @@ public partial class SettingsViewModel : ObservableObject
         await DownloadToolAsync(
             () => _toolDownloadService.DownloadUbersignerAsync(),
             path => UbersignPath = path,
-            Properties.Resources.DownloadUbersignerButton);
+            Properties.Resources.ResourceManager.GetString("DownloadUbersignerButton") ?? "Ubersigner");
     }
 
     private async Task DownloadToolAsync(
@@ -148,23 +148,19 @@ public partial class SettingsViewModel : ObservableObject
 
         if (IsManagedToolMissing(ApktoolPath))
         {
-            _apktoolPath = string.Empty;
-            _settingsService.Settings.ApktoolPath = string.Empty;
+            ApktoolPath = string.Empty;
             changed = true;
         }
 
         if (IsManagedToolMissing(UbersignPath))
         {
-            _ubersignPath = string.Empty;
-            _settingsService.Settings.UbersignPath = string.Empty;
+            UbersignPath = string.Empty;
             changed = true;
         }
 
         if (changed)
         {
             _settingsService.Save();
-            OnPropertyChanged(nameof(ApktoolPath));
-            OnPropertyChanged(nameof(UbersignPath));
         }
     }
 


### PR DESCRIPTION
### Motivation
- The AppImage build was failing due to C# compile errors: missing resource members and an ambiguous `string.Split` call reported during publish. 
- Update resource usage and path normalization to avoid relying on non-generated `Resources` members and to comply with MVVM Toolkit recommendations.

### Description
- Replaced direct references to non-existent strongly-typed resources `DownloadApktoolButton` and `DownloadUbersignerButton` with safe lookups using `Properties.Resources.ResourceManager.GetString(...)` and fallbacks in `src/PulseAPK.Core/ViewModels/SettingsViewModel.cs`.
- Fixed the ambiguous overload for `string.Split` in `src/PulseAPK.Core/Services/ToolDownloadService.cs` by using `checksumContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)`.
- Updated managed-tool normalization to set observable properties (`ApktoolPath` / `UbersignPath`) instead of writing backing fields directly, and removed redundant `OnPropertyChanged` calls to keep property change flow consistent.

### Testing
- Ran `./scripts/build-appimage.sh`, but the attempt failed because `dotnet` was not available in `PATH`, so a full build verification could not be completed (error: `'dotnet' is required but was not found in PATH`).
- Verified code edits with `git diff` and inspected modified files `src/PulseAPK.Core/ViewModels/SettingsViewModel.cs` and `src/PulseAPK.Core/Services/ToolDownloadService.cs` to confirm intended changes were applied.
- Confirmed changes were committed to the repository via `git status` and the commit operation (local commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58067fd188322b3f21e225465a3a4)