### PR TITLE
Centralize MainViewModel navigation with disposable-aware SetCurrentView

### DIFF
--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -34,42 +34,57 @@ public partial class MainViewModel : ObservableObject
         WindowTitle = _localizationService["AppTitle"];
         _localizationService.PropertyChanged += HandleLocalizationChanged;
         // Initial view
-        CurrentView = Resolve<DecompileViewModel>();
+        SetCurrentView(Resolve<DecompileViewModel>());
     }
 
     [RelayCommand]
     private void NavigateToDecompile()
     {
-        CurrentView = Resolve<DecompileViewModel>();
+        SetCurrentView(Resolve<DecompileViewModel>());
         SelectedMenu = "Decompile";
     }
 
     [RelayCommand]
     private void NavigateToSettings()
     {
-        CurrentView = Resolve<SettingsViewModel>();
+        SetCurrentView(Resolve<SettingsViewModel>());
         SelectedMenu = "Settings";
     }
 
     [RelayCommand]
     private void NavigateToBuild()
     {
-        CurrentView = Resolve<BuildViewModel>();
+        SetCurrentView(Resolve<BuildViewModel>());
         SelectedMenu = "Build";
     }
 
     [RelayCommand]
     private void NavigateToAnalyser()
     {
-        CurrentView = Resolve<AnalyserViewModel>();
+        SetCurrentView(Resolve<AnalyserViewModel>());
         SelectedMenu = "Analyser";
     }
 
     [RelayCommand]
     private void NavigateToAbout()
     {
-        CurrentView = Resolve<AboutViewModel>();
+        SetCurrentView(Resolve<AboutViewModel>());
         SelectedMenu = "About";
+    }
+
+    private void SetCurrentView(object nextView)
+    {
+        if (ReferenceEquals(CurrentView, nextView))
+        {
+            return;
+        }
+
+        if (CurrentView is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        CurrentView = nextView;
     }
 
     private T Resolve<T>() where T : notnull


### PR DESCRIPTION
### Motivation
- Reduce duplication and ensure proper disposal when switching views by centralizing view transitions in `MainViewModel`.
- Avoid potential resource leaks by disposing the previous view when it implements `IDisposable` while keeping menu selection behavior unchanged to minimize regressions.

### Description
- Added a helper `SetCurrentView(object nextView)` to `MainViewModel` that no-ops when `ReferenceEquals(CurrentView, nextView)`, disposes the previous `CurrentView` if it implements `IDisposable`, and then assigns `CurrentView = nextView`.
- Replaced direct `CurrentView = Resolve<...>()` assignments with `SetCurrentView(Resolve<...>())` in the constructor and in `NavigateToDecompile`, `NavigateToSettings`, `NavigateToBuild`, `NavigateToAnalyser`, and `NavigateToAbout`.
- Left existing `SelectedMenu` updates intact in each navigation method to preserve existing menu-selection logic.

### Testing
- Attempted to run `dotnet build src/PulseAPK.Core/PulseAPK.Core.csproj`, but the `dotnet` SDK is not available in the execution environment so compilation could not be verified.
- No automated unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a5310e508322b05a20a411a0e9c5)