### PR TITLE
Normalize activity names across detection and smali patching

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -42,9 +42,7 @@ public sealed class ActivityDetectionService : IActivityDetectionService
             if (withLauncher.Name.LocalName == "activity-alias")
             {
                 var targetActivity = (string?)withLauncher.Attribute(androidNs + "targetActivity");
-                var resolvedTarget = ResolveActivityName(targetActivity, packageName);
-
-                if (!string.IsNullOrWhiteSpace(resolvedTarget))
+                if (TryResolveActivityName(targetActivity, packageName, out var resolvedTarget))
                 {
                     var targetExists = activities.Any(activity =>
                         string.Equals(
@@ -54,34 +52,32 @@ public sealed class ActivityDetectionService : IActivityDetectionService
 
                     if (targetExists)
                     {
-                        return Task.FromResult<(string?, string?, string?)>((resolvedTarget, null, null));
+                        return Task.FromResult<(string?, string?, string?)>((ResolveActivityName(resolvedTarget, packageName), null, null));
                     }
                 }
 
                 var fallbackActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
-                var resolvedFallback = ResolveActivityName(fallbackActivityName, packageName);
-                if (!string.IsNullOrWhiteSpace(resolvedFallback))
+                if (TryResolveActivityName(fallbackActivityName, packageName, out var resolvedFallback))
                 {
-                    return Task.FromResult<(string?, string?, string?)>((resolvedFallback, "Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", null));
+                    return Task.FromResult<(string?, string?, string?)>((ResolveActivityName(resolvedFallback, packageName), "Launcher activity alias has missing or invalid targetActivity. Falling back to first concrete activity in manifest.", null));
                 }
 
                 return Task.FromResult<(string?, string?, string?)>((null, null, "Launcher activity alias has missing or invalid targetActivity, and no concrete activity entries were found in AndroidManifest.xml."));
             }
 
-            var resolvedLauncher = ResolveActivityName((string?)withLauncher.Attribute(androidNs + "name"), packageName);
-            if (!string.IsNullOrWhiteSpace(resolvedLauncher))
+            var launcherActivityName = (string?)withLauncher.Attribute(androidNs + "name");
+            if (TryResolveActivityName(launcherActivityName, packageName, out var resolvedLauncher))
             {
-                return Task.FromResult<(string?, string?, string?)>((resolvedLauncher, null, null));
+                return Task.FromResult<(string?, string?, string?)>((ResolveActivityName(resolvedLauncher, packageName), null, null));
             }
 
             return Task.FromResult<(string?, string?, string?)>((null, null, "Launcher activity is missing a valid android:name value in AndroidManifest.xml."));
         }
 
         var firstActivityName = (string?)activities.FirstOrDefault()?.Attribute(androidNs + "name");
-        var resolvedFirstActivity = ResolveActivityName(firstActivityName, packageName);
-        if (!string.IsNullOrWhiteSpace(resolvedFirstActivity))
+        if (TryResolveActivityName(firstActivityName, packageName, out var resolvedFirstActivity))
         {
-            return Task.FromResult<(string?, string?, string?)>((resolvedFirstActivity, "No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", null));
+            return Task.FromResult<(string?, string?, string?)>((ResolveActivityName(resolvedFirstActivity, packageName), "No MAIN/LAUNCHER activity found. Falling back to first activity in manifest.", null));
         }
 
         return Task.FromResult<(string?, string?, string?)>((null, null, "No activity entries found in AndroidManifest.xml."));
@@ -105,5 +101,11 @@ public sealed class ActivityDetectionService : IActivityDetectionService
         }
 
         return string.IsNullOrWhiteSpace(packageName) ? null : $"{packageName}.{activityName}";
+    }
+
+    private static bool TryResolveActivityName(string? activityName, string? packageName, out string resolvedActivityName)
+    {
+        resolvedActivityName = ResolveActivityName(activityName, packageName) ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(resolvedActivityName);
     }
 }

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -90,7 +90,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return null;
         }
 
-        var normalizedActivityName = activityName.Trim();
+        var normalizedActivityName = NormalizeActivityName(decompiledDirectory, activityName);
         var relativePath = normalizedActivityName.TrimStart('.').Replace('.', Path.DirectorySeparatorChar) + ".smali";
         var fallbackFileName = normalizedActivityName.TrimStart('.');
         if (fallbackFileName.Contains(Path.DirectorySeparatorChar) || fallbackFileName.Contains(Path.AltDirectorySeparatorChar))
@@ -129,6 +129,43 @@ public sealed class SmaliPatchService : ISmaliPatchService
         }
 
         return null;
