### PR TITLE
Add Patch APK tab and integrate patch pipeline flow

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -4,7 +4,9 @@ using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using PulseAPK.Avalonia.Services;
 using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Abstractions.Patching;
 using PulseAPK.Core.Services;
+using PulseAPK.Core.Services.Patching;
 using PulseAPK.Core.ViewModels;
 using System;
 
@@ -53,6 +55,19 @@ public partial class App : Application
         services.AddTransient<ReportService>();
         services.AddSingleton<ISystemService, PulseAPK.Core.Services.SystemService>();
 
+        // Patching services
+        services.AddTransient<PatchRequestValidatorService>();
+        services.AddTransient<IArchitectureDetectionService, ArchitectureDetectionService>();
+        services.AddTransient<IFridaArtifactService, FridaArtifactService>();
+        services.AddTransient<IApktoolService, ApktoolServiceAdapter>();
+        services.AddTransient<IActivityDetectionService, ActivityDetectionService>();
+        services.AddTransient<IManifestPatchService, ManifestPatchService>();
+        services.AddTransient<IGadgetInjectionService, GadgetInjectionService>();
+        services.AddTransient<ISmaliPatchService, SmaliPatchService>();
+        services.AddTransient<IDexMergeService, DexMergeService>();
+        services.AddTransient<ISigningService, SigningService>();
+        services.AddTransient<IPatchPipelineService, PatchPipelineService>();
+
         // Avalonia Services
         services.AddSingleton<IDialogService, AvaloniaDialogService>();
         services.AddSingleton<IDispatcherService, AvaloniaDispatcherService>();
@@ -63,6 +78,7 @@ public partial class App : Application
         services.AddSingleton<MainViewModel>();
         services.AddTransient<DecompileViewModel>();
         services.AddTransient<BuildViewModel>();
+        services.AddTransient<PatchViewModel>();
         services.AddTransient<SettingsViewModel>();
         services.AddTransient<AnalyserViewModel>();
         services.AddTransient<AboutViewModel>();

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -18,6 +18,9 @@
         <DataTemplate DataType="{x:Type vm:BuildViewModel}">
             <views:BuildView/>
         </DataTemplate>
+        <DataTemplate DataType="{x:Type vm:PatchViewModel}">
+            <views:PatchView/>
+        </DataTemplate>
         <DataTemplate DataType="{x:Type vm:SettingsViewModel}">
             <views:SettingsView/>
         </DataTemplate>
