### PR TITLE
Localize Theme label and Light/Dark mode options

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -21,7 +21,7 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
 
-        <TextBlock Text="Theme"
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ThemeLabel]}"
                    FontWeight="SemiBold" />
         <ComboBox ItemsSource="{Binding AvailableThemeModes}"
                   SelectedItem="{Binding SelectedThemeMode}"

--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>تلميح: انقر على "استعراض" لاختيار مجلد المشروع.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>السمة</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>الوضع الداكن</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>الوضع الفاتح</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Tipp: Klicken Sie auf „Durchsuchen“, um einen Projektordner auszuwählen.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Thema</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Dunkler Modus</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Heller Modus</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Sugerencia: haz clic en Examinar para seleccionar una carpeta de proyecto.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Modo oscuro</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Modo claro</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Astuce : cliquez sur Parcourir pour choisir un dossier de projet.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Thème</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Mode sombre</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Mode clair</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Dica: clique em Procurar para escolher uma pasta de projeto.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Modo escuro</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Modo claro</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Tip: Click Browse to choose a project folder.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Theme</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Dark mode</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Light mode</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Подсказка: нажмите «Обзор», чтобы выбрать папку проекта.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Тема</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Тёмная тема</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Светлая тема</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Порада: натисніть «Огляд», щоб вибрати папку проєкту.</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>Тема</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>Темна тема</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>Світла тема</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -307,4 +307,13 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>提示：点击“浏览”以选择项目文件夹。</value>
   </data>
+  <data name="ThemeLabel" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="ThemeModeDark" xml:space="preserve">
+    <value>深色模式</value>
+  </data>
+  <data name="ThemeModeLight" xml:space="preserve">
+    <value>浅色模式</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -32,11 +32,13 @@ public partial class SettingsViewModel : ObservableObject
     private ThemeModeItem _selectedThemeMode;
     
     public List<LanguageItem> AvailableLanguages => _localizationService.AvailableLanguages;
-    public List<ThemeModeItem> AvailableThemeModes { get; } =
-    [
-        new("dark_mode", "Dark mode"),
-        new("light_mode", "Light mode")
-    ];
+    private List<ThemeModeItem> _availableThemeModes = [];
+
+    public List<ThemeModeItem> AvailableThemeModes
+    {
+        get => _availableThemeModes;
+        private set => SetProperty(ref _availableThemeModes, value);
+    }
 
     public SettingsViewModel(
         ISettingsService settingsService,
@@ -58,7 +60,9 @@ public partial class SettingsViewModel : ObservableObject
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
         _selectedLanguage = _localizationService.CurrentLanguage;
-        _selectedThemeMode = ResolveThemeMode(_settingsService.Settings.ThemeMode);
+
+        RefreshThemeModes(_settingsService.Settings.ThemeMode);
+        _localizationService.PropertyChanged += OnLocalizationChanged;
 
         NormalizeManagedToolPathsIfMissing();
     }
@@ -206,6 +210,26 @@ public partial class SettingsViewModel : ObservableObject
         var normalizedConfiguredPath = Path.GetFullPath(configuredPath);
 
         return normalizedConfiguredPath.StartsWith(normalizedToolFolder, StringComparison.OrdinalIgnoreCase);
+    }
+
+
+    private void OnLocalizationChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == "Item[]" || e.PropertyName == string.Empty)
+        {
+            RefreshThemeModes(SelectedThemeMode?.Key);
+        }
+    }
+
+    private void RefreshThemeModes(string? selectedThemeKey)
+    {
+        AvailableThemeModes =
+        [
+            new ThemeModeItem("dark_mode", _localizationService["ThemeModeDark"]),
+            new ThemeModeItem("light_mode", _localizationService["ThemeModeLight"])
+        ];
+
+        SelectedThemeMode = ResolveThemeMode(selectedThemeKey);
     }
 
     private ThemeModeItem ResolveThemeMode(string? themeMode)


### PR DESCRIPTION
### Motivation
- Make the Settings UI fully localizable by replacing hardcoded theme text with resource-backed strings so the Theme label and mode names follow the selected language. 

### Description
- Replace hardcoded `"Theme"` text in `src/PulseAPK.Avalonia/Views/SettingsView.axaml` with a localization binding to the `ThemeLabel` resource. 
- Change `SettingsViewModel` to build `AvailableThemeModes` from localized resources using `ThemeModeDark` and `ThemeModeLight`, expose it as a mutable property with `SetProperty`, and initialize it via `RefreshThemeModes`. 
- Add `OnLocalizationChanged` handler to refresh the mode labels when the app language changes and preserve the currently selected theme key via `ResolveThemeMode`. 
- Add new resource keys `ThemeLabel`, `ThemeModeDark`, and `ThemeModeLight` to the English and all supported locale `.resx` files with translated values. 

### Testing
- Attempted to run `dotnet build` to validate the change, but the environment does not have the .NET SDK installed and `dotnet` is not available, so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69fb4fb848322a89ccce6ebc7d8f9)