+    }
+
+
+    private static string NormalizeActivityName(string decompiledDirectory, string activityName)
+    {
+        var trimmedActivityName = activityName.Trim();
+        if (trimmedActivityName.StartsWith('.', StringComparison.Ordinal))
+        {
+            var packageName = ReadPackageName(decompiledDirectory);
+            if (!string.IsNullOrWhiteSpace(packageName))
+            {
+                return packageName + trimmedActivityName;
+            }
+
+            return trimmedActivityName;
+        }
+
+        if (trimmedActivityName.Contains('.', StringComparison.Ordinal))
+        {
+            return trimmedActivityName;
+        }
+
+        var manifestPackageName = ReadPackageName(decompiledDirectory);
+        return string.IsNullOrWhiteSpace(manifestPackageName) ? trimmedActivityName : $"{manifestPackageName}.{trimmedActivityName}";
+    }
+
+    private static string? ReadPackageName(string decompiledDirectory)
+    {
+        var manifestPath = Path.Combine(decompiledDirectory, "AndroidManifest.xml");
+        if (!File.Exists(manifestPath))
+        {
+            return null;
+        }
+
+        var manifestContent = File.ReadAllText(manifestPath);
+        var packageMatch = Regex.Match(manifestContent, @"\bpackage\s*=\s*['"](?<package>[^'"]+)['"]");
+        return packageMatch.Success ? packageMatch.Groups["package"].Value : null;
     }
 
     private static string? ExtractClassDescriptor(string content)

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs
@@ -136,6 +136,53 @@ public class ActivityDetectionServiceTests
         Assert.Null(result.Error);
     }
 
+
+
+    [Fact]
+    public async Task DetectMainActivityAsync_LauncherAliasTargetWithDotPrefixedName_ReturnsFullyQualifiedActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='com.example.MainActivity' />
+    <activity-alias android:name='com.example.EntryAlias' android:targetActivity='.MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity-alias>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task DetectMainActivityAsync_LauncherAliasTargetWithShortName_ReturnsFullyQualifiedActivity()
+    {
+        var root = CreateManifest(@"<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.example'>
+  <application>
+    <activity android:name='com.example.MainActivity' />
+    <activity-alias android:name='com.example.EntryAlias' android:targetActivity='MainActivity'>
+      <intent-filter>
+        <action android:name='android.intent.action.MAIN' />
+        <category android:name='android.intent.category.LAUNCHER' />
+      </intent-filter>
+    </activity-alias>
+  </application>
+</manifest>");
+
+        var service = new ActivityDetectionService();
+        var result = await service.DetectMainActivityAsync(root);
+
+        Assert.Equal("com.example.MainActivity", result.ActivityName);
+        Assert.Null(result.Warning);
+        Assert.Null(result.Error);
+    }
     private static string CreateManifest(string manifest)
     {
         var root = Path.Combine(Path.GetTempPath(), $"pulseapk-manifest-{Guid.NewGuid():N}");


### PR DESCRIPTION
### Motivation

- Ensure every `ActivityName` returned from detection is fully resolved and consistently normalized to avoid downstream mismatches when locating smali files and performing patches.  
- Harden smali resolution so short-form activity names like `.MainActivity` or `MainActivity` can be expanded using the manifest package when present.  
- Add explicit unit coverage for alias `targetActivity` values that use dot-prefixed and short names so these cases remain correct going forward.

### Description

- Updated `ActivityDetectionService` to validate and normalize all successful return paths by introducing `TryResolveActivityName(...)` and ensuring returned `ActivityName` values go through `ResolveActivityName(...)` for the concrete launcher, alias target, alias fallback, and first-activity fallback flows.  
- Hardened `SmaliPatchService` by adding `NormalizeActivityName(...)` and `ReadPackageName(...)` and using `NormalizeActivityName(...)` in `ResolveActivitySmaliFile(...)` so short or dot-prefixed activity names are expanded against `AndroidManifest.xml` when possible.  
- Fixed regex string literal usage when reading the manifest package and guarded manifest reads for package extraction.  
- Added two unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/ActivityDetectionServiceTests.cs` covering alias `targetActivity` values of `.MainActivity` and `MainActivity` (with package `com.example`).

### Testing

- Added unit tests `DetectMainActivityAsync_LauncherAliasTargetWithDotPrefixedName_ReturnsFullyQualifiedActivity` and `DetectMainActivityAsync_LauncherAliasTargetWithShortName_ReturnsFullyQualifiedActivity`, but they were not executed in this environment because `dotnet` is not available.  
- An automated `dotnet test` invocation was attempted (`--filter ActivityDetectionServiceTests`) and failed with `command not found` due to the missing SDK in the container.  
- No other automated test runs were performed in this environment; the test files are present and ready to run in a CI environment with `dotnet` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b809adc0608322936048df6ea8ae64)