### PR TITLE
Map GitHub release JSON fields to C# properties for tool downloads

### DIFF
--- a/src/PulseAPK.Core/Services/ToolDownloadService.cs
+++ b/src/PulseAPK.Core/Services/ToolDownloadService.cs
@@ -191,12 +191,16 @@ public sealed class ToolDownloadService : IToolDownloadService
 
 public sealed class GitHubReleaseResponse
 {
+    [JsonPropertyName("assets")]
     public required List<GitHubReleaseAssetResponse> Assets { get; init; }
 }
 
 public sealed class GitHubReleaseAssetResponse
 {
+    [JsonPropertyName("name")]
     public required string Name { get; init; }
+
+    [JsonPropertyName("browser_download_url")]
     public required string BrowserDownloadUrl { get; init; }
 }
 


### PR DESCRIPTION
### Motivation
- Fix runtime deserialization failure when fetching GitHub release data for tool downloads caused by GitHub's snake_case JSON fields not matching the C# property names.

### Description
- Add `[JsonPropertyName("assets")]`, `[JsonPropertyName("name")]` and `[JsonPropertyName("browser_download_url")]` to the GitHub release models in `src/PulseAPK.Core/Services/ToolDownloadService.cs` so `System.Text.Json` correctly binds the API payload to `Assets`, `Name`, and `BrowserDownloadUrl`.

### Testing
- Attempted to run `dotnet build /workspace/PulseAPK-Core/PulseAPK.sln`, but the `dotnet` CLI is not installed in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b581c60ec883229423e94cf6244388)