### PR TITLE
docs: clarify automatic Apktool/Ubersigner download options

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,8 +57,8 @@ PulseAPK includes a built-in static analyzer that scans decompiled code for comm
 ## Prerequisites
 
 1.  **Java Runtime Environment (JRE)**: Required for `apktool`. Ensure `java` is in your system `PATH`.
-2.  **Apktool**: Download `apktool.jar` from [ibotpeaches.github.io](https://ibotpeaches.github.io/Apktool/).
-3.  **Ubersign (Uber APK Signer)**: Required for signing rebuilt APKs. Download the latest `uber-apk-signer.jar` from the [GitHub releases](https://github.com/patrickfav/uber-apk-signer/releases).
+2.  **Apktool**: You can download `apktool.jar` directly from PulseAPK by pressing the download button in **Settings**, or provide it manually from [ibotpeaches.github.io](https://ibotpeaches.github.io/Apktool/).
+3.  **Ubersign (Uber APK Signer)**: Required for signing rebuilt APKs. You can download the latest `uber-apk-signer.jar` automatically in **Settings**, or still provide it manually from the [GitHub releases](https://github.com/patrickfav/uber-apk-signer/releases).
 4.  **.NET 8.0 Runtime**: Required to run PulseAPK on supported platforms (Windows, Linux, and macOS).
 
 ## Quick Start Guide


### PR DESCRIPTION
### Motivation
- Clarify in the README that PulseAPK can now download `apktool.jar` and `uber-apk-signer.jar` automatically from the Settings UI while still allowing manual provisioning.

### Description
- Updated the Prerequisites section in `README.MD` to state that `apktool.jar` can be downloaded via the Settings download button or provided manually.
- Updated the Prerequisites section in `README.MD` to state that `uber-apk-signer.jar` can be downloaded automatically in Settings or provided manually.

### Testing
- No automated tests were required for this documentation-only change; commit succeeded and repository status was clean after the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6eb5dc55c8322a6744419772cf52b)