### PR TITLE
Add NOTICE file and clarify attribution/licensing in README

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+PulseAPK
+Copyright (c) 2026 Dmitry Yarygin.
+
+Maintainer / Organization
+- PulseAPK project (maintained by Dmitry Yarygin)
+
+Attribution and contribution records
+- Contributor attribution is tracked through the Git commit history and pull request metadata.
+- All contributions are additionally documented through the Contributor License Agreement process in CLA.md.
+- Individual contributors retain copyright in their own contributions, while licensing contributions under Apache License 2.0 terms as described in LICENSE.md and CLA.md.

--- a/README.MD
+++ b/README.MD
@@ -116,6 +116,14 @@ PulseAPK utilizes a clean MVVM (Model-View-ViewModel) architecture:
 
 This project is open-source and available under the [Apache License 2.0](LICENSE.md).
 
+## Attribution and Copyright
+
+- Licensing terms are defined by [LICENSE.md](LICENSE.md) (Apache-2.0).
+- Contributor licensing and ownership terms are defined by [CLA.md](CLA.md).
+- Project-level copyright and attribution practices are documented in [NOTICE](NOTICE).
+- Per-file copyright/license headers are **optional** unless a file requires an explicit third-party notice; repository-level `LICENSE.md` and `NOTICE` remain authoritative.
+- Contributors do **not** need to add themselves to a separate acknowledgements list in this repository; attribution is handled through Git history, pull request metadata, and signed CLA records.
+
 ### ❤️ Support the project
 
 If PulseAPK is useful for you, you can support its development by pressing the "Support" button at the top


### PR DESCRIPTION
### Motivation
- Provide a project-level attribution notice and clarify contributor licensing and attribution workflow for the repository.

### Description
- Add a new `NOTICE` file containing copyright, maintainer, and contributor/CLA information, and update `README.MD` with an "Attribution and Copyright" section that references `LICENSE.md`, `CLA.md`, and the new `NOTICE` and explains per-file header policy and how contributions are tracked.

### Testing
- No code changes were made; documentation was linted with `markdownlint` and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5cbe3bc288322b791d893fdead5ea)