### PR TITLE
Use 'Get' for ApkTool/Ubersigner English labels

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -272,13 +272,13 @@
     <value>The selected folder does not contain Smali files.</value>
   </data>
   <data name="DownloadApktoolButton" xml:space="preserve">
-    <value>Download ApkTool</value>
+    <value>Get ApkTool</value>
   </data>
   <data name="DownloadJavaButton" xml:space="preserve">
     <value>Download JAVA</value>
   </data>
   <data name="DownloadUbersignerButton" xml:space="preserve">
-    <value>Download Ubersigner</value>
+    <value>Get Ubersigner</value>
   </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Language</value>


### PR DESCRIPTION
### Motivation
- Reduce button text width in the English UI by replacing the longer word "Download" with the shorter "Get" for the two external-tool actions.

### Description
- Updated the English resource file `src/PulseAPK.Core/Properties/Resources.resx` to change `Download ApkTool` → `Get ApkTool` and `Download Ubersigner` → `Get Ubersigner` without modifying any button layout or behavior.

### Testing
- Verified the updated strings by running `rg` to locate occurrences and inspecting the resource snippet with `nl -ba src/PulseAPK.Core/Properties/Resources.resx | sed -n '268,286p'`, which showed the new `Get ApkTool` and `Get Ubersigner` values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5881f660c83228e9c30a2af8ecf0b)