@@ -45,6 +48,9 @@
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToBuildCommand}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"
+                        HorizontalAlignment="Stretch"/>
+                <Button Command="{Binding NavigateToPatchCommand}"
+                        Content="{Binding MenuPatchLabel}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToAnalyserCommand}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -1,0 +1,98 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
+             x:Class="PulseAPK.Avalonia.Views.PatchView"
+             x:DataType="vm:PatchViewModel">
+    <Grid RowDefinitions="Auto,Auto,Auto,*"
+          RowSpacing="16"
+          Margin="20">
+        <TextBlock Text="Patch APK"
+                   FontSize="24"
+                   FontWeight="SemiBold" />
+
+        <Border Grid.Row="1"
+                Background="{DynamicResource CardBackgroundBrush}"
+                BorderBrush="{DynamicResource CardBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="6">
+                    <TextBlock Text="Select APK"
+                               FontWeight="SemiBold" />
+                    <TextBox Text="{Binding ApkPath}"
+                             Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApkPathPlaceholder]}"
+                             IsReadOnly="True"
+                             IsTabStop="False"
+                             IsHitTestVisible="False" />
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseApkTip]}"
+                               FontSize="12"
+                               Opacity="0.7"
+                               IsVisible="{Binding IsHintVisible}" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseApkCommand}"
+                            MinWidth="120"
+                            Height="38"
+                            FontSize="14"
+                            VerticalContentAlignment="Center"
+                            Padding="16,0" />
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
+                            Command="{Binding RunPatchCommand}"
+                            MinWidth="120"
+                            Height="38"
+                            FontSize="14"
+                            VerticalContentAlignment="Center"
+                            Padding="16,0" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
+            <StackPanel Spacing="8">
+                <CheckBox Content="Sign output APK (ubersigner)"
+                          IsChecked="{Binding SignApk}" />
+                <CheckBox Content="Decode resources"
+                          IsChecked="{Binding DecodeResources}" />
+                <CheckBox Content="Decode sources"
+                          IsChecked="{Binding DecodeSources}" />
+                <CheckBox Content="Use AAPT2 for build"
+                          IsChecked="{Binding UseAapt2ForBuild}" />
+            </StackPanel>
+            <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="Output"
+                           FontWeight="SemiBold" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                    <TextBox Text="{Binding OutputFolderPath}" />
+                    <Button Grid.Column="1"
+                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                            Command="{Binding BrowseOutputFolderCommand}"
+                            Width="100" />
+                </Grid>
+                <TextBox Text="{Binding OutputApkName}" Watermark="patched.apk" />
+                <TextBox Text="{Binding OutputApkPath}" IsReadOnly="True" />
+            </StackPanel>
+        </Grid>
+
+        <Border Grid.Row="3"
+                Background="{DynamicResource MainBackgroundBrush}"
+                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="12">
+            <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                           FontWeight="SemiBold" />
+                <TextBox Grid.Row="1"
+                         Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         VerticalAlignment="Stretch" />
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml.cs
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PulseAPK.Avalonia.Views;
+
+public partial class PatchView : UserControl
+{
+    public PatchView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -23,6 +23,7 @@ public partial class MainViewModel : ObservableObject
 
     public string MenuDecompileLabel => _localizationService["MenuDecompile"];
     public string MenuBuildLabel => _localizationService["MenuBuild"];
+    public string MenuPatchLabel => "Patch APK";
     public string MenuAnalyserLabel => _localizationService["MenuAnalyser"];
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
@@ -56,6 +57,13 @@ public partial class MainViewModel : ObservableObject
     {
         SetCurrentView(Resolve<BuildViewModel>());
         SelectedMenu = "Build";
+    }
+
+    [RelayCommand]
+    private void NavigateToPatch()
+    {
+        SetCurrentView(Resolve<PatchViewModel>());
+        SelectedMenu = "Patch";
     }
 
     [RelayCommand]

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -1,0 +1,280 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PulseAPK.Core.Abstractions;
+using PulseAPK.Core.Abstractions.Patching;
+using PulseAPK.Core.Models;
+using PulseAPK.Core.Services;
+using PulseAPK.Core.Utils;
+using System.Text;
+using Properties = PulseAPK.Core.Properties;
+
+namespace PulseAPK.Core.ViewModels;
+
+public partial class PatchViewModel : ObservableObject
+{
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsHintVisible))]
+    private string _apkPath = string.Empty;
+
+    [ObservableProperty]
+    private string _outputFolderPath = string.Empty;
+
+    [ObservableProperty]
+    private string _outputApkName = string.Empty;
+
+    [ObservableProperty]
+    private string _outputApkPath = string.Empty;
+
+    [ObservableProperty]
+    private bool _signApk = true;
+
+    [ObservableProperty]
+    private bool _decodeResources = true;
+
+    [ObservableProperty]
+    private bool _decodeSources = true;
+
+    [ObservableProperty]
+    private bool _useAapt2ForBuild;
+
+    [ObservableProperty]
+    private string _consoleLog;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RunPatchCommand))]
+    private bool _isRunning;
+
+    private readonly IFilePickerService _filePickerService;
+    private readonly ISettingsService _settingsService;
+    private readonly IPatchPipelineService _patchPipelineService;
+    private readonly IDialogService _dialogService;
+
+    public bool IsHintVisible => string.IsNullOrWhiteSpace(ApkPath);
+
+    public PatchViewModel(
+        IFilePickerService filePickerService,
+        ISettingsService settingsService,
+        IPatchPipelineService patchPipelineService,
+        IDialogService dialogService)
+    {
+        _filePickerService = filePickerService;
+        _settingsService = settingsService;
+        _patchPipelineService = patchPipelineService;
+        _dialogService = dialogService;
+
+        _consoleLog = Properties.Resources.WaitingForCommand;
+
+        OutputFolderPath = EnsureCompiledDirectory();
+        OutputApkName = "patched.apk";
+        UpdateOutputApkPath();
+        UpdateCommandPreview();
+    }
+
+    partial void OnApkPathChanged(string value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            var fileName = Path.GetFileNameWithoutExtension(value);
+            OutputApkName = $"{fileName}_patched.apk";
+        }
+
+        UpdateOutputApkPath();
+        RunPatchCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnOutputFolderPathChanged(string value)
+    {
+        UpdateOutputApkPath();
+    }
+
+    partial void OnOutputApkNameChanged(string value)
+    {
+        UpdateOutputApkPath();
+        RunPatchCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
+    partial void OnSignApkChanged(bool value) => UpdateCommandPreview();
+    partial void OnDecodeResourcesChanged(bool value) => UpdateCommandPreview();
+    partial void OnDecodeSourcesChanged(bool value) => UpdateCommandPreview();
+    partial void OnUseAapt2ForBuildChanged(bool value) => UpdateCommandPreview();
+
+    [RelayCommand]
+    private async Task BrowseApk()
+    {
+        var file = await _filePickerService.OpenFileAsync("APK Files (*.apk)|*.apk|All Files (*.*)|*.*");
+        if (file is null)
+        {
+            return;
+        }
+
+        var (isValid, message) = FileSanitizer.ValidateApk(file);
+        if (!isValid)
+        {
+            await _dialogService.ShowErrorAsync(message, "Invalid APK File");
+            return;
+        }
+
+        ApkPath = file;
+    }
+
+    [RelayCommand]
+    private async Task BrowseOutputFolder()
+    {
+        var folder = await _filePickerService.OpenFolderAsync(OutputFolderPath);
+        if (!string.IsNullOrWhiteSpace(folder))
+        {
+            OutputFolderPath = folder;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunPatch))]
+    private async Task RunPatch()
+    {
+        if (string.IsNullOrWhiteSpace(ApkPath))
+        {
+            await _dialogService.ShowWarningAsync("Please select an APK file to patch.", "Missing APK");
+            return;
+        }
+
+        var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
+        if (string.IsNullOrWhiteSpace(apktoolPath) || !File.Exists(apktoolPath))
+        {
+            await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
+            return;
+        }
+
+        IsRunning = true;
+        SetConsoleLog("Starting patch pipeline...");
+
+        try
+        {
+            var request = new PatchRequest
+            {
+                InputApkPath = ApkPath,
+                OutputApkPath = OutputApkPath,
+                SignOutput = SignApk,
+                DecodeResources = DecodeResources,
+                DecodeSources = DecodeSources,
+                UseAapt2ForBuild = UseAapt2ForBuild,
+                WorkingDirectory = Path.Combine(Path.GetTempPath(), "pulseapk-patch-ui"),
+                KeepIntermediateFiles = false
+            };
+
+            AppendLog(BuildRunSummary(request));
+
+            var result = await _patchPipelineService.RunAsync(request);
+
+            foreach (var stage in result.StageSummaries)
+            {
+                var icon = stage.Success ? "[OK]" : "[FAIL]";
+                AppendLog($"{icon} {stage.Stage}: {stage.Message}");
+            }
+
+            foreach (var warning in result.Warnings)
+            {
+                AppendLog($"[WARN] {warning}");
+            }
+
+            if (result.Success)
+            {
+                AppendLog($"Patched APK created: {result.OutputApkPath}");
+                await _dialogService.ShowInfoAsync($"Patch completed successfully.\nOutput: {result.OutputApkPath}", "Patch complete");
+            }
+            else
+            {
+                foreach (var error in result.Errors)
+                {
+                    AppendLog($"[ERROR] {error}");
+                }
+
+                await _dialogService.ShowErrorAsync("Patch failed. See console output for details.", "Patch failed");
+            }
+        }
+        catch (Exception ex)
+        {
+            AppendLog($"[ERROR] {ex.Message}");
+            await _dialogService.ShowErrorAsync(ex.Message, "Patch failed");
+        }
+        finally
+        {
+            IsRunning = false;
+            RunPatchCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private bool CanRunPatch()
+    {
+        return !IsRunning
+            && !string.IsNullOrWhiteSpace(ApkPath)
+            && !string.IsNullOrWhiteSpace(OutputApkPath);
+    }
+
+    private void UpdateOutputApkPath()
+    {
+        var folder = string.IsNullOrWhiteSpace(OutputFolderPath) ? EnsureCompiledDirectory() : OutputFolderPath;
+        OutputFolderPath = folder;
+
+        if (string.IsNullOrWhiteSpace(OutputApkName))
+        {
+            OutputApkPath = folder;
+            return;
+        }
+
+        OutputApkPath = Path.Combine(folder, OutputApkName);
+    }
+
+    private string EnsureCompiledDirectory()
+    {
+        var preferred = PathUtils.GetDefaultCompiledPath();
+        try
+        {
+            Directory.CreateDirectory(preferred);
+            return preferred;
+        }
+        catch
+        {
+            return Directory.GetCurrentDirectory();
+        }
+    }
+
+    private void AppendLog(string message)
+    {
+        if (string.IsNullOrWhiteSpace(ConsoleLog) || ConsoleLog == "Waiting for command...")
+        {
+            ConsoleLog = message;
+        }
+        else
+        {
+            ConsoleLog += $"{Environment.NewLine}{message}";
+        }
+    }
+
+    private void SetConsoleLog(string message)
+    {
+        ConsoleLog = message;
+    }
+
+    private void UpdateCommandPreview()
+    {
+        if (IsRunning)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Patch preview:");
+        builder.AppendLine($"Input APK: {(string.IsNullOrWhiteSpace(ApkPath) ? "<select apk>" : ApkPath)}");
+        builder.AppendLine($"Output APK: {(string.IsNullOrWhiteSpace(OutputApkPath) ? "<output apk>" : OutputApkPath)}");
+        builder.AppendLine($"Decode resources: {DecodeResources}");
+        builder.AppendLine($"Decode sources: {DecodeSources}");
+        builder.AppendLine($"Use AAPT2: {UseAapt2ForBuild}");
+        builder.Append($"Sign output: {SignApk}");
+        ConsoleLog = builder.ToString();
+    }
+
+    private static string BuildRunSummary(PatchRequest request)
+    {
+        return $"Patching '{request.InputApkPath}' -> '{request.OutputApkPath}' (sign={request.SignOutput}, decodeRes={request.DecodeResources}, decodeSrc={request.DecodeSources}, aapt2={request.UseAapt2ForBuild})";
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose the newly implemented pulse-gadget patching pipeline in the GUI so users can pick an APK, run the patch workflow (artifact resolution, gadget injection, smali/manifest patches, rebuild) and optionally sign the rebuilt APK with ubersigner, using a UI flow consistent with existing tabs.
- Keep the new view decoupled from other tabs while reusing existing services and patterns (file picker, console output, DI) so the same core pipeline logic is executed from the app UI.

### Description
- Added a new `PatchViewModel` that builds a `PatchRequest` and runs the existing `IPatchPipelineService`, collects `StageSummaries`/warnings/errors and reports progress to a console log; it supports picks for APK, output folder/name and toggles for signing, decode options and `aapt2` usage (`src/PulseAPK.Core/ViewModels/PatchViewModel.cs`).
- Added an Avalonia view `PatchView` and code-behind to match existing UI conventions (APK selector + Browse/Run buttons, options panel, output controls and console) (`src/PulseAPK.Avalonia/Views/PatchView.axaml` and `.axaml.cs`).
- Wired navigation and view resolution: added `NavigateToPatch` in `MainViewModel`, registered the `PatchViewModel` in DI and added a `DataTemplate` and sidebar button in `MainWindow.axaml` so the tab appears alongside Decompile/Build (`src/PulseAPK.Core/ViewModels/MainViewModel.cs`, `src/PulseAPK.Avalonia/MainWindow.axaml`).
- Registered patching-related services and the patch pipeline in `App.axaml.cs` so the UI can resolve and execute the full pipeline (`src/PulseAPK.Avalonia/App.axaml.cs`).
- Kept UI/localization consistent with other views; `MenuPatchLabel` is currently provided as a hard-coded label in `MainViewModel` (can be localized later).

### Testing
- Attempted to build the solution with `dotnet build PulseAPK.sln` to validate compilation, but the environment lacks the .NET SDK so the build could not be executed (`bash: command not found: dotnet`).
- No automated unit tests were run in this environment; the patch uses existing services and unit-tested pipeline components, and the UI wiring was validated by local compilation attempts (blocked by missing SDK) and manual code inspection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b738344ee883228e9323719afaa426)