### PR TITLE
Parse smali .super and use superclass descriptor for synthetic lifecycle methods

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -26,11 +26,15 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return Task.FromResult<(bool Success, string? Error)>((false, "Unable to determine class descriptor from smali file."));
         }
 
+        var superClassDescriptor = ExtractSuperClassDescriptor(originalContent);
+        if (string.IsNullOrWhiteSpace(superClassDescriptor))
+        {
+            return Task.FromResult<(bool Success, string? Error)>((false, $"Unable to determine superclass descriptor from smali file '{smaliFile}'."));
+        }
+
         var helperMethods = useDelayedLoad ? BuildDelayedLoadHelperMethods() : BuildImmediateLoadHelperMethods();
         var lifecycleMethodName = useDelayedLoad ? "onResume" : "onCreate";
         var lifecycleSignature = useDelayedLoad ? "()V" : "(Landroid/os/Bundle;)V";
-        var superClassDescriptor = useDelayedLoad ? "Landroid/app/Activity;" : "Landroid/app/Activity;";
-
         var patched = originalContent;
         patched = InsertHelperMethods(patched, helperMethods);
         patched = InjectCallIntoLifecycleMethod(patched, classDescriptor, lifecycleMethodName, lifecycleSignature, superClassDescriptor);
@@ -171,6 +175,12 @@ public sealed class SmaliPatchService : ISmaliPatchService
     private static string? ExtractClassDescriptor(string content)
     {
         var match = Regex.Match(content, @"\.class\s+[\w\s-]+\s+(L[^;]+;)");
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string? ExtractSuperClassDescriptor(string content)
+    {
+        var match = Regex.Match(content, @"(?m)^\.super\s+(L[^;]+;)");
         return match.Success ? match.Groups[1].Value : null;
     }
 

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -78,4 +78,70 @@ public class SmaliPatchServiceTests
         Assert.Contains(".method protected onResume()V", delayedOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("loadFridaGadgetIfNeeded", immediateOutput, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task PatchAsync_GeneratesLifecycleMethodUsingParsedAppCompatSuperclass()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-appcompat-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+.super Landroidx/appcompat/app/AppCompatActivity;
+
+.end class");
+
+        var service = new SmaliPatchService();
+
+        var result = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+        var output = await File.ReadAllTextAsync(file);
+
+        Assert.True(result.Success);
+        Assert.Contains("invoke-super {p0, p1}, Landroidx/appcompat/app/AppCompatActivity;->onCreate(Landroid/os/Bundle;)V", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PatchAsync_GeneratesLifecycleMethodUsingParsedCustomSuperclass()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-custom-super-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+.super Lcom/example/BaseActivity;
+
+.end class");
+
+        var service = new SmaliPatchService();
+
+        var result = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: true);
+        var output = await File.ReadAllTextAsync(file);
+
+        Assert.True(result.Success);
+        Assert.Contains("invoke-super {p0}, Lcom/example/BaseActivity;->onResume()V", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PatchAsync_FailsWhenSuperclassDescriptorCannotBeParsed()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-missing-super-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+
+.end class");
+
+        var service = new SmaliPatchService();
+
+        var result = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Error);
+        Assert.Contains("Unable to determine superclass descriptor", result.Error, StringComparison.Ordinal);
+        Assert.Contains(file, result.Error, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
### Motivation

- Smali lifecycle stubs were using a hardcoded `Landroid/app/Activity;` which is incorrect for classes that extend `AppCompatActivity` or custom base activities.
- The patch should generate `invoke-super` calls against the actual smali superclass so injected lifecycle stubs call the correct parent implementation.

### Description

- Parse the `.super` descriptor from the target smali content with a new `ExtractSuperClassDescriptor` helper and use it when generating synthetic `onCreate`/`onResume` methods in `SmaliPatchService` (`src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs`).
- Replace the previous hardcoded `Landroid/app/Activity;` with the parsed `superClassDescriptor` and fail early with a clear error that includes the smali file path when parsing fails.
- Add unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs` that cover classes extending `Landroidx/appcompat/app/AppCompatActivity;`, a custom superclass `Lcom/example/BaseActivity;`, and the failure case when `.super` is missing.

### Testing

- Added unit tests for the new behavior in `SmaliPatchServiceTests` (AppCompat, custom superclass, and missing `.super`).
- Attempted to run `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter SmaliPatchServiceTests`, but the command could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80a8dc7408322865dac0b3186069c)