### PR TITLE
Fix CS8619 nullability warnings in patching services

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
+++ b/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
@@ -9,7 +9,7 @@ public sealed class DexMergeService : IDexMergeService
     {
         if (!File.Exists(originalApkPath) || !File.Exists(rebuiltApkPath))
         {
-            return Task.FromResult((false, "Original or rebuilt APK path does not exist."));
+            return Task.FromResult<(bool Success, string? Error)>((false, "Original or rebuilt APK path does not exist."));
         }
 
         using var original = ZipFile.OpenRead(originalApkPath);
@@ -34,6 +34,6 @@ public sealed class DexMergeService : IDexMergeService
             input.CopyTo(output);
         }
 
-        return Task.FromResult((true, (string?)null));
+        return Task.FromResult<(bool Success, string? Error)>((true, null));
     }
 }

--- a/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/GadgetInjectionService.cs
@@ -9,7 +9,7 @@ public sealed class GadgetInjectionService : IGadgetInjectionService
     {
         if (!File.Exists(gadgetSourcePath))
         {
-            return Task.FromResult((false, $"Resolved gadget source '{gadgetSourcePath}' does not exist."));
+            return Task.FromResult<(bool Success, string? Error)>((false, $"Resolved gadget source '{gadgetSourcePath}' does not exist."));
         }
 
         var libDirectory = Path.Combine(decompiledDirectory, "lib", architecture);
@@ -19,7 +19,7 @@ public sealed class GadgetInjectionService : IGadgetInjectionService
         EnsureOptionalAsset(request.ConfigFilePath, decompiledDirectory, "frida-gadget.config");
         EnsureOptionalAsset(request.ScriptFilePath, decompiledDirectory, "frida-script.js");
 
-        return Task.FromResult((true, (string?)null));
+        return Task.FromResult<(bool Success, string? Error)>((true, null));
     }
 
     private static void EnsureOptionalAsset(string? sourceFile, string decompiledDirectory, string outputName)

--- a/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ManifestPatchService.cs
@@ -12,7 +12,7 @@ public sealed class ManifestPatchService : IManifestPatchService
     {
         if (!File.Exists(manifestPath))
         {
-            return Task.FromResult((false, "Manifest file was not found."));
+            return Task.FromResult<(bool Success, string? Error)>((false, "Manifest file was not found."));
         }
 
         var document = new XmlDocument { PreserveWhitespace = true };
@@ -24,7 +24,7 @@ public sealed class ManifestPatchService : IManifestPatchService
         var manifestNode = document.SelectSingleNode("/manifest");
         if (manifestNode is null)
         {
-            return Task.FromResult((false, "Invalid AndroidManifest.xml structure."));
+            return Task.FromResult<(bool Success, string? Error)>((false, "Invalid AndroidManifest.xml structure."));
         }
 
         if (request.EnsureInternetPermission)
@@ -38,7 +38,7 @@ public sealed class ManifestPatchService : IManifestPatchService
         }
 
         document.Save(manifestPath);
-        return Task.FromResult((true, (string?)null));
+        return Task.FromResult<(bool Success, string? Error)>((true, null));
     }
 
     private static void EnsureInternetPermission(XmlDocument document, XmlNode manifestNode, XmlNamespaceManager manager)

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -10,20 +10,20 @@ public sealed class SmaliPatchService : ISmaliPatchService
         var smaliFile = ResolveActivitySmaliFile(decompiledDirectory, activityName);
         if (smaliFile is null)
         {
-            return Task.FromResult((false, $"Could not locate smali file for activity '{activityName}'."));
+            return Task.FromResult<(bool Success, string? Error)>((false, $"Could not locate smali file for activity '{activityName}'."));
         }
 
         var originalContent = File.ReadAllText(smaliFile);
         if (originalContent.Contains("frida-gadget", StringComparison.Ordinal) ||
             originalContent.Contains("loadFridaGadget", StringComparison.Ordinal))
         {
-            return Task.FromResult((true, (string?)null));
+            return Task.FromResult<(bool Success, string? Error)>((true, null));
         }
 
         var classDescriptor = ExtractClassDescriptor(originalContent);
         if (string.IsNullOrWhiteSpace(classDescriptor))
         {
-            return Task.FromResult((false, "Unable to determine class descriptor from smali file."));
+            return Task.FromResult<(bool Success, string? Error)>((false, "Unable to determine class descriptor from smali file."));
         }
 
         var methodBody = useDelayedLoad
@@ -56,11 +56,11 @@ public sealed class SmaliPatchService : ISmaliPatchService
 
         if (ReferenceEquals(patched, originalContent) || patched == originalContent)
         {
-            return Task.FromResult((false, "Unable to find an injection point in activity smali file."));
+            return Task.FromResult<(bool Success, string? Error)>((false, "Unable to find an injection point in activity smali file."));
         }
 
         File.WriteAllText(smaliFile, patched);
-        return Task.FromResult((true, (string?)null));
+        return Task.FromResult<(bool Success, string? Error)>((true, null));
     }
 
     private static string? ResolveActivitySmaliFile(string decompiledDirectory, string activityName)


### PR DESCRIPTION
### Motivation
- Silence CS8619 nullability mismatch warnings where methods declare `Task<(bool Success, string? Error)>` but returned `Task<(bool, string)>` values with non-matching reference nullability.
- Ensure returned tuple nullability aligns with the service interface contracts to avoid compiler warnings and clarify intent for success/error returns.

### Description
- Updated `Task.FromResult` calls to the explicit generic form `Task.FromResult<(bool Success, string? Error)>(...)` across patching services to make tuple nullability explicit.
- Replaced success return tuples like `(true, (string?)null)` with `(true, null)` when using the explicit generic `Task.FromResult` to simplify the code.
- Changes applied in `GadgetInjectionService`, `ManifestPatchService`, `SmaliPatchService`, and `DexMergeService` in `src/PulseAPK.Core/Services/Patching`.
- Committed the changes with message `Fix nullability tuple warnings in patching services`.

### Testing
- Attempted to run `dotnet build src/PulseAPK.Core/PulseAPK.Core.csproj -v minimal`, but the build could not be executed in this environment because the `dotnet` CLI is not installed (`command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74054d1088322b0bccb575642c684)