### PR TITLE
Increase horizontal padding for Settings download buttons

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -32,7 +32,8 @@
             <Button Grid.Column="2"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadApktoolButton]}"
                     Command="{Binding DownloadApktoolCommand}"
-                    Width="150" />
+                    MinWidth="150"
+                    Padding="16,0" />
         </Grid>
 
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UbersignPath]}"
@@ -46,7 +47,8 @@
             <Button Grid.Column="2"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadUbersignerButton]}"
                     Command="{Binding DownloadUbersignerCommand}"
-                    Width="150" />
+                    MinWidth="150"
+                    Padding="16,0" />
         </Grid>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Prevent the Download ApkTool and Download Ubersigner button labels from being clipped when localized or longer text is used by giving the buttons extra horizontal space.

### Description
- Modified `src/PulseAPK.Avalonia/Views/SettingsView.axaml` to replace the fixed `Width="150"` on both download buttons with `MinWidth="150"` and added `Padding="16,0"` to provide additional horizontal breathing room for their content.

### Testing
- Attempted to run `dotnet build`, but `dotnet` is not available in this environment so the build could not be executed; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b585a3487c8322b6180d81e05f2a2e)