### PR TITLE
Localize tool download success popup text across all languages

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>تنزيل Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>تم تنزيل {0} بنجاح.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>اللغة</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Ubersigner herunterladen</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} erfolgreich heruntergeladen.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Sprache</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Descargar Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} se descargó correctamente.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Idioma</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Télécharger Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} téléchargé avec succès.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Langue</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Baixar Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} baixado com sucesso.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Idioma</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Get Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} downloaded successfully.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Language</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Скачать Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} успешно загружен.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Язык</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>Завантажити Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} успішно завантажено.</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>Мова</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -280,6 +280,15 @@
   <data name="DownloadUbersignerButton" xml:space="preserve">
     <value>下载 Ubersigner</value>
   </data>
+  <data name="ToolNameApktool" xml:space="preserve">
+    <value>Apktool</value>
+  </data>
+  <data name="ToolNameUbersigner" xml:space="preserve">
+    <value>Ubersigner</value>
+  </data>
+  <data name="ToolDownloadedSuccessfullyMessage" xml:space="preserve">
+    <value>{0} 下载成功。</value>
+  </data>
   <data name="LanguageLabel" xml:space="preserve">
     <value>语言</value>
   </data>

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -128,7 +128,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         await DownloadToolAsync(
             () => _toolDownloadService.DownloadApktoolAsync(),
             path => ApktoolPath = path,
-            Properties.Resources.ResourceManager.GetString("DownloadApktoolButton") ?? Properties.Resources.DownloadApktool);
+            Properties.Resources.ResourceManager.GetString("ToolNameApktool") ?? "Apktool");
     }
 
     [RelayCommand]
@@ -137,7 +137,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         await DownloadToolAsync(
             () => _toolDownloadService.DownloadUbersignerAsync(),
             path => UbersignPath = path,
-            Properties.Resources.ResourceManager.GetString("DownloadUbersignerButton") ?? "Ubersigner");
+            Properties.Resources.ResourceManager.GetString("ToolNameUbersigner") ?? "Ubersigner");
     }
 
     private async Task DownloadToolAsync(
@@ -158,7 +158,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
             if (result.Downloaded)
             {
-                await _dialogService.ShowInfoAsync($"{toolDisplayName} downloaded successfully.", Properties.Resources.SettingsHeader);
+                var successTemplate = Properties.Resources.ResourceManager.GetString("ToolDownloadedSuccessfullyMessage")
+                    ?? "{0} downloaded successfully.";
+                await _dialogService.ShowInfoAsync(string.Format(successTemplate, toolDisplayName), Properties.Resources.SettingsHeader);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
### Motivation
- Make the download success popup show the tool name and a fully localized success message instead of composing hardcoded English text.
- Keep the existing download flow and behavior intact while improving translations and UX clarity.

### Description
- Updated `SettingsViewModel` to use localized tool-name keys (`ToolNameApktool`, `ToolNameUbersigner`) when building the success message instead of button label keys. (`DownloadApktool`, `DownloadUbersigner` usage for display was removed in this path.)
- Replaced the inline success string with a localized template `ToolDownloadedSuccessfullyMessage` and used `string.Format(...)` to insert the tool name in `DownloadToolAsync`.
- Added the new resource keys (`ToolNameApktool`, `ToolNameUbersigner`, `ToolDownloadedSuccessfullyMessage`) to all existing resource files under `src/PulseAPK.Core/Properties/` for English, Arabic, German, Spanish, French, Portuguese (pt-BR), Russian, Ukrainian and Chinese (zh-CN).
- Preserved all existing download logic and error handling (`DownloadToolAsync`, `ToolDownloadService` usage) so behavior is unchanged except for localized text.

### Testing
- Verified the new resource keys are present in each `src/PulseAPK.Core/Properties/Resources*.resx` file via automated file checks (search/inspection of resource files), and inspected the `SettingsViewModel` diff to confirm formatting changes were applied.
- Attempted to run `dotnet build PulseAPK.sln` but the environment lacks the .NET SDK (`dotnet: command not found`), so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a86533ac8322a32b794f2cb20a66)