### PR TITLE
Bump app and core versions to 1.2.2

### DIFF
--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PulseAPK.Core</RootNamespace>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
### Motivation
- Align project versioning and prepare the next patch release by updating the current `1.2.1` version to `1.2.2` across projects.

### Description
- Updated the `<Version>` element from `1.2.1` to `1.2.2` in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.
- Updated the `<Version>` element from `1.2.1` to `1.2.2` in `src/PulseAPK.Core/PulseAPK.Core.csproj`.
- Changes were committed with message `Bump app version to 1.2.2`.

### Testing
- Attempted `dotnet build PulseAPK.sln -c Release`, but the command failed because `dotnet` is not available in this environment (`command not found`).
- No automated unit tests were executed due to the missing `dotnet` tool in the runtime environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59f064fb48322a16be2066f05b180)