### PR TITLE
Differentiate delayed and immediate smali injection paths

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -26,33 +26,14 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return Task.FromResult<(bool Success, string? Error)>((false, "Unable to determine class descriptor from smali file."));
         }
 
-        var methodBody = useDelayedLoad
-            ? new[]
-            {
-                ".method private static loadFridaGadget()V",
-                "    .locals 1",
-                "",
-                "    const-string v0, \"frida-gadget\"",
-                "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
-                "    return-void",
-                ".end method",
-                string.Empty
-            }
-            : new[]
-            {
-                ".method private static loadFridaGadget()V",
-                "    .locals 1",
-                "",
-                "    const-string v0, \"frida-gadget\"",
-                "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
-                "    return-void",
-                ".end method",
-                string.Empty
-            };
+        var helperMethods = useDelayedLoad ? BuildDelayedLoadHelperMethods() : BuildImmediateLoadHelperMethods();
+        var lifecycleMethodName = useDelayedLoad ? "onResume" : "onCreate";
+        var lifecycleSignature = useDelayedLoad ? "()V" : "(Landroid/os/Bundle;)V";
+        var superClassDescriptor = useDelayedLoad ? "Landroid/app/Activity;" : "Landroid/app/Activity;";
 
         var patched = originalContent;
-        patched = InsertHelperMethod(patched, methodBody);
-        patched = InjectCallIntoOnCreate(patched, classDescriptor);
+        patched = InsertHelperMethods(patched, helperMethods);
+        patched = InjectCallIntoLifecycleMethod(patched, classDescriptor, lifecycleMethodName, lifecycleSignature, superClassDescriptor);
 
         if (ReferenceEquals(patched, originalContent) || patched == originalContent)
         {
@@ -61,6 +42,45 @@ public sealed class SmaliPatchService : ISmaliPatchService
 
         File.WriteAllText(smaliFile, patched);
         return Task.FromResult<(bool Success, string? Error)>((true, null));
+    }
+
+    private static IReadOnlyList<string> BuildImmediateLoadHelperMethods()
+    {
+        return
+        [
+            ".method private static loadFridaGadget()V",
+            "    .locals 1",
+            string.Empty,
+            "    const-string v0, \"frida-gadget\"",
+            "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
+            "    return-void",
+            ".end method",
+            string.Empty
+        ];
+    }
+
+    private static IReadOnlyList<string> BuildDelayedLoadHelperMethods()
+    {
+        return
+        [
+            ".field private static sFridaLoaded:Z",
+            string.Empty,
+            ".method private static loadFridaGadgetIfNeeded()V",
+            "    .locals 1",
+            string.Empty,
+            "    sget-boolean v0, Lcom/example/PLACEHOLDER;->sFridaLoaded:Z",
+            "    if-nez v0, :loaded",
+            string.Empty,
+            "    const-string v0, \"frida-gadget\"",
+            "    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V",
+            "    const/4 v0, 0x1",
+            "    sput-boolean v0, Lcom/example/PLACEHOLDER;->sFridaLoaded:Z",
+            string.Empty,
+            "    :loaded",
+            "    return-void",
+            ".end method",
+            string.Empty
+        ];
     }
 
     private static string? ResolveActivitySmaliFile(string decompiledDirectory, string activityName)
@@ -91,7 +111,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    private static string InsertHelperMethod(string content, IReadOnlyList<string> lines)
+    private static string InsertHelperMethods(string content, IReadOnlyList<string> lines)
     {
         var endIndex = content.LastIndexOf(".end class", StringComparison.Ordinal);
         if (endIndex < 0)
@@ -99,25 +119,28 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return content;
         }
 
-        var method = string.Join(Environment.NewLine, lines) + Environment.NewLine;
+        var classDescriptor = ExtractClassDescriptor(content);
+        var normalizedLines = lines.Select(line => line.Replace("Lcom/example/PLACEHOLDER;", classDescriptor, StringComparison.Ordinal)).ToArray();
+        var method = string.Join(Environment.NewLine, normalizedLines) + Environment.NewLine;
         return content.Insert(endIndex, method);
     }
 
