### PR TITLE
Fix light mode theme switching and use light-friendly UI colors

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -7,4 +7,25 @@
     <Application.Styles>
         <FluentTheme />
     </Application.Styles>
+
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#202020" />
+                    <SolidColorBrush x:Key="MainBackgroundBrush" Color="#121212" />
+                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#1B1B1B" />
+                    <SolidColorBrush x:Key="CardBorderBrush" Color="#3C3C3C" />
+                    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#2E2E2E" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#F3F3F3" />
+                    <SolidColorBrush x:Key="MainBackgroundBrush" Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="CardBorderBrush" Color="#DADADA" />
+                    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#CDCDCD" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using Avalonia.Styling;
 using Microsoft.Extensions.DependencyInjection;
 using PulseAPK.Avalonia.Services;
 using PulseAPK.Core.Abstractions;
@@ -29,7 +28,8 @@ public partial class App : Application
         // Initialize settings/localization
         var settingsService = Services.GetRequiredService<ISettingsService>();
         LocalizationService.Instance.Initialize(settingsService);
-        RequestedThemeVariant = ResolveThemeVariant(settingsService.Settings.ThemeMode);
+        var themeService = Services.GetRequiredService<IThemeService>();
+        themeService.ApplyTheme(settingsService.Settings.ThemeMode);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
@@ -57,6 +57,7 @@ public partial class App : Application
         services.AddSingleton<IDialogService, AvaloniaDialogService>();
         services.AddSingleton<IDispatcherService, AvaloniaDispatcherService>();
         services.AddSingleton<IFilePickerService, AvaloniaFilePickerService>();
+        services.AddSingleton<IThemeService, AvaloniaThemeService>();
 
         // ViewModels
         services.AddSingleton<MainViewModel>();
@@ -68,12 +69,5 @@ public partial class App : Application
 
         // Windows
         services.AddTransient<MainWindow>();
-    }
-
-    private static ThemeVariant ResolveThemeVariant(string? themeMode)
-    {
-        return string.Equals(themeMode, "light_mode", StringComparison.OrdinalIgnoreCase)
-            ? ThemeVariant.Light
-            : ThemeVariant.Dark;
     }
 }

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -31,12 +31,12 @@
 
     <Grid ColumnDefinitions="220, *">
         <!-- Sidebar -->
-        <Border Grid.Column="0" Background="#202020" Padding="16">
+        <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}" Padding="16">
             <StackPanel Spacing="10">
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
                            FontSize="20"
                            FontWeight="Bold"
-                           Foreground="Cyan"
+                           Foreground="{DynamicResource SystemAccentColor}"
                            HorizontalAlignment="Center"
                            Margin="0,0,0,20"/>
                 
@@ -59,7 +59,7 @@
         </Border>
 
         <!-- Content -->
-        <Border Grid.Column="1" Background="#121212" Padding="20">
+        <Border Grid.Column="1" Background="{DynamicResource MainBackgroundBrush}" Padding="20">
             <ContentControl Content="{Binding CurrentView}"/>
         </Border>
     </Grid>

--- a/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
+++ b/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
@@ -1,0 +1,21 @@
+using Avalonia;
+using Avalonia.Styling;
+using PulseAPK.Core.Abstractions;
+using System;
+
+namespace PulseAPK.Avalonia.Services;
+
+public sealed class AvaloniaThemeService : IThemeService
+{
+    public void ApplyTheme(string? themeMode)
+    {
+        if (Application.Current is null)
+        {
+            return;
+        }
+
+        Application.Current.RequestedThemeVariant = string.Equals(themeMode, "light_mode", StringComparison.OrdinalIgnoreCase)
+            ? ThemeVariant.Light
+            : ThemeVariant.Dark;
+    }
+}

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -10,8 +10,8 @@
                    FontWeight="SemiBold" />
 
         <Border Grid.Row="1"
-                Background="#1B1B1B"
-                BorderBrush="#3C3C3C"
+                Background="{DynamicResource CardBackgroundBrush}"
+                BorderBrush="{DynamicResource CardBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">
@@ -49,8 +49,8 @@
         </Border>
 
         <Border Grid.Row="2"
-                Background="#121212"
-                BorderBrush="#2E2E2E"
+                Background="{DynamicResource MainBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -10,8 +10,8 @@
                    FontWeight="SemiBold" />
 
         <Border Grid.Row="1"
