### PR TITLE
Fix Apktool downloader asset selection for latest releases

### DIFF
--- a/src/PulseAPK.Core/Services/ToolDownloadService.cs
+++ b/src/PulseAPK.Core/Services/ToolDownloadService.cs
@@ -28,7 +28,7 @@ public sealed class ToolDownloadService : IToolDownloadService
             owner: "iBotPeaches",
             repo: "Apktool",
             artifactFileName: "apktool.jar",
-            assetPredicate: static name => name.Equals("apktool.jar", StringComparison.OrdinalIgnoreCase),
+            assetPredicate: static name => IsApktoolReleaseJarAssetName(name),
             checksumFileName: null,
             checksumAssetPredicate: null,
             checksumValueSelector: null,
@@ -186,6 +186,19 @@ public sealed class ToolDownloadService : IToolDownloadService
         }
 
         return value;
+    }
+
+    private static bool IsApktoolReleaseJarAssetName(string name)
+    {
+        if (!name.EndsWith(".jar", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var baseName = Path.GetFileNameWithoutExtension(name);
+        return baseName.Equals("apktool", StringComparison.OrdinalIgnoreCase)
+            || baseName.StartsWith("apktool_", StringComparison.OrdinalIgnoreCase)
+            || baseName.StartsWith("apktool-", StringComparison.OrdinalIgnoreCase);
     }
 }
 

--- a/tests/unit/PulseAPK.Tests/Services/ToolDownloadServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ToolDownloadServiceTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Services;
+using Xunit;
+
+namespace PulseAPK.Tests.Services;
+
+public class ToolDownloadServiceTests
+{
+    [Fact]
+    public async Task DownloadApktoolAsync_DownloadsVersionedJarAssetName()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"pulseapk-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+
+        try
+        {
+            const string versionedAssetName = "apktool_2.11.1.jar";
+            const string downloadUrl = "https://example.test/assets/apktool_2.11.1.jar";
+            var payload = Encoding.UTF8.GetBytes("fake-apktool-binary");
+
+            using var httpClient = new HttpClient(new StubHttpMessageHandler(request =>
+            {
+                if (request.RequestUri?.AbsoluteUri == "https://api.github.com/repos/iBotPeaches/Apktool/releases/latest")
+                {
+                    var release = new
+                    {
+                        assets = new[]
+                        {
+                            new { name = "notes.txt", browser_download_url = "https://example.test/assets/notes.txt" },
+                            new { name = versionedAssetName, browser_download_url = downloadUrl }
+                        }
+                    };
+
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(JsonSerializer.Serialize(release), Encoding.UTF8, "application/json")
+                    };
+                }
+
+                if (request.RequestUri?.AbsoluteUri == downloadUrl)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(payload)
+                    };
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }));
+
+            var toolRepository = new TestToolRepository(tempRoot);
+            var service = new ToolDownloadService(httpClient, toolRepository);
+
+            var result = await service.DownloadApktoolAsync();
+
+            Assert.True(result.Downloaded);
+            Assert.Equal(toolRepository.GetToolPath("apktool.jar"), result.ToolPath);
+            Assert.True(File.Exists(result.ToolPath));
+            Assert.Equal(payload, await File.ReadAllBytesAsync(result.ToolPath));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
+    private sealed class TestToolRepository : IToolRepository
+    {
+        public TestToolRepository(string toolsDirectory)
+        {
+            ToolsDirectory = toolsDirectory;
+        }
+
+        public string ToolsDirectory { get; }
+
+        public string GetToolPath(string fileName)
+        {
+            return Path.Combine(ToolsDirectory, fileName);
+        }
+
+        public bool TryGetCachedToolPath(string fileName, out string path)
+        {
+            path = GetToolPath(fileName);
+            return File.Exists(path);
+        }
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_responder(request));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Recent Apktool releases publish JARs with versioned filenames (for example `apktool_2.11.1.jar` or `apktool-2.11.1.jar`) which caused the existing downloader to fail when it only looked for an exact `apktool.jar` asset.

### Description
- Changed `ToolDownloadService.DownloadApktoolAsync` to use a flexible predicate by delegating to a new `IsApktoolReleaseJarAssetName` helper instead of matching the exact `apktool.jar` filename.
- Added `IsApktoolReleaseJarAssetName` which accepts `.jar` assets whose base name is `apktool` or starts with `apktool_` or `apktool-`.
- Added unit test `DownloadApktoolAsync_DownloadsVersionedJarAssetName` in `ToolDownloadServiceTests` that stubs the GitHub latest-release response with a versioned `apktool_2.11.1.jar` asset and verifies the file is downloaded and written to the expected local `apktool.jar` path.

### Testing
- Added unit test `DownloadApktoolAsync_DownloadsVersionedJarAssetName` which exercises the new matching logic and verifies the downloaded bytes and target path; the test file is `tests/unit/PulseAPK.Tests/Services/ToolDownloadServiceTests.cs`.
- An attempt to run the test runner with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter ToolDownloadServiceTests` failed in this environment because `dotnet` is not installed (so tests were not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5836ca35883229b6328977e126ac1)