### PR TITLE
Handle launcher activity-alias target resolution in activity detection

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -15,12 +15,21 @@ public sealed class ActivityDetectionService : IActivityDetectionService
 
         var document = XDocument.Load(manifestPath);
         var androidNs = XNamespace.Get("http://schemas.android.com/apk/res/android");
+        var packageName = (string?)document.Root?.Attribute("package");
 
         var activities = document.Descendants()
-            .Where(element => element.Name.LocalName is "activity" or "activity-alias")
+            .Where(element => element.Name.LocalName == "activity")
             .ToList();
 
-        var withLauncher = activities.FirstOrDefault(activity =>
+        var aliases = document.Descendants()
+            .Where(element => element.Name.LocalName == "activity-alias")
+            .ToList();
+
+        var launchableComponents = activities
+            .Concat(aliases)
+            .ToList();
+
+        var withLauncher = launchableComponents.FirstOrDefault(activity =>
             activity.Descendants().Any(node =>
                 node.Name.LocalName == "action" &&
                 string.Equals((string?)node.Attribute(androidNs + "name"), "android.intent.action.MAIN", StringComparison.Ordinal))
@@ -30,6 +39,34 @@ public sealed class ActivityDetectionService : IActivityDetectionService
 
         if (withLauncher is not null)
         {
+            if (withLauncher.Name.LocalName == "activity-alias")
+            {
+                var targetActivity = (string?)withLauncher.Attribute(androidNs + "targetActivity");
+                var resolvedTarget = ResolveActivityName(targetActivity, packageName);
+
+                if (!string.IsNullOrWhiteSpace(resolvedTarget))
+                {
+                    var targetExists = activities.Any(activity =>
+                        string.Equals(
+                            ResolveActivityName((string?)activity.Attribute(androidNs + "name"), packageName),
+                            resolvedTarget,
+                            StringComparison.Ordinal));
+
+                    if (targetExists)
+                    {
+                        return Task.FromResult<(string?, string?, string?)>((resolvedTarget, null, null));
+                    }
+                }
+
+                var fallbackActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
+                if (!string.IsNullOrWhiteSpace(fallbackActivityName))
+                {
+                    return Task.FromResult<(string?, string?, string?)>((fallbackActivityName, "Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", null));
+                }
+
+                return Task.FromResult<(string?, string?, string?)>((null, null, "Launcher activity alias has missing or invalid targetActivity, and no concrete activity entries were found in AndroidManifest.xml."));
+            }
+
             return Task.FromResult<(string?, string?, string?)>(((string?)withLauncher.Attribute(androidNs + "name"), null, null));
         }
 
@@ -40,5 +77,25 @@ public sealed class ActivityDetectionService : IActivityDetectionService
         }
 
         return Task.FromResult<(string?, string?, string?)>((null, null, "No activity entries found in AndroidManifest.xml."));
+    }
+
+    private static string? ResolveActivityName(string? activityName, string? packageName)
+    {
+        if (string.IsNullOrWhiteSpace(activityName))
+        {
+            return null;
+        }
+
+        if (activityName.StartsWith('.', StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(packageName) ? null : packageName + activityName;
+        }
+
+        if (activityName.Contains('.', StringComparison.Ordinal))
+        {
+            return activityName;
+        }
+
+        return string.IsNullOrWhiteSpace(packageName) ? null : $"{packageName}.{activityName}";
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
@@ -5,7 +5,54 @@ namespace PulseAPK.Tests.Services.Patching;
 public class ActivityDetectionServiceTests
 {
     [Fact]
-    public async Task DetectMainActivityAsync_PrefersMainLauncherActivity()
+    public async Task DetectMainActivityAsync_LauncherAliasWithValidTargetActivity_ReturnsTargetActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='com.example.MainActivity' />
+    <activity-alias android:name='com.example.EntryAlias' android:targetActivity='com.example.MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity-alias>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task DetectMainActivityAsync_LauncherAliasWithoutTargetActivity_FallsBackToFirstConcreteActivityWithWarning()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='com.example.FallbackActivity' />
+    <activity android:name='com.example.SecondActivity' />
+    <activity-alias android:name='com.example.EntryAlias'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity-alias>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.FallbackActivity", result.ActivityName);
+        Assert.Equal("Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", result.Warning);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task DetectMainActivityAsync_PrefersMainLauncherActivity_WhenLauncherIsConcreteActivity()
     {
         var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
   <application>
@@ -23,6 +70,7 @@ public class ActivityDetectionServiceTests
         var result = await service.DetectMainActivityAsync(root);
 
         Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
         Assert.Null(result.Error);
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the activity selected for patching accounts for launcher aliases (`<activity-alias>`) that reference a concrete activity via `android:targetActivity`.
- When an alias is selected the code should resolve the actual target activity name (including relative names) and use that for smali/manifest patching.
- If the alias `targetActivity` is missing or invalid, fall back to a concrete `<activity>` with a warning so patching can proceed.

### Description
- Updated `DetectMainActivityAsync` in `src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs` to separate concrete `<activity>` nodes from `<activity-alias>` nodes and search MAIN/LAUNCHER across both sets.
- Added alias handling that reads `android:targetActivity`, resolves relative/package-scoped names via a new helper `ResolveActivityName`, validates the resolved target exists among concrete activities, and returns the resolved activity name for patching.
- Implemented fallback behavior for missing/invalid `targetActivity` that returns a warning and falls back to the first concrete `<activity>`, and an error if no concrete activities exist.
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs` covering a launcher alias with a valid `targetActivity`, an alias without `targetActivity` (warning + fallback), and the existing concrete launcher activity case.

### Testing
- Added unit tests in `ActivityDetectionServiceTests` to exercise alias resolution, alias fallback, and the concrete launcher activity path.
- Attempted to run the new test filter with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter ActivityDetectionServiceTests`, but the test run could not be executed because `dotnet` is not installed in this environment (test execution failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8044f876483228e1b0081e018845c)