-    private static string InjectCallIntoOnCreate(string content, string classDescriptor)
+    private static string InjectCallIntoLifecycleMethod(string content, string classDescriptor, string methodName, string methodSignature, string superClassDescriptor)
     {
-        var onCreatePattern = new Regex(@"(?ms)(\.method[^\n]* onCreate\(Landroid/os/Bundle;\)V\s+)(.*?)(\.end method)");
-        var match = onCreatePattern.Match(content);
+        var helperMethodName = methodName == "onResume" ? "loadFridaGadgetIfNeeded" : "loadFridaGadget";
+        var methodPattern = new Regex($@"(?ms)(\.method[^\n]* {methodName}\{Regex.Escape(methodSignature)}\s+)(.*?)(\.end method)");
+        var match = methodPattern.Match(content);
 
         if (match.Success)
         {
             var body = match.Groups[2].Value;
-            if (body.Contains("loadFridaGadget", StringComparison.Ordinal))
+            if (body.Contains(helperMethodName, StringComparison.Ordinal))
             {
                 return content;
             }
 
-            var call = "    invoke-static {}, " + classDescriptor + "->loadFridaGadget()V";
-            var superCallPattern = new Regex(@"(?m)^\s*invoke-super \{[^\n]+\}, [^\n]+->onCreate\(Landroid/os/Bundle;\)V\s*$");
+            var call = "    invoke-static {}, " + classDescriptor + $"->{helperMethodName}()V";
+            var superCallPattern = new Regex($@"(?m)^\s*invoke-super \{{[^\n]+\}}, [^\n]+->{methodName}\{Regex.Escape(methodSignature)}\s*$");
             if (superCallPattern.IsMatch(body))
             {
                 body = superCallPattern.Replace(body, m => m.Value + Environment.NewLine + call, 1);
@@ -141,12 +164,19 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return content[..match.Groups[2].Index] + body + content[(match.Groups[2].Index + match.Groups[2].Length)..];
         }
 
-        var methodToAdd = $".method protected onCreate(Landroid/os/Bundle;)V{Environment.NewLine}" +
-                          "    .locals 0" + Environment.NewLine +
-                          "    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V" + Environment.NewLine +
-                          $"    invoke-static {{}}, {classDescriptor}->loadFridaGadget()V{Environment.NewLine}" +
-                          "    return-void" + Environment.NewLine +
-                          ".end method" + Environment.NewLine + Environment.NewLine;
+        var newMethod = methodName == "onResume"
+            ? $".method protected onResume()V{Environment.NewLine}" +
+              "    .locals 0" + Environment.NewLine +
+              $"    invoke-super {{p0}}, {superClassDescriptor}->onResume()V{Environment.NewLine}" +
+              $"    invoke-static {{}}, {classDescriptor}->loadFridaGadgetIfNeeded()V{Environment.NewLine}" +
+              "    return-void" + Environment.NewLine +
+              ".end method" + Environment.NewLine + Environment.NewLine
+            : $".method protected onCreate(Landroid/os/Bundle;)V{Environment.NewLine}" +
+              "    .locals 0" + Environment.NewLine +
+              $"    invoke-super {{p0, p1}}, {superClassDescriptor}->onCreate(Landroid/os/Bundle;)V{Environment.NewLine}" +
+              $"    invoke-static {{}}, {classDescriptor}->loadFridaGadget()V{Environment.NewLine}" +
+              "    return-void" + Environment.NewLine +
+              ".end method" + Environment.NewLine + Environment.NewLine;
 
         var endClassIndex = content.LastIndexOf(".end class", StringComparison.Ordinal);
         if (endClassIndex < 0)
@@ -154,6 +184,6 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return content;
         }
 
-        return content.Insert(endClassIndex, methodToAdd);
+        return content.Insert(endClassIndex, newMethod);
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -35,4 +35,47 @@ public class SmaliPatchServiceTests
         Assert.Equal(firstContent, secondContent);
         Assert.Contains("loadFridaGadget", secondContent, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task PatchAsync_ProducesDifferentInjection_ForDelayedMode()
+    {
+        var immediateRoot = Path.Combine(Path.GetTempPath(), $"smali-patch-immediate-{Guid.NewGuid():N}");
+        var delayedRoot = Path.Combine(Path.GetTempPath(), $"smali-patch-delayed-{Guid.NewGuid():N}");
+        var immediateSmaliPath = Path.Combine(immediateRoot, "smali", "com", "example");
+        var delayedSmaliPath = Path.Combine(delayedRoot, "smali", "com", "example");
+        Directory.CreateDirectory(immediateSmaliPath);
+        Directory.CreateDirectory(delayedSmaliPath);
+
+        var smaliContent = @".class public Lcom/example/MainActivity;
+.super Landroid/app/Activity;
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 0
+    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
+    return-void
+.end method
+
+.end class";
+
+        var immediateFile = Path.Combine(immediateSmaliPath, "MainActivity.smali");
+        var delayedFile = Path.Combine(delayedSmaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(immediateFile, smaliContent);
+        await File.WriteAllTextAsync(delayedFile, smaliContent);
+
+        var service = new SmaliPatchService();
+
+        var immediate = await service.PatchAsync(immediateRoot, "com.example.MainActivity", useDelayedLoad: false);
+        var delayed = await service.PatchAsync(delayedRoot, "com.example.MainActivity", useDelayedLoad: true);
+
+        var immediateOutput = await File.ReadAllTextAsync(immediateFile);
+        var delayedOutput = await File.ReadAllTextAsync(delayedFile);
+
+        Assert.True(immediate.Success);
+        Assert.True(delayed.Success);
+        Assert.NotEqual(immediateOutput, delayedOutput);
+        Assert.Contains("invoke-static {}, Lcom/example/MainActivity;->loadFridaGadget()V", immediateOutput, StringComparison.Ordinal);
+        Assert.Contains("invoke-static {}, Lcom/example/MainActivity;->loadFridaGadgetIfNeeded()V", delayedOutput, StringComparison.Ordinal);
+        Assert.Contains(".method protected onResume()V", delayedOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("loadFridaGadgetIfNeeded", immediateOutput, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
### Motivation
- Make `SmaliPatchService` behave differently for immediate vs delayed loading so smali injection strategies are distinct and delayed loading defers library initialization to a later lifecycle point. 
- Add coverage to assert the two modes produce different smali outputs so accidental parity or misuse is detected by tests.

### Description
- Implemented mode-specific helper insertion in `SmaliPatchService.PatchAsync()` so immediate mode inserts `loadFridaGadget()` and delayed mode inserts a guarded `loadFridaGadgetIfNeeded()` plus a static `sFridaLoaded` field. 
- Delayed mode now injects the call into `onResume` (creating `onResume` when missing) while immediate mode continues to target `onCreate`. 
- Refactored helper/method insertion logic into `BuildImmediateLoadHelperMethods()`, `BuildDelayedLoadHelperMethods()`, `InsertHelperMethods()` and `InjectCallIntoLifecycleMethod()` for clearer branching. 
- Added a unit test `PatchAsync_ProducesDifferentInjection_ForDelayedMode` to `SmaliPatchServiceTests` that patches the same baseline smali file in both modes and asserts the outputs differ and include mode-specific markers.

### Testing
- Added unit test `PatchAsync_ProducesDifferentInjection_ForDelayedMode` in `tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs` and retained the existing idempotency test. 
- Attempted to run `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter SmaliPatchServiceTests` but the environment lacks the `dotnet` SDK so tests could not be executed here. 
- The change is limited to `src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs` and the test file `tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs` for review and CI execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b805778c9883229ac63f8e27737968)