### PR TITLE
Bump project version to 1.2.3

### DIFF
--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PulseAPK.Core</RootNamespace>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
### Motivation
- Prepare a patch release by updating the project version metadata to `1.2.3` for the application and core library.

### Description
- Updated the `<Version>` property to `1.2.3` in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` and `src/PulseAPK.Core/PulseAPK.Core.csproj`.

### Testing
- Verified the changes with `rg -n "<Version>"` which shows both files now contain `1.2.3` (succeeded).
- Attempted `dotnet build PulseAPK.sln -v minimal` but the `dotnet` CLI is not available in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ab63a60483229cd4fdfa8fc864f8)