### PR TITLE
Implement IDisposable cleanup in SettingsViewModel

### DIFF
--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -6,7 +6,7 @@ using Properties = PulseAPK.Core.Properties;
 
 namespace PulseAPK.Core.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel : ObservableObject, IDisposable
 {
     private readonly ISettingsService _settingsService;
     private readonly IFilePickerService _filePickerService;
@@ -15,6 +15,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly IToolDownloadService _toolDownloadService;
     private readonly LocalizationService _localizationService;
     private readonly IThemeService _themeService;
+    private bool _disposed;
 
     [ObservableProperty]
     private string _apktoolPath;
@@ -237,6 +238,17 @@ public partial class SettingsViewModel : ObservableObject
         return AvailableThemeModes.FirstOrDefault(mode =>
                    string.Equals(mode.Key, themeMode, StringComparison.OrdinalIgnoreCase))
                ?? AvailableThemeModes[0];
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _localizationService.PropertyChanged -= OnLocalizationChanged;
+        _disposed = true;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the view model unsubscribes from localization events to prevent potential memory leaks and make disposal idempotent.

### Description
- Implemented `IDisposable` on `SettingsViewModel`, added a private `_disposed` flag, and added `Dispose()` which guards on `_disposed` and detaches `_localizationService.PropertyChanged -= OnLocalizationChanged;` while leaving the constructor subscription (`_localizationService.PropertyChanged += OnLocalizationChanged;`) unchanged.

### Testing
- Attempted to run `dotnet test PulseAPK.sln`, but the command failed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a41f008c8322b2e071d57d4457c6)