-                Background="#1B1B1B"
-                BorderBrush="#3C3C3C"
+                Background="{DynamicResource CardBackgroundBrush}"
+                BorderBrush="{DynamicResource CardBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">
@@ -73,8 +73,8 @@
         </Grid>
 
         <Border Grid.Row="3"
-                Background="#121212"
-                BorderBrush="#2E2E2E"
+                Background="{DynamicResource MainBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -12,8 +12,8 @@
                    FontWeight="SemiBold" />
 
         <Border Grid.Row="1"
-                Background="#1B1B1B"
-                BorderBrush="#3C3C3C"
+                Background="{DynamicResource CardBackgroundBrush}"
+                BorderBrush="{DynamicResource CardBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">
@@ -79,8 +79,8 @@
         </Grid>
 
         <Border Grid.Row="3"
-                Background="#121212"
-                BorderBrush="#2E2E2E"
+                Background="{DynamicResource MainBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">

--- a/src/PulseAPK.Core/Abstractions/IThemeService.cs
+++ b/src/PulseAPK.Core/Abstractions/IThemeService.cs
@@ -1,0 +1,9 @@
+namespace PulseAPK.Core.Abstractions;
+
+/// <summary>
+/// Platform-agnostic theme service used to apply UI theme changes at runtime.
+/// </summary>
+public interface IThemeService
+{
+    void ApplyTheme(string? themeMode);
+}

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -14,6 +14,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly IToolRepository _toolRepository;
     private readonly IToolDownloadService _toolDownloadService;
     private readonly LocalizationService _localizationService;
+    private readonly IThemeService _themeService;
 
     [ObservableProperty]
     private string _apktoolPath;
@@ -43,7 +44,8 @@ public partial class SettingsViewModel : ObservableObject
         IDialogService dialogService,
         IToolRepository toolRepository,
         IToolDownloadService toolDownloadService,
-        LocalizationService localizationService)
+        LocalizationService localizationService,
+        IThemeService themeService)
     {
         _settingsService = settingsService;
         _filePickerService = filePickerService;
@@ -51,6 +53,7 @@ public partial class SettingsViewModel : ObservableObject
         _toolRepository = toolRepository;
         _toolDownloadService = toolDownloadService;
         _localizationService = localizationService;
+        _themeService = themeService;
 
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
@@ -91,6 +94,7 @@ public partial class SettingsViewModel : ObservableObject
 
         _settingsService.Settings.ThemeMode = value.Key;
         _settingsService.Save();
+        _themeService.ApplyTheme(value.Key);
     }
 
     [RelayCommand]


### PR DESCRIPTION
### Motivation
- The app saved theme changes but did not apply light mode immediately at runtime, leaving the UI in dark colors even after selecting light mode.
- Hardcoded dark hex colors in multiple XAML views prevented a proper light appearance when the theme changed.

### Description
- Introduced a platform-agnostic `IThemeService` in Core and an Avalonia implementation `AvaloniaThemeService` that maps `light_mode` to `ThemeVariant.Light` and defaults to dark otherwise (`src/PulseAPK.Core/Abstractions/IThemeService.cs`, `src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs`).
- Wired the theme service into DI and used it at startup to apply the persisted theme so launch-time theme selection is consistent (`src/PulseAPK.Avalonia/App.axaml.cs`).
- Updated `SettingsViewModel` to take an `IThemeService` and call `ApplyTheme(...)` when `SelectedThemeMode` changes so the UI updates immediately when a user switches theme (`src/PulseAPK.Core/ViewModels/SettingsViewModel.cs`).
- Replaced hardcoded dark brushes in main window and major views with theme-aware dynamic resources and added light/dark `ThemeDictionaries` in `App.axaml` to provide a proper light palette (`src/PulseAPK.Avalonia/App.axaml`, `src/PulseAPK.Avalonia/MainWindow.axaml`, `src/PulseAPK.Avalonia/Views/*.axaml`).

### Testing
- Attempted to run the test suite with `dotnet test PulseAPK.sln`, but the environment does not have `dotnet` installed so automated tests could not be executed (`bash: command not found: dotnet`).
- Verified via static inspection that theme resources are added and XAML views now reference `{DynamicResource ...}` keys and that the theme service is invoked both at startup and on settings changes; no runtime test executed due to the missing SDK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69c3c40b883228c01bc82338a9e89)