### PR TITLE
Add modular Frida gadget patch pipeline for APKs

### DIFF
--- a/src/PulseAPK.Core/Abstractions/Patching/IActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IActivityDetectionService.cs
@@ -1,0 +1,6 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IActivityDetectionService
+{
+    Task<(string? ActivityName, string? Warning, string? Error)> DetectMainActivityAsync(string decompiledDirectory, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IApktoolService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IApktoolService.cs
@@ -1,0 +1,7 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IApktoolService
+{
+    Task<int> DecompileAsync(string apkPath, string outputDirectory, bool decodeResources, bool decodeSources, CancellationToken cancellationToken = default);
+    Task<int> BuildAsync(string decompiledDirectory, string outputApkPath, bool useAapt2, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IArchitectureDetectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IArchitectureDetectionService.cs
@@ -1,0 +1,8 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IArchitectureDetectionService
+{
+    Task<(string? Architecture, string? Error, string? Warning)> ResolveAsync(PatchRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IDexMergeService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IDexMergeService.cs
@@ -1,0 +1,6 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IDexMergeService
+{
+    Task<(bool Success, string? Error)> PreserveOriginalDexFilesAsync(string originalApkPath, string rebuiltApkPath, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IFridaArtifactService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IFridaArtifactService.cs
@@ -1,0 +1,8 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IFridaArtifactService
+{
+    Task<(string? GadgetPath, string? Error)> ResolveGadgetAsync(PatchRequest request, string architecture, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IGadgetInjectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IGadgetInjectionService.cs
@@ -1,0 +1,8 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IGadgetInjectionService
+{
+    Task<(bool Success, string? Error)> InjectAsync(string decompiledDirectory, PatchRequest request, string architecture, string gadgetSourcePath, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IManifestPatchService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IManifestPatchService.cs
@@ -1,0 +1,8 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IManifestPatchService
+{
+    Task<(bool Success, string? Error)> PatchAsync(string manifestPath, PatchRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/IPatchPipelineService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IPatchPipelineService.cs
@@ -1,0 +1,8 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IPatchPipelineService
+{
+    Task<PatchResult> RunAsync(PatchRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/ISigningService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/ISigningService.cs
@@ -1,0 +1,6 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface ISigningService
+{
+    Task<(bool Success, string? SignedApkPath, string? Error)> SignAsync(string inputApkPath, string outputApkPath, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Abstractions/Patching/ISmaliPatchService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/ISmaliPatchService.cs
@@ -1,0 +1,6 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface ISmaliPatchService
+{
+    Task<(bool Success, string? Error)> PatchAsync(string decompiledDirectory, string activityName, bool useDelayedLoad, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Models/PatchRequest.cs
+++ b/src/PulseAPK.Core/Models/PatchRequest.cs
@@ -1,0 +1,23 @@
+namespace PulseAPK.Core.Models;
+
+public sealed record PatchRequest
+{
+    public string InputApkPath { get; init; } = string.Empty;
+    public string OutputApkPath { get; init; } = string.Empty;
+    public string? SelectedArchitecture { get; init; }
+    public bool SignOutput { get; init; }
+    public string? ConfigFilePath { get; init; }
+    public string? ScriptFilePath { get; init; }
+    public bool UseDelayedLoad { get; init; }
+    public string? WorkingDirectory { get; init; }
+    public bool KeepIntermediateFiles { get; init; }
+    public bool PreserveOriginalDexFiles { get; init; } = true;
+    public bool EnsureInternetPermission { get; init; } = true;
+    public bool EnsureExtractNativeLibs { get; init; } = true;
+    public string? PreferredActivityName { get; init; }
+    public string? DeviceAbi { get; init; }
+    public string? CustomGadgetBinaryPath { get; init; }
+    public bool DecodeResources { get; init; } = true;
+    public bool DecodeSources { get; init; } = true;
+    public bool UseAapt2ForBuild { get; init; }
+}

--- a/src/PulseAPK.Core/Models/PatchResult.cs
+++ b/src/PulseAPK.Core/Models/PatchResult.cs
@@ -1,0 +1,20 @@
+namespace PulseAPK.Core.Models;
+
+public sealed class PatchResult
+{
+    public bool Success { get; set; }
+    public string? OutputApkPath { get; set; }
+    public string? SelectedArchitecture { get; set; }
+    public string? PatchedActivity { get; set; }
+    public bool UsedSigning { get; set; }
+    public List<string> Warnings { get; } = new();
+    public List<string> Errors { get; } = new();
+    public List<PatchStageSummary> StageSummaries { get; } = new();
+
+    public static PatchResult Failure(params string[] errors)
+    {
+        var result = new PatchResult { Success = false };
+        result.Errors.AddRange(errors.Where(error => !string.IsNullOrWhiteSpace(error)));
+        return result;
+    }
+}

--- a/src/PulseAPK.Core/Models/PatchStageSummary.cs
+++ b/src/PulseAPK.Core/Models/PatchStageSummary.cs
@@ -1,0 +1,3 @@
+namespace PulseAPK.Core.Models;
+
+public sealed record PatchStageSummary(string Stage, bool Success, string Message);

--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -1,0 +1,44 @@
+using System.Xml.Linq;
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class ActivityDetectionService : IActivityDetectionService
+{
+    public Task<(string? ActivityName, string? Warning, string? Error)> DetectMainActivityAsync(string decompiledDirectory, CancellationToken cancellationToken = default)
+    {
+        var manifestPath = Path.Combine(decompiledDirectory, "AndroidManifest.xml");
+        if (!File.Exists(manifestPath))
+        {
+            return Task.FromResult<(string?, string?, string?)>((null, null, "AndroidManifest.xml was not found in decompiled output."));
+        }
+
+        var document = XDocument.Load(manifestPath);
+        var androidNs = XNamespace.Get("http://schemas.android.com/apk/res/android");
+
+        var activities = document.Descendants()
+            .Where(element => element.Name.LocalName is "activity" or "activity-alias")
+            .ToList();
+
+        var withLauncher = activities.FirstOrDefault(activity =>
+            activity.Descendants().Any(node =>
+                node.Name.LocalName == "action" &&
+                string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.action.MAIN", StringComparison.Ordinal))
+            && activity.Descendants().Any(node =>
+                node.Name.LocalName == "category" &&
+                string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.category.LAUNCHER", StringComparison.Ordinal))));
+
+        if (withLauncher is not null)
+        {
+            return Task.FromResult<(string?, string?, string?)>(((string?)withLauncher.Attribute(androidNs + "name"), null, null));
+        }
+
+        var firstActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
+        if (!string.IsNullOrWhiteSpace(firstActivityName))
+        {
+            return Task.FromResult<(string?, string?, string?)>((firstActivityName, "No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", null));
+        }
+
+        return Task.FromResult<(string?, string?, string?)>((null, null, "No activity entries found in AndroidManifest.xml."));
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/ApktoolServiceAdapter.cs
+++ b/src/PulseAPK.Core/Services/Patching/ApktoolServiceAdapter.cs
@@ -1,0 +1,19 @@
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class ApktoolServiceAdapter : IApktoolService
+{
+    private readonly ApktoolRunner _runner;
+
+    public ApktoolServiceAdapter(ApktoolRunner runner)
+    {
+        _runner = runner;
+    }
+
+    public Task<int> DecompileAsync(string apkPath, string outputDirectory, bool decodeResources, bool decodeSources, CancellationToken cancellationToken = default)
+        => _runner.RunDecompileAsync(apkPath, outputDirectory, decodeResources, decodeSources, keepOriginalManifest: false, forceOverwrite: true, cancellationToken);
+
+    public Task<int> BuildAsync(string decompiledDirectory, string outputApkPath, bool useAapt2, CancellationToken cancellationToken = default)
+        => _runner.RunBuildAsync(decompiledDirectory, outputApkPath, useAapt2, cancellationToken);
+}

--- a/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
@@ -1,0 +1,49 @@
+using System.IO.Compression;
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class ArchitectureDetectionService : IArchitectureDetectionService
+{
+    private static readonly HashSet<string> SupportedArchitectures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
+    };
+
+    public Task<(string? Architecture, string? Error, string? Warning)> ResolveAsync(PatchRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(request.SelectedArchitecture))
+        {
+            return Task.FromResult(SupportedArchitectures.Contains(request.SelectedArchitecture)
+                ? (request.SelectedArchitecture, null, null)
+                : (null, $"Unsupported architecture: {request.SelectedArchitecture}", null));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.DeviceAbi) && SupportedArchitectures.Contains(request.DeviceAbi))
+        {
+            return Task.FromResult<(string?, string?, string?)>((request.DeviceAbi, null, null));
+        }
+
+        if (!File.Exists(request.InputApkPath))
+        {
+            return Task.FromResult<(string?, string?, string?)>((null, "Input APK was not found for architecture scanning.", null));
+        }
+
+        using var archive = ZipFile.OpenRead(request.InputApkPath);
+        var found = archive.Entries
+            .Select(entry => entry.FullName)
+            .Where(path => path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase))
+            .Select(path => path.Split('/'))
+            .Where(parts => parts.Length >= 3)
+            .Select(parts => parts[1])
+            .FirstOrDefault(abi => SupportedArchitectures.Contains(abi));
+
+        if (!string.IsNullOrWhiteSpace(found))
+        {
+            return Task.FromResult<(string?, string?, string?)>((found, null, null));
+        }
+
+        return Task.FromResult<(string?, string?, string?)>(("arm64-v8a", null, "No lib/<abi>/ entries were found in the APK. Falling back to arm64-v8a."));
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
+++ b/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
@@ -1,0 +1,39 @@
+using System.IO.Compression;
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class DexMergeService : IDexMergeService
+{
+    public Task<(bool Success, string? Error)> PreserveOriginalDexFilesAsync(string originalApkPath, string rebuiltApkPath, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(originalApkPath) || !File.Exists(rebuiltApkPath))
+        {
+            return Task.FromResult((false, "Original or rebuilt APK path does not exist." as string));
+        }
+
+        using var original = ZipFile.OpenRead(originalApkPath);
+        using var rebuilt = ZipFile.Open(rebuiltApkPath, ZipArchiveMode.Update);
+
+        var rebuiltDex = rebuilt.Entries.Where(entry => entry.FullName.StartsWith("classes", StringComparison.OrdinalIgnoreCase) && entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase)).ToList();
+        foreach (var dex in rebuiltDex)
+        {
+            dex.Delete();
+        }
+
+        var sourceDexEntries = original.Entries
+            .Where(entry => entry.FullName.StartsWith("classes", StringComparison.OrdinalIgnoreCase) && entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(entry => entry.FullName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var source in sourceDexEntries)
+        {
+            var target = rebuilt.CreateEntry(source.FullName, CompressionLevel.Optimal);
+            using var input = source.Open();
+            using var output = target.Open();
+            input.CopyTo(output);
+        }
+
+        return Task.FromResult((true, (string?)null));
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/FridaArtifactService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FridaArtifactService.cs
@@ -1,0 +1,36 @@
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class FridaArtifactService : IFridaArtifactService
+{
+    private readonly IToolRepository _toolRepository;
+
+    public FridaArtifactService(IToolRepository toolRepository)
+    {
+        _toolRepository = toolRepository;
+    }
+
+    public Task<(string? GadgetPath, string? Error)> ResolveGadgetAsync(PatchRequest request, string architecture, CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(request.CustomGadgetBinaryPath))
+        {
+            if (File.Exists(request.CustomGadgetBinaryPath))
+            {
+                return Task.FromResult<(string?, string?)>((request.CustomGadgetBinaryPath, null));
+            }
+
+            return Task.FromResult<(string?, string?)>((null, $"Custom gadget binary '{request.CustomGadgetBinaryPath}' was not found."));
+        }
+
+        var cachePath = _toolRepository.GetToolPath(Path.Combine("frida", architecture, "libfrida-gadget.so"));
+        if (File.Exists(cachePath))
+        {
+            return Task.FromResult<(string?, string?)>((cachePath, null));
+        }
+
+        return Task.FromResult<(string?, string?)>((null, $"Frida gadget for ABI '{architecture}' was not found in tool cache: '{cachePath}'."));
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
@@ -1,0 +1,36 @@
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class GadgetInjectionService : IGadgetInjectionService
+{
+    public Task<(bool Success, string? Error)> InjectAsync(string decompiledDirectory, PatchRequest request, string architecture, string gadgetSourcePath, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(gadgetSourcePath))
+        {
+            return Task.FromResult((false, $"Resolved gadget source '{gadgetSourcePath}' does not exist." as string));
+        }
+
+        var libDirectory = Path.Combine(decompiledDirectory, "lib", architecture);
+        Directory.CreateDirectory(libDirectory);
+        File.Copy(gadgetSourcePath, Path.Combine(libDirectory, "libfrida-gadget.so"), overwrite: true);
+
+        EnsureOptionalAsset(request.ConfigFilePath, decompiledDirectory, "frida-gadget.config");
+        EnsureOptionalAsset(request.ScriptFilePath, decompiledDirectory, "frida-script.js");
+
+        return Task.FromResult((true, (string?)null));
+    }
+
+    private static void EnsureOptionalAsset(string? sourceFile, string decompiledDirectory, string outputName)
+    {
+        if (string.IsNullOrWhiteSpace(sourceFile) || !File.Exists(sourceFile))
+        {
+            return;
+        }
+
+        var assetsDirectory = Path.Combine(decompiledDirectory, "assets");
+        Directory.CreateDirectory(assetsDirectory);
+        File.Copy(sourceFile, Path.Combine(assetsDirectory, outputName), overwrite: true);
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
@@ -1,0 +1,79 @@
+using System.Xml;
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class ManifestPatchService : IManifestPatchService
+{
+    private const string AndroidNs = "http://schemas.android.com/apk/res/android";
+
+    public Task<(bool Success, string? Error)> PatchAsync(string manifestPath, PatchRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(manifestPath))
+        {
+            return Task.FromResult((false, "Manifest file was not found." as string));
+        }
+
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.Load(manifestPath);
+
+        var manager = new XmlNamespaceManager(document.NameTable);
+        manager.AddNamespace("android", AndroidNs);
+
+        var manifestNode = document.SelectSingleNode("/manifest");
+        if (manifestNode is null)
+        {
+            return Task.FromResult((false, "Invalid AndroidManifest.xml structure." as string));
+        }
+
+        if (request.EnsureInternetPermission)
+        {
+            EnsureInternetPermission(document, manifestNode, manager);
+        }
+
+        if (request.EnsureExtractNativeLibs)
+        {
+            EnsureExtractNativeLibs(document, manager);
+        }
+
+        document.Save(manifestPath);
+        return Task.FromResult((true, (string?)null));
+    }
+
+    private static void EnsureInternetPermission(XmlDocument document, XmlNode manifestNode, XmlNamespaceManager manager)
+    {
+        var exists = document.SelectSingleNode("/manifest/uses-permission[@android:name='android.permission.INTERNET']", manager) is not null;
+        if (exists)
+        {
+            return;
+        }
+
+        var permission = document.CreateElement("uses-permission");
+        var attr = document.CreateAttribute("android", "name", AndroidNs);
+        attr.Value = "android.permission.INTERNET";
+        permission.Attributes?.Append(attr);
+
+        manifestNode.PrependChild(permission);
+    }
+
+    private static void EnsureExtractNativeLibs(XmlDocument document, XmlNamespaceManager manager)
+    {
+        var applicationNode = document.SelectSingleNode("/manifest/application", manager);
+        if (applicationNode is null)
+        {
+            return;
+        }
+
+        var existing = applicationNode.Attributes?["extractNativeLibs", AndroidNs];
+        if (existing is not null)
+        {
+            existing.Value = "true";
+            return;
+        }
+
+        var attr = document.CreateAttribute("android", "extractNativeLibs", AndroidNs);
+        attr.Value = "true";
+        applicationNode.Attributes?.Append(attr);
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -1,0 +1,219 @@
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class PatchPipelineService : IPatchPipelineService
+{
+    private readonly PatchRequestValidatorService _requestValidator;
+    private readonly IArchitectureDetectionService _architectureDetectionService;
+    private readonly IFridaArtifactService _fridaArtifactService;
+    private readonly IApktoolService _apktoolService;
+    private readonly IActivityDetectionService _activityDetectionService;
+    private readonly IManifestPatchService _manifestPatchService;
+    private readonly IGadgetInjectionService _gadgetInjectionService;
+    private readonly ISmaliPatchService _smaliPatchService;
+    private readonly IDexMergeService _dexMergeService;
+    private readonly ISigningService _signingService;
+
+    public PatchPipelineService(
+        PatchRequestValidatorService requestValidator,
+        IArchitectureDetectionService architectureDetectionService,
+        IFridaArtifactService fridaArtifactService,
+        IApktoolService apktoolService,
+        IActivityDetectionService activityDetectionService,
+        IManifestPatchService manifestPatchService,
+        IGadgetInjectionService gadgetInjectionService,
+        ISmaliPatchService smaliPatchService,
+        IDexMergeService dexMergeService,
+        ISigningService signingService)
+    {
+        _requestValidator = requestValidator;
+        _architectureDetectionService = architectureDetectionService;
+        _fridaArtifactService = fridaArtifactService;
+        _apktoolService = apktoolService;
+        _activityDetectionService = activityDetectionService;
+        _manifestPatchService = manifestPatchService;
+        _gadgetInjectionService = gadgetInjectionService;
+        _smaliPatchService = smaliPatchService;
+        _dexMergeService = dexMergeService;
+        _signingService = signingService;
+    }
+
+    public async Task<PatchResult> RunAsync(PatchRequest request, CancellationToken cancellationToken = default)
+    {
+        var result = new PatchResult();
+        var validationErrors = _requestValidator.Validate(request);
+        if (validationErrors.Count > 0)
+        {
+            result.Errors.AddRange(validationErrors);
+            result.StageSummaries.Add(new PatchStageSummary("validation", false, string.Join("; ", validationErrors)));
+            return result;
+        }
+
+        var architectureResolution = await _architectureDetectionService.ResolveAsync(request, cancellationToken);
+        if (architectureResolution.Warning is not null)
+        {
+            result.Warnings.Add(architectureResolution.Warning);
+        }
+
+        if (architectureResolution.Error is not null || architectureResolution.Architecture is null)
+        {
+            result.Errors.Add(architectureResolution.Error ?? "Could not resolve architecture.");
+            result.StageSummaries.Add(new PatchStageSummary("architecture", false, result.Errors.Last()));
+            return result;
+        }
+
+        var architecture = architectureResolution.Architecture;
+        result.StageSummaries.Add(new PatchStageSummary("architecture", true, $"Using architecture '{architecture}'."));
+
+        var gadgetResolution = await _fridaArtifactService.ResolveGadgetAsync(request, architecture, cancellationToken);
+        if (gadgetResolution.Error is not null || gadgetResolution.GadgetPath is null)
+        {
+            result.Errors.Add(gadgetResolution.Error ?? "Unable to resolve Frida gadget artifact.");
+            result.StageSummaries.Add(new PatchStageSummary("artifact-resolution", false, result.Errors.Last()));
+            return result;
+        }
+
+        var decompiledDirectory = PrepareWorkingDirectory(request);
+        var cleanupDirectory = !request.KeepIntermediateFiles ? decompiledDirectory : null;
+
+        try
+        {
+            var decompileCode = await _apktoolService.DecompileAsync(request.InputApkPath, decompiledDirectory, request.DecodeResources, request.DecodeSources, cancellationToken);
+            if (decompileCode != 0)
+            {
+                result.Errors.Add($"Decompile failed with exit code {decompileCode}.");
+                result.StageSummaries.Add(new PatchStageSummary("decompile", false, result.Errors.Last()));
+                return result;
+            }
+
+            result.StageSummaries.Add(new PatchStageSummary("decompile", true, "APK decompiled successfully."));
+
+            var activityResult = await _activityDetectionService.DetectMainActivityAsync(decompiledDirectory, cancellationToken);
+            if (activityResult.Warning is not null)
+            {
+                result.Warnings.Add(activityResult.Warning);
+            }
+
+            if (activityResult.Error is not null || activityResult.ActivityName is null)
+            {
+                result.Errors.Add(activityResult.Error ?? "Unable to detect main activity.");
+                result.StageSummaries.Add(new PatchStageSummary("activity-detection", false, result.Errors.Last()));
+                return result;
+            }
+
+            var activityName = activityResult.ActivityName;
+            result.PatchedActivity = activityName;
+            result.StageSummaries.Add(new PatchStageSummary("activity-detection", true, $"Selected activity '{activityName}'."));
+
+            var manifestPath = Path.Combine(decompiledDirectory, "AndroidManifest.xml");
+            var manifestPatch = await _manifestPatchService.PatchAsync(manifestPath, request, cancellationToken);
+            if (!manifestPatch.Success)
+            {
+                result.Errors.Add(manifestPatch.Error ?? "Manifest patch failed.");
+                result.StageSummaries.Add(new PatchStageSummary("manifest-patch", false, result.Errors.Last()));
+                return result;
+            }
+
+            result.StageSummaries.Add(new PatchStageSummary("manifest-patch", true, "Manifest patched."));
+
+            var gadgetInject = await _gadgetInjectionService.InjectAsync(decompiledDirectory, request, architecture, gadgetResolution.GadgetPath, cancellationToken);
+            if (!gadgetInject.Success)
+            {
+                result.Errors.Add(gadgetInject.Error ?? "Gadget injection failed.");
+                result.StageSummaries.Add(new PatchStageSummary("gadget-injection", false, result.Errors.Last()));
+                return result;
+            }
+
+            result.StageSummaries.Add(new PatchStageSummary("gadget-injection", true, "Frida gadget injected."));
+
+            var smaliPatch = await _smaliPatchService.PatchAsync(decompiledDirectory, activityName, request.UseDelayedLoad, cancellationToken);
+            if (!smaliPatch.Success)
+            {
+                result.Errors.Add(smaliPatch.Error ?? "Smali patch failed.");
+                result.StageSummaries.Add(new PatchStageSummary("smali-patch", false, result.Errors.Last()));
+                return result;
+            }
+
+            result.StageSummaries.Add(new PatchStageSummary("smali-patch", true, "Smali patched."));
+
+            var buildCode = await _apktoolService.BuildAsync(decompiledDirectory, request.OutputApkPath, request.UseAapt2ForBuild, cancellationToken);
+            if (buildCode != 0)
+            {
+                result.Errors.Add($"Build failed with exit code {buildCode}.");
+                result.StageSummaries.Add(new PatchStageSummary("build", false, result.Errors.Last()));
+                return result;
+            }
+
+            result.StageSummaries.Add(new PatchStageSummary("build", true, "APK rebuilt successfully."));
+
+            if (request.PreserveOriginalDexFiles)
+            {
+                var dexResult = await _dexMergeService.PreserveOriginalDexFilesAsync(request.InputApkPath, request.OutputApkPath, cancellationToken);
+                if (!dexResult.Success)
+                {
+                    result.Errors.Add(dexResult.Error ?? "DEX merge failed.");
+                    result.StageSummaries.Add(new PatchStageSummary("dex-preservation", false, result.Errors.Last()));
+                    return result;
+                }
+
+                result.StageSummaries.Add(new PatchStageSummary("dex-preservation", true, "Original dex files preserved."));
+            }
+
+            if (request.SignOutput)
+            {
+                var signedPath = GetSignedPath(request.OutputApkPath);
+                var signResult = await _signingService.SignAsync(request.OutputApkPath, signedPath, cancellationToken);
+                if (!signResult.Success)
+                {
+                    result.Errors.Add(signResult.Error ?? "Signing failed.");
+                    result.Warnings.Add("Unsigned rebuilt APK was preserved.");
+                    result.StageSummaries.Add(new PatchStageSummary("signing", false, result.Errors.Last()));
+                    result.OutputApkPath = request.OutputApkPath;
+                    result.SelectedArchitecture = architecture;
+                    return result;
+                }
+
+                result.StageSummaries.Add(new PatchStageSummary("signing", true, "Signed APK created."));
+                result.Success = true;
+                result.UsedSigning = true;
+                result.OutputApkPath = signResult.SignedApkPath;
+                result.SelectedArchitecture = architecture;
+                return result;
+            }
+
+            result.Success = true;
+            result.OutputApkPath = request.OutputApkPath;
+            result.SelectedArchitecture = architecture;
+            result.UsedSigning = false;
+            return result;
+        }
+        finally
+        {
+            if (cleanupDirectory is not null && Directory.Exists(cleanupDirectory))
+            {
+                Directory.Delete(cleanupDirectory, recursive: true);
+            }
+        }
+    }
+
+    private static string PrepareWorkingDirectory(PatchRequest request)
+    {
+        var root = string.IsNullOrWhiteSpace(request.WorkingDirectory)
+            ? Path.Combine(Path.GetTempPath(), "pulseapk-patch")
+            : request.WorkingDirectory;
+
+        var path = Path.Combine(root!, $"job-{Guid.NewGuid():N}", "decompiled");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string GetSignedPath(string outputApkPath)
+    {
+        var directory = Path.GetDirectoryName(outputApkPath) ?? Directory.GetCurrentDirectory();
+        var name = Path.GetFileNameWithoutExtension(outputApkPath);
+        var extension = Path.GetExtension(outputApkPath);
+        return Path.Combine(directory, $"{name}_signed{extension}");
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/PatchRequestValidatorService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchRequestValidatorService.cs
@@ -1,0 +1,37 @@
+using PulseAPK.Core.Models;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class PatchRequestValidatorService
+{
+    public IReadOnlyList<string> Validate(PatchRequest request)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(request.InputApkPath))
+        {
+            errors.Add("Input APK path is required.");
+        }
+        else if (!File.Exists(request.InputApkPath))
+        {
+            errors.Add($"Input APK '{request.InputApkPath}' was not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.OutputApkPath))
+        {
+            errors.Add("Output APK path is required.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ConfigFilePath) && !File.Exists(request.ConfigFilePath))
+        {
+            errors.Add($"Config file '{request.ConfigFilePath}' was not found.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.ScriptFilePath) && !File.Exists(request.ScriptFilePath))
+        {
+            errors.Add($"Script file '{request.ScriptFilePath}' was not found.");
+        }
+
+        return errors;
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/SigningService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SigningService.cs
@@ -1,0 +1,28 @@
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class SigningService : ISigningService
+{
+    private readonly UbersignRunner _ubersignRunner;
+
+    public SigningService(UbersignRunner ubersignRunner)
+    {
+        _ubersignRunner = ubersignRunner;
+    }
+
+    public async Task<(bool Success, string? SignedApkPath, string? Error)> SignAsync(string inputApkPath, string outputApkPath, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var code = await _ubersignRunner.RunSigningAsync(inputApkPath, outputApkPath, cancellationToken);
+            return code == 0
+                ? (true, outputApkPath, null)
+                : (false, null, $"Signing failed with exit code {code}.");
+        }
+        catch (Exception ex)
+        {
+            return (false, null, ex.Message);
+        }
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -1,0 +1,159 @@
+using System.Text.RegularExpressions;
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class SmaliPatchService : ISmaliPatchService
+{
+    public Task<(bool Success, string? Error)> PatchAsync(string decompiledDirectory, string activityName, bool useDelayedLoad, CancellationToken cancellationToken = default)
+    {
+        var smaliFile = ResolveActivitySmaliFile(decompiledDirectory, activityName);
+        if (smaliFile is null)
+        {
+            return Task.FromResult((false, $"Could not locate smali file for activity '{activityName}'." as string));
+        }
+
+        var originalContent = File.ReadAllText(smaliFile);
+        if (originalContent.Contains("frida-gadget", StringComparison.Ordinal) ||
+            originalContent.Contains("loadFridaGadget", StringComparison.Ordinal))
+        {
+            return Task.FromResult((true, (string?)null));
+        }
+
+        var classDescriptor = ExtractClassDescriptor(originalContent);
+        if (string.IsNullOrWhiteSpace(classDescriptor))
+        {
+            return Task.FromResult((false, "Unable to determine class descriptor from smali file." as string));
+        }
+
+        var methodBody = useDelayedLoad
+            ? new[]
+            {
+                ".method private static loadFridaGadget()V",
+                "    .locals 1",
+                "",
+                "    const-string v0, \"frida-gadget\"",
+                "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
+                "    return-void",
+                ".end method",
+                string.Empty
+            }
+            : new[]
+            {
+                ".method private static loadFridaGadget()V",
+                "    .locals 1",
+                "",
+                "    const-string v0, \"frida-gadget\"",
+                "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
+                "    return-void",
+                ".end method",
+                string.Empty
+            };
+
+        var patched = originalContent;
+        patched = InsertHelperMethod(patched, methodBody);
+        patched = InjectCallIntoOnCreate(patched, classDescriptor);
+
+        if (ReferenceEquals(patched, originalContent) || patched == originalContent)
+        {
+            return Task.FromResult((false, "Unable to find an injection point in activity smali file." as string));
+        }
+
+        File.WriteAllText(smaliFile, patched);
+        return Task.FromResult((true, (string?)null));
+    }
+
+    private static string? ResolveActivitySmaliFile(string decompiledDirectory, string activityName)
+    {
+        var relativePath = activityName.TrimStart('.').Replace('.', Path.DirectorySeparatorChar) + ".smali";
+        foreach (var smaliRoot in Directory.EnumerateDirectories(decompiledDirectory, "smali*", SearchOption.TopDirectoryOnly))
+        {
+            var direct = Path.Combine(smaliRoot, relativePath);
+            if (File.Exists(direct))
+            {
+                return direct;
+            }
+
+            var match = Directory.EnumerateFiles(smaliRoot, Path.GetFileName(relativePath), SearchOption.AllDirectories)
+                .FirstOrDefault(path => path.EndsWith(relativePath, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ExtractClassDescriptor(string content)
+    {
+        var match = Regex.Match(content, @"\.class\s+[\w\s-]+\s+(L[^;]+;)");
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string InsertHelperMethod(string content, IReadOnlyList<string> lines)
+    {
+        var endIndex = content.LastIndexOf(".end class", StringComparison.Ordinal);
+        if (endIndex < 0)
+        {
+            return content;
+        }
+
+        var method = string.Join(Environment.NewLine, lines) + Environment.NewLine;
+        return content.Insert(endIndex, method);
+    }
+
+    private static string InjectCallIntoOnCreate(string content, string classDescriptor)
+    {
+        var onCreatePattern = new Regex(@"(?ms)(\.method[^\n]* onCreate\(Landroid/os/Bundle;\)V\s+)(.*?)(\.end method)");
+        var match = onCreatePattern.Match(content);
+
+        if (match.Success)
+        {
+            var body = match.Groups[2].Value;
+            if (body.Contains("loadFridaGadget", StringComparison.Ordinal))
+            {
+                return content;
+            }
+
+            var call = "    invoke-static {}, " + classDescriptor + "->loadFridaGadget()V";
+            var superCallPattern = new Regex(@"(?m)^\s*invoke-super \{[^\n]+\}, [^\n]+->onCreate\(Landroid/os/Bundle;\)V\s*$");
+            if (superCallPattern.IsMatch(body))
+            {
+                body = superCallPattern.Replace(body, m => m.Value + Environment.NewLine + call, 1);
+            }
+            else
+            {
+                var split = body.Split(Environment.NewLine);
+                var insertAt = Array.FindIndex(split, line => line.TrimStart().StartsWith(".locals", StringComparison.Ordinal) || line.TrimStart().StartsWith(".registers", StringComparison.Ordinal));
+                if (insertAt >= 0)
+                {
+                    var lines = split.ToList();
+                    lines.Insert(insertAt + 1, call);
+                    body = string.Join(Environment.NewLine, lines);
+                }
+                else
+                {
+                    return content;
+                }
+            }
+
+            return content[..match.Groups[2].Index] + body + content[(match.Groups[2].Index + match.Groups[2].Length)..];
+        }
+
+        var methodToAdd = $".method protected onCreate(Landroid/os/Bundle;)V{Environment.NewLine}" +
+                          "    .locals 0" + Environment.NewLine +
+                          "    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V" + Environment.NewLine +
+                          $"    invoke-static {{}}, {classDescriptor}->loadFridaGadget()V{Environment.NewLine}" +
+                          "    return-void" + Environment.NewLine +
+                          ".end method" + Environment.NewLine + Environment.NewLine;
+
+        var endClassIndex = content.LastIndexOf(".end class", StringComparison.Ordinal);
+        if (endClassIndex < 0)
+        {
+            return content;
+        }
+
+        return content.Insert(endClassIndex, methodToAdd);
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
@@ -1,0 +1,36 @@
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class ActivityDetectionServiceTests
+{
+    [Fact]
+    public async Task DetectMainActivityAsync_PrefersMainLauncherActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='com.example.FallbackActivity' />
+    <activity android:name='com.example.MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Error);
+    }
+
+    private static string CreateManifest(string manifest)
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"pulseapk-manifest-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "AndroidManifest.xml"), manifest);
+        return root;
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ArchitectureDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ArchitectureDetectionServiceTests.cs
@@ -1,0 +1,40 @@
+using System.IO.Compression;
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class ArchitectureDetectionServiceTests
+{
+    [Fact]
+    public async Task ResolveAsync_UsesExplicitArchitecture_WhenProvided()
+    {
+        var service = new ArchitectureDetectionService();
+        var request = new PatchRequest { SelectedArchitecture = "x86_64" };
+
+        var result = await service.ResolveAsync(request);
+
+        Assert.Equal("x86_64", result.Architecture);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ScansApkLibraries_WhenNoExplicitArchitecture()
+    {
+        var apkPath = CreateApkWithEntry("lib/armeabi-v7a/libfoo.so");
+        var service = new ArchitectureDetectionService();
+
+        var result = await service.ResolveAsync(new PatchRequest { InputApkPath = apkPath });
+
+        Assert.Equal("armeabi-v7a", result.Architecture);
+        Assert.Null(result.Error);
+    }
+
+    private static string CreateApkWithEntry(string entry)
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.apk");
+        using var archive = ZipFile.Open(tempFile, ZipArchiveMode.Create);
+        archive.CreateEntry(entry);
+        return tempFile;
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/GadgetInjectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/GadgetInjectionServiceTests.cs
@@ -1,0 +1,25 @@
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class GadgetInjectionServiceTests
+{
+    [Fact]
+    public async Task InjectAsync_CopiesGadgetToAbiFolder()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"gadget-injection-{Guid.NewGuid():N}");
+        var gadgetPath = Path.Combine(root, "libfrida-gadget.so");
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(gadgetPath, "gadget");
+
+        var decompiled = Path.Combine(root, "decompiled");
+        Directory.CreateDirectory(decompiled);
+
+        var service = new GadgetInjectionService();
+        var result = await service.InjectAsync(decompiled, new PatchRequest(), "arm64-v8a", gadgetPath);
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(Path.Combine(decompiled, "lib", "arm64-v8a", "libfrida-gadget.so")));
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ManifestPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ManifestPatchServiceTests.cs
@@ -1,0 +1,22 @@
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class ManifestPatchServiceTests
+{
+    [Fact]
+    public async Task PatchAsync_AddsInternetPermission_AndExtractNativeLibs()
+    {
+        var manifestPath = Path.Combine(Path.GetTempPath(), $"manifest-{Guid.NewGuid():N}.xml");
+        await File.WriteAllTextAsync(manifestPath, "<manifest xmlns:android='http://schemas.android.com/apk/res/android'><application /></manifest>");
+
+        var service = new ManifestPatchService();
+        var result = await service.PatchAsync(manifestPath, new PatchRequest());
+
+        var content = await File.ReadAllTextAsync(manifestPath);
+        Assert.True(result.Success);
+        Assert.Contains("android.permission.INTERNET", content, StringComparison.Ordinal);
+        Assert.Contains("extractNativeLibs=\"true\"", content, StringComparison.Ordinal);
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -1,0 +1,120 @@
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class PatchPipelineServiceTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsFailure_WhenValidationFails()
+    {
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.RunAsync(new PatchRequest());
+
+        Assert.False(result.Success);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccess_WhenAllStagesPass()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var pipeline = CreatePipeline();
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = false
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(outputApk, result.OutputApkPath);
+    }
+
+    private static PatchPipelineService CreatePipeline()
+    {
+        return new PatchPipelineService(
+            new PatchRequestValidatorService(),
+            new FakeArchitectureService(),
+            new FakeArtifactService(),
+            new FakeApktoolService(),
+            new FakeActivityDetectionService(),
+            new FakeManifestPatchService(),
+            new FakeGadgetInjectionService(),
+            new FakeSmaliPatchService(),
+            new FakeDexMergeService(),
+            new FakeSigningService());
+    }
+
+    private sealed class FakeArchitectureService : IArchitectureDetectionService
+    {
+        public Task<(string? Architecture, string? Error, string? Warning)> ResolveAsync(PatchRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult<(string?, string?, string?)>(("arm64-v8a", null, null));
+    }
+
+    private sealed class FakeArtifactService : IFridaArtifactService
+    {
+        public Task<(string? GadgetPath, string? Error)> ResolveGadgetAsync(PatchRequest request, string architecture, CancellationToken cancellationToken = default)
+            => Task.FromResult<(string?, string?)>((request.InputApkPath, null));
+    }
+
+    private sealed class FakeApktoolService : IApktoolService
+    {
+        public Task<int> DecompileAsync(string apkPath, string outputDirectory, bool decodeResources, bool decodeSources, CancellationToken cancellationToken = default)
+        {
+            Directory.CreateDirectory(outputDirectory);
+            File.WriteAllText(Path.Combine(outputDirectory, "AndroidManifest.xml"), "<manifest xmlns:android='http://schemas.android.com/apk/res/android'><application><activity android:name='com.example.MainActivity' /></application></manifest>");
+            Directory.CreateDirectory(Path.Combine(outputDirectory, "smali", "com", "example"));
+            File.WriteAllText(Path.Combine(outputDirectory, "smali", "com", "example", "MainActivity.smali"), ".class public Lcom/example/MainActivity;\n.super Landroid/app/Activity;\n\n.end class");
+            return Task.FromResult(0);
+        }
+
+        public Task<int> BuildAsync(string decompiledDirectory, string outputApkPath, bool useAapt2, CancellationToken cancellationToken = default)
+        {
+            File.WriteAllText(outputApkPath, "built");
+            return Task.FromResult(0);
+        }
+    }
+
+    private sealed class FakeActivityDetectionService : IActivityDetectionService
+    {
+        public Task<(string? ActivityName, string? Warning, string? Error)> DetectMainActivityAsync(string decompiledDirectory, CancellationToken cancellationToken = default)
+            => Task.FromResult<(string?, string?, string?)>(("com.example.MainActivity", null, null));
+    }
+
+    private sealed class FakeManifestPatchService : IManifestPatchService
+    {
+        public Task<(bool Success, string? Error)> PatchAsync(string manifestPath, PatchRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult((true, (string?)null));
+    }
+
+    private sealed class FakeGadgetInjectionService : IGadgetInjectionService
+    {
+        public Task<(bool Success, string? Error)> InjectAsync(string decompiledDirectory, PatchRequest request, string architecture, string gadgetSourcePath, CancellationToken cancellationToken = default)
+            => Task.FromResult((true, (string?)null));
+    }
+
+    private sealed class FakeSmaliPatchService : ISmaliPatchService
+    {
+        public Task<(bool Success, string? Error)> PatchAsync(string decompiledDirectory, string activityName, bool useDelayedLoad, CancellationToken cancellationToken = default)
+            => Task.FromResult((true, (string?)null));
+    }
+
+    private sealed class FakeDexMergeService : IDexMergeService
+    {
+        public Task<(bool Success, string? Error)> PreserveOriginalDexFilesAsync(string originalApkPath, string rebuiltApkPath, CancellationToken cancellationToken = default)
+            => Task.FromResult((true, (string?)null));
+    }
+
+    private sealed class FakeSigningService : ISigningService
+    {
+        public Task<(bool Success, string? SignedApkPath, string? Error)> SignAsync(string inputApkPath, string outputApkPath, CancellationToken cancellationToken = default)
+            => Task.FromResult((true, outputApkPath, (string?)null));
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchRequestValidatorServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchRequestValidatorServiceTests.cs
@@ -1,0 +1,19 @@
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class PatchRequestValidatorServiceTests
+{
+    [Fact]
+    public void Validate_ReturnsErrors_WhenRequiredInputsMissing()
+    {
+        var service = new PatchRequestValidatorService();
+        var request = new PatchRequest();
+
+        var errors = service.Validate(request);
+
+        Assert.Contains(errors, error => error.Contains("Input APK", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(errors, error => error.Contains("Output APK", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -1,0 +1,38 @@
+using PulseAPK.Core.Services.Patching;
+
+namespace PulseAPK.Tests.Services.Patching;
+
+public class SmaliPatchServiceTests
+{
+    [Fact]
+    public async Task PatchAsync_IsIdempotent_ForRepeatedPatches()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+.super Landroid/app/Activity;
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 0
+    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
+    return-void
+.end method
+
+.end class");
+
+        var service = new SmaliPatchService();
+
+        var first = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+        var firstContent = await File.ReadAllTextAsync(file);
+        var second = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+        var secondContent = await File.ReadAllTextAsync(file);
+
+        Assert.True(first.Success);
+        Assert.True(second.Success);
+        Assert.Equal(firstContent, secondContent);
+        Assert.Contains("loadFridaGadget", secondContent, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, layered core workflow to patch APKs by injecting the Frida Gadget that can be invoked from CLI/GUI/API through a single typed contract (`PatchRequest`).
- Keep UI/command handlers thin and move business logic into single-responsibility, testable services with clear stage boundaries and structured results (`PatchResult`).
- Preserve existing PulseAPK behavior where relevant (apktool adapter, optional dex preservation and optional signing) while adding safe, idempotent smali/manifest changes for gadget injection.

### Description
- Added typed data contracts `PatchRequest`, `PatchResult`, and `PatchStageSummary` under `src/PulseAPK.Core/Models` for stable orchestration and result reporting.
- Introduced a stage-based pipeline `PatchPipelineService` and a validator `PatchRequestValidatorService` under `src/PulseAPK.Core/Services/Patching` that orchestrate validation, architecture resolution, artifact resolution, decompile/build, activity detection, manifest patching, gadget injection, smali patching, dex preservation, and optional signing.
- Implemented single-responsibility services and interfaces under `src/PulseAPK.Core/Abstractions/Patching` and `src/PulseAPK.Core/Services/Patching` including `IArchitectureDetectionService`/`ArchitectureDetectionService`, `IActivityDetectionService`/`ActivityDetectionService`, `IManifestPatchService`/`ManifestPatchService`, `IGadgetInjectionService`/`GadgetInjectionService`, `ISmaliPatchService`/`SmaliPatchService`, `IDexMergeService`/`DexMergeService`, `IFridaArtifactService`/`FridaArtifactService`, `ISigningService`/`SigningService`, and an `ApktoolServiceAdapter` to wrap the existing `ApktoolRunner`.
- Smali and manifest modifications are conservative and idempotent: `SmaliPatchService` avoids duplicate `loadFridaGadget` insertion and either injects into `onCreate` or safely adds a helper method; `ManifestPatchService` only adds internet permission and `extractNativeLibs` when needed and preserves whitespace.
- Added unit/integration-style tests covering request validation, architecture resolution, main activity detection, manifest patching, gadget injection path selection, smali idempotency, and pipeline success/failure reporting under `tests/unit/PulseAPK.Tests/Services/Patching`.

### Testing
- Unit tests were added for core stages: `PatchRequestValidatorServiceTests`, `ArchitectureDetectionServiceTests`, `ActivityDetectionServiceTests`, `ManifestPatchServiceTests`, `GadgetInjectionServiceTests`, `SmaliPatchServiceTests`, and `PatchPipelineServiceTests` and placed in `tests/unit/PulseAPK.Tests/Services/Patching`.
- An attempt to run the test suite with `dotnet test` was made but failed in the execution environment due to missing SDK (`dotnet: command not found`).
- All new code is structured for easy unit testing and the tests should succeed in a normal .NET SDK environment; CI should be able to run `dotnet test` to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7322ab7dc832287f9d09b1cefe622)