### PR TITLE
Fix ActivityDetectionService launcher query syntax error

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -26,7 +26,7 @@ public sealed class ActivityDetectionService : IActivityDetectionService
                 string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.action.MAIN", StringComparison.Ordinal))
             && activity.Descendants().Any(node =>
                 node.Name.LocalName == "category" &&
-                string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.category.LAUNCHER", StringComparison.Ordinal))));
+                string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.category.LAUNCHER", StringComparison.Ordinal)));
 
         if (withLauncher is not null)
         {


### PR DESCRIPTION
### Motivation
- Fix the `CS1003: Syntax error, ',' expected` compilation error caused by an extra closing parenthesis in the LINQ expression that detects MAIN/LAUNCHER activities.

### Description
- Removed the stray closing parenthesis in the `withLauncher` predicate in `src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs`, correcting the logic that checks for `android.intent.action.MAIN` and `android.intent.category.LAUNCHER`.

### Testing
- Attempted `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj -c Release`, but the build could not be run in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73532f1008322a13a51c76831a970)