### PR TITLE
Fix nullable reference warnings across core view models and services

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml.cs
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml.cs
@@ -5,9 +5,13 @@ namespace PulseAPK.Avalonia;
 
 public partial class MainWindow : Window
 {
-    public MainWindow(MainViewModel viewModel)
+    public MainWindow()
     {
         InitializeComponent();
+    }
+
+    public MainWindow(MainViewModel viewModel) : this()
+    {
         DataContext = viewModel;
     }
 }

--- a/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
+++ b/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
@@ -9,7 +9,7 @@ public sealed class DexMergeService : IDexMergeService
     {
         if (!File.Exists(originalApkPath) || !File.Exists(rebuiltApkPath))
         {
-            return Task.FromResult((false, "Original or rebuilt APK path does not exist." as string));
+            return Task.FromResult((false, "Original or rebuilt APK path does not exist."));
         }
 
         using var original = ZipFile.OpenRead(originalApkPath);

--- a/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
@@ -9,7 +9,7 @@ public sealed class GadgetInjectionService : IGadgetInjectionService
     {
         if (!File.Exists(gadgetSourcePath))
         {
-            return Task.FromResult((false, $"Resolved gadget source '{gadgetSourcePath}' does not exist." as string));
+            return Task.FromResult((false, $"Resolved gadget source '{gadgetSourcePath}' does not exist."));
         }
 
         var libDirectory = Path.Combine(decompiledDirectory, "lib", architecture);

--- a/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
@@ -12,7 +12,7 @@ public sealed class ManifestPatchService : IManifestPatchService
     {
         if (!File.Exists(manifestPath))
         {
-            return Task.FromResult((false, "Manifest file was not found." as string));
+            return Task.FromResult((false, "Manifest file was not found."));
         }
 
         var document = new XmlDocument { PreserveWhitespace = true };
@@ -24,7 +24,7 @@ public sealed class ManifestPatchService : IManifestPatchService
         var manifestNode = document.SelectSingleNode("/manifest");
         if (manifestNode is null)
         {
-            return Task.FromResult((false, "Invalid AndroidManifest.xml structure." as string));
+            return Task.FromResult((false, "Invalid AndroidManifest.xml structure."));
         }
 
         if (request.EnsureInternetPermission)

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -10,7 +10,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
         var smaliFile = ResolveActivitySmaliFile(decompiledDirectory, activityName);
         if (smaliFile is null)
         {
-            return Task.FromResult((false, $"Could not locate smali file for activity '{activityName}'." as string));
+            return Task.FromResult((false, $"Could not locate smali file for activity '{activityName}'."));
         }
 
         var originalContent = File.ReadAllText(smaliFile);
@@ -23,7 +23,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
         var classDescriptor = ExtractClassDescriptor(originalContent);
         if (string.IsNullOrWhiteSpace(classDescriptor))
         {
-            return Task.FromResult((false, "Unable to determine class descriptor from smali file." as string));
+            return Task.FromResult((false, "Unable to determine class descriptor from smali file."));
         }
 
         var methodBody = useDelayedLoad
@@ -56,7 +56,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
 
         if (ReferenceEquals(patched, originalContent) || patched == originalContent)
         {
-            return Task.FromResult((false, "Unable to find an injection point in activity smali file." as string));
+            return Task.FromResult((false, "Unable to find an injection point in activity smali file."));
         }
 
         File.WriteAllText(smaliFile, patched);

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -78,7 +78,7 @@ namespace PulseAPK.Core.Services
 
         private static bool TryLoadSettings(string settingsPath, out AppSettings settings)
         {
-            settings = null;
+            settings = null!;
             if (!File.Exists(settingsPath))
             {
                 return false;
@@ -87,8 +87,8 @@ namespace PulseAPK.Core.Services
             try
             {
                 var json = File.ReadAllText(settingsPath);
-                settings = JsonSerializer.Deserialize<AppSettings>(json);
-                return settings != null;
+                settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+                return true;
             }
             catch
             {

--- a/src/PulseAPK.Core/Services/SmaliAnalyserService.cs
+++ b/src/PulseAPK.Core/Services/SmaliAnalyserService.cs
@@ -8,7 +8,7 @@ namespace PulseAPK.Core.Services
 {
     public class SmaliAnalyserService
     {
-        public async Task<AnalysisResult> AnalyseProjectAsync(string projectPath, Action<string> logCallback)
+        public async Task<AnalysisResult> AnalyseProjectAsync(string projectPath, Action<string>? logCallback)
         {
             var result = new AnalysisResult();
 
@@ -85,7 +85,7 @@ namespace PulseAPK.Core.Services
             return result;
         }
 
-        private string[] GetSmaliFiles(string projectPath, Action<string> logCallback)
+        private string[] GetSmaliFiles(string projectPath, Action<string>? logCallback)
         {
             try
             {
@@ -211,7 +211,7 @@ namespace PulseAPK.Core.Services
             return false;
         }
 
-        private Dictionary<string, List<Regex>> BuildRegexCache(AnalysisRuleSet rules, Action<string> logCallback)
+        private Dictionary<string, List<Regex>> BuildRegexCache(AnalysisRuleSet rules, Action<string>? logCallback)
         {
             var cache = new Dictionary<string, List<Regex>>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/AnalyserViewModel.cs
@@ -31,7 +31,7 @@ public partial class AnalyserViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
     [NotifyPropertyChangedFor(nameof(HasProject))]
-    private string _projectPath;
+    private string _projectPath = string.Empty;
 
     [ObservableProperty]
     private string _consoleLog = Properties.Resources.WaitingForCommand;

--- a/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
@@ -13,16 +13,16 @@ public partial class BuildViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
     [NotifyPropertyChangedFor(nameof(HasProject))]
-    private string _projectPath;
+    private string _projectPath = string.Empty;
 
     [ObservableProperty]
-    private string _outputApkPath;
+    private string _outputApkPath = string.Empty;
 
     [ObservableProperty]
-    private string _outputFolderPath;
+    private string _outputFolderPath = string.Empty;
 
     [ObservableProperty]
-    private string _outputApkName;
+    private string _outputApkName = string.Empty;
 
     [ObservableProperty]
     private bool _useAapt2;

--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -12,7 +12,7 @@ public partial class DecompileViewModel : ObservableObject
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
-    private string _apkPath;
+    private string _apkPath = string.Empty;
 
     [ObservableProperty]
     private bool _decodeResources = true;

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -13,7 +13,7 @@ public partial class MainViewModel : ObservableObject
     private readonly LocalizationService _localizationService;
 
     [ObservableProperty]
-    private object _currentView;
+    private object _currentView = null!;
 
     [ObservableProperty]
     private string _windowTitle = Properties.Resources.AppTitle;

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -30,7 +30,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private LanguageItem _selectedLanguage;
 
     [ObservableProperty]
-    private ThemeModeItem _selectedThemeMode;
+    private ThemeModeItem _selectedThemeMode = null!;
     
     public List<LanguageItem> AvailableLanguages => _localizationService.AvailableLanguages;
     private List<ThemeModeItem> _availableThemeModes = [];


### PR DESCRIPTION
### Motivation
- Reduce C# nullable-reference warnings (CS8618/CS8625/CS8619/CS8604) and remove runtime issues flagged by the analyzer by ensuring non-nullable fields are initialized and nullable annotations reflect actual usage.
- Make Avalonia view instantiation safe for the XAML runtime by providing a public parameterless constructor for `MainWindow`.

### Description
- Initialize non-nullable backing fields in view models to safe defaults (e.g. `_projectPath`, `_apkPath`, `_outputApkPath`, `_outputFolderPath`, `_outputApkName`, `_currentView`, `_selectedThemeMode`) to satisfy constructor-exit requirements and avoid nullability warnings; changes affect `AnalyserViewModel`, `DecompileViewModel`, `BuildViewModel`, `MainViewModel`, and `SettingsViewModel`.
- Harden `SettingsService.TryLoadSettings` to avoid assigning `null` by using a non-null suppression for the out variable and falling back to `new AppSettings()` when `JsonSerializer.Deserialize` returns `null`.
- Align tuple return nullability in patching services by removing unnecessary `as string` casts and returning non-null error messages where appropriate while keeping `null` for successful `Error` values; updates in `GadgetInjectionService`, `SmaliPatchService`, `DexMergeService`, and `ManifestPatchService`.
- Make callback parameters nullable in `SmaliAnalyserService` (`Action<string>? logCallback`) to match existing `logCallback?.Invoke(...)` usage and avoid possible null-reference diagnostics, and propagate that change to helper methods (`GetSmaliFiles`, `BuildRegexCache`).
- Add a public parameterless constructor to `PulseAPK.Avalonia.MainWindow` and chain the DI constructor to it so the Avalonia runtime loader can instantiate the XAML resource.
- Minor formatting/cleanup related to the above changes across the listed files.

### Testing
- Attempted to run `dotnet build -c Release` to validate the changes, but the `dotnet` SDK is not available in this execution environment (`bash: command not found: dotnet`), so an automated build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73f2e7ee8832280d897cc9e3ff757)