### PR TITLE
Fix CS0411 in ArchitectureDetectionService

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
@@ -15,7 +15,7 @@ public sealed class ArchitectureDetectionService : IArchitectureDetectionService
     {
         if (!string.IsNullOrWhiteSpace(request.SelectedArchitecture))
         {
-            return Task.FromResult(SupportedArchitectures.Contains(request.SelectedArchitecture)
+            return Task.FromResult<(string?, string?, string?)>(SupportedArchitectures.Contains(request.SelectedArchitecture)
                 ? (request.SelectedArchitecture, null, null)
                 : (null, $"Unsupported architecture: {request.SelectedArchitecture}", null));
         }


### PR DESCRIPTION
### Motivation
- Resolve a compiler error (CS0411) caused by the compiler being unable to infer the generic type for a `Task.FromResult` call that returns a nullable tuple result in the architecture detection logic.

### Description
- Updated `src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs` to explicitly specify the tuple generic parameter on the `Task.FromResult` call for the selected-architecture return path so all return branches produce a concrete `Task<(string?, string?, string?)>` type.

### Testing
- Attempted to run `dotnet build src/PulseAPK.Core/PulseAPK.Core.csproj`, but the `dotnet` CLI is not available in this environment so the project build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b735ddc40483228eec66e8186fdf94)