### PR TITLE
Normalize activity detection output and add coverage for short activity names

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -59,21 +59,29 @@ public sealed class ActivityDetectionService : IActivityDetectionService
                 }
 
                 var fallbackActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
-                if (!string.IsNullOrWhiteSpace(fallbackActivityName))
+                var resolvedFallback = ResolveActivityName(fallbackActivityName, packageName);
+                if (!string.IsNullOrWhiteSpace(resolvedFallback))
                 {
-                    return Task.FromResult<(string?, string?, string?)>((fallbackActivityName, "Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", null));
+                    return Task.FromResult<(string?, string?, string?)>((resolvedFallback, "Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", null));
                 }
 
                 return Task.FromResult<(string?, string?, string?)>((null, null, "Launcher activity alias has missing or invalid targetActivity, and no concrete activity entries were found in AndroidManifest.xml."));
             }
 
-            return Task.FromResult<(string?, string?, string?)>(((string?)withLauncher.Attribute(androidNs + "name"), null, null));
+            var resolvedLauncher = ResolveActivityName((string?)withLauncher.Attribute(androidNs + "name"), packageName);
+            if (!string.IsNullOrWhiteSpace(resolvedLauncher))
+            {
+                return Task.FromResult<(string?, string?, string?)>((resolvedLauncher, null, null));
+            }
+
+            return Task.FromResult<(string?, string?, string?)>((null, null, "Launcher activity is missing a valid android:name value in AndroidManifest.xml."));
         }
 
         var firstActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
-        if (!string.IsNullOrWhiteSpace(firstActivityName))
+        var resolvedFirstActivity = ResolveActivityName(firstActivityName, packageName);
+        if (!string.IsNullOrWhiteSpace(resolvedFirstActivity))
         {
-            return Task.FromResult<(string?, string?, string?)>((firstActivityName, "No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", null));
+            return Task.FromResult<(string?, string?, string?)>((resolvedFirstActivity, "No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", null));
         }
 
         return Task.FromResult<(string?, string?, string?)>((null, null, "No activity entries found in AndroidManifest.xml."));

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -85,7 +85,21 @@ public sealed class SmaliPatchService : ISmaliPatchService
 
     private static string? ResolveActivitySmaliFile(string decompiledDirectory, string activityName)
     {
-        var relativePath = activityName.TrimStart('.').Replace('.', Path.DirectorySeparatorChar) + ".smali";
+        if (string.IsNullOrWhiteSpace(activityName))
+        {
+            return null;
+        }
+
+        var normalizedActivityName = activityName.Trim();
+        var relativePath = normalizedActivityName.TrimStart('.').Replace('.', Path.DirectorySeparatorChar) + ".smali";
+        var fallbackFileName = normalizedActivityName.TrimStart('.');
+        if (fallbackFileName.Contains(Path.DirectorySeparatorChar) || fallbackFileName.Contains(Path.AltDirectorySeparatorChar))
+        {
+            fallbackFileName = Path.GetFileName(fallbackFileName);
+        }
+
+        fallbackFileName += ".smali";
+
         foreach (var smaliRoot in Directory.EnumerateDirectories(decompiledDirectory, "smali*", SearchOption.TopDirectoryOnly))
         {
             var direct = Path.Combine(smaliRoot, relativePath);
@@ -99,6 +113,18 @@ public sealed class SmaliPatchService : ISmaliPatchService
             if (match is not null)
             {
                 return match;
+            }
+
+            if (fallbackFileName.Contains(Path.DirectorySeparatorChar) || fallbackFileName.Contains(Path.AltDirectorySeparatorChar))
+            {
+                continue;
+            }
+
+            var fallbackMatch = Directory.EnumerateFiles(smaliRoot, fallbackFileName, SearchOption.AllDirectories)
+                .FirstOrDefault();
+            if (fallbackMatch is not null)
+            {
+                return fallbackMatch;
             }
         }
 

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
@@ -51,6 +51,68 @@ public class ActivityDetectionServiceTests
         Assert.Null(result.Error);
     }
 
+
+    [Fact]
+    public async Task DetectMainActivityAsync_ConcreteLauncherWithDotPrefixedName_ReturnsFullyQualifiedActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='.MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task DetectMainActivityAsync_ConcreteLauncherWithShortName_ReturnsFullyQualifiedActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task DetectMainActivityAsync_NoLauncherFallbackWithShortName_ReturnsFullyQualifiedActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='MainActivity' />
+    <activity android:name='SecondActivity' />
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Equal("No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", result.Warning);
+        Assert.Null(result.Error);
+    }
     [Fact]
     public async Task DetectMainActivityAsync_PrefersMainLauncherActivity_WhenLauncherIsConcreteActivity()
     {


### PR DESCRIPTION
### Motivation

- Ensure any activity name returned by activity detection is normalized to a fully-qualified name so downstream pipeline stages and smali lookups receive consistent values.
- Improve robustness when AndroidManifest entries use shorthand activity names (dot-prefixed or unqualified) or when alias targetActivity values are missing or unnormalized.

### Description

- Updated `ActivityDetectionService.DetectMainActivityAsync(...)` to run all returned concrete activity names through `ResolveActivityName(...)`, covering launcher-path, alias-fallback-to-first-activity, and fallback-to-first-activity cases, and to return an error when a launcher entry lacks a valid `android:name` value.
- Hardened `SmaliPatchService.ResolveActivitySmaliFile(...)` to defensively handle blank/short/unnormalized activity names and to attempt a filename-based fallback search when a direct relative path lookup fails.
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs` exercising dot-prefixed launcher names, short (unqualified) launcher names, and fallback normalization to fully-qualified names.
- Files changed: `src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs`, `src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs`, and `tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs`.

### Testing

- Unit tests were added for the new normalization behavior but test execution was not completed because the environment lacks the `dotnet` CLI, so `dotnet test --filter ActivityDetectionServiceTests` could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8074650c083228bb72ffb6ab287ed)