### PR TITLE
Add selectable Light/Dark mode in Settings with persisted config value

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -8,7 +8,6 @@ using PulseAPK.Core.Abstractions;
 using PulseAPK.Core.Services;
 using PulseAPK.Core.ViewModels;
 using System;
-using System.Runtime.InteropServices;
 
 namespace PulseAPK.Avalonia;
 
@@ -30,13 +29,7 @@ public partial class App : Application
         // Initialize settings/localization
         var settingsService = Services.GetRequiredService<ISettingsService>();
         LocalizationService.Instance.Initialize(settingsService);
-
-        // The app layout uses a dark visual palette; force dark mode on Windows to
-        // avoid low-contrast dark text when the OS is set to light mode.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            RequestedThemeVariant = ThemeVariant.Dark;
-        }
+        RequestedThemeVariant = ResolveThemeVariant(settingsService.Settings.ThemeMode);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -75,5 +68,12 @@ public partial class App : Application
 
         // Windows
         services.AddTransient<MainWindow>();
+    }
+
+    private static ThemeVariant ResolveThemeVariant(string? themeMode)
+    {
+        return string.Equals(themeMode, "light_mode", StringComparison.OrdinalIgnoreCase)
+            ? ThemeVariant.Light
+            : ThemeVariant.Dark;
     }
 }

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -21,6 +21,18 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
 
+        <TextBlock Text="Theme"
+                   FontWeight="SemiBold" />
+        <ComboBox ItemsSource="{Binding AvailableThemeModes}"
+                  SelectedItem="{Binding SelectedThemeMode}"
+                  Width="260">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}" />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
                    FontWeight="SemiBold" />
         <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -9,6 +9,7 @@ namespace PulseAPK.Core.Services
         public string ApktoolPath { get; set; } = "apktool.jar";
         public string UbersignPath { get; set; } = string.Empty;
         public string SelectedLanguage { get; set; } = "en-US";
+        public string ThemeMode { get; set; } = "dark_mode";
     }
 
     public interface ISettingsService

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -26,8 +26,16 @@ public partial class SettingsViewModel : ObservableObject
     
     [ObservableProperty]
     private LanguageItem _selectedLanguage;
+
+    [ObservableProperty]
+    private ThemeModeItem _selectedThemeMode;
     
     public List<LanguageItem> AvailableLanguages => _localizationService.AvailableLanguages;
+    public List<ThemeModeItem> AvailableThemeModes { get; } =
+    [
+        new("dark_mode", "Dark mode"),
+        new("light_mode", "Light mode")
+    ];
 
     public SettingsViewModel(
         ISettingsService settingsService,
@@ -47,6 +55,7 @@ public partial class SettingsViewModel : ObservableObject
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
         _selectedLanguage = _localizationService.CurrentLanguage;
+        _selectedThemeMode = ResolveThemeMode(_settingsService.Settings.ThemeMode);
 
         NormalizeManagedToolPathsIfMissing();
     }
@@ -71,6 +80,17 @@ public partial class SettingsViewModel : ObservableObject
             _settingsService.Settings.SelectedLanguage = value.Code;
             _settingsService.Save();
         }
+    }
+
+    partial void OnSelectedThemeModeChanged(ThemeModeItem value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        _settingsService.Settings.ThemeMode = value.Key;
+        _settingsService.Save();
     }
 
     [RelayCommand]
@@ -183,4 +203,13 @@ public partial class SettingsViewModel : ObservableObject
 
         return normalizedConfiguredPath.StartsWith(normalizedToolFolder, StringComparison.OrdinalIgnoreCase);
     }
+
+    private ThemeModeItem ResolveThemeMode(string? themeMode)
+    {
+        return AvailableThemeModes.FirstOrDefault(mode =>
+                   string.Equals(mode.Key, themeMode, StringComparison.OrdinalIgnoreCase))
+               ?? AvailableThemeModes[0];
+    }
 }
+
+public sealed record ThemeModeItem(string Key, string Name);


### PR DESCRIPTION
### Motivation
- Add a user-selectable theme option in Settings under the language selector so the UI can be switched to a Light mode while preserving the existing Dark default behavior. 

### Description
- Added a `ThemeMode` property to `AppSettings` with a default of `"dark_mode"` so missing settings fall back to dark mode. 
- Added a `Theme` ComboBox beneath the language selector in `SettingsView.axaml` bound to `AvailableThemeModes` and `SelectedThemeMode`. 
- Extended `SettingsViewModel` with `AvailableThemeModes`, `SelectedThemeMode`, `ThemeModeItem`, persistence in `OnSelectedThemeModeChanged`, and `ResolveThemeMode` to initialize the selection. 
- Updated application startup in `App.axaml.cs` to call `ResolveThemeVariant` and apply `ThemeVariant.Light` only when `ThemeMode == "light_mode"`, otherwise `ThemeVariant.Dark` (replacing the previous Windows-only forced dark logic). 

### Testing
- Attempted to run an automated build with `dotnet build PulseAPK.sln -c Release`, but the environment lacks the `dotnet` SDK so the build could not be executed (failed: `dotnet` command not found`).
- No other automated tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b699b1b2408322822241a3992ee587)