### PR TITLE
Add advanced dex preservation options and guardrails for dangerous replace-all mode

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -60,6 +60,22 @@
                           IsChecked="{Binding DecodeSources}" />
                 <CheckBox Content="Use AAPT2 for build"
                           IsChecked="{Binding UseAapt2ForBuild}" />
+
+                <TextBlock Text="DEX preservation mode"
+                           FontWeight="SemiBold"
+                           Margin="0,8,0,0" />
+                <ComboBox ItemsSource="{Binding DexPreservationOptions}"
+                          SelectedItem="{Binding SelectedDexPreservationOption}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Label}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBlock Text="Disabled: no dex copy. Preserve unmodified secondary dex: keeps additional original classes*.dex not produced during rebuild. Replace all dex (dangerous): restores every original dex and may discard injected smali changes."
+                           TextWrapping="Wrap"
+                           FontSize="12"
+                           Opacity="0.75" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
                 <TextBlock Text="Output"

--- a/src/PulseAPK.Core/Abstractions/Patching/IDexMergeService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IDexMergeService.cs
@@ -2,6 +2,7 @@ namespace PulseAPK.Core.Abstractions.Patching;
 
 public enum DexPreservationMode
 {
+    Disabled,
     ReplaceAllDexFiles,
     PreserveUnmodifiedSecondaryDexFiles
 }

--- a/src/PulseAPK.Core/Models/PatchRequest.cs
+++ b/src/PulseAPK.Core/Models/PatchRequest.cs
@@ -1,3 +1,5 @@
+using PulseAPK.Core.Abstractions.Patching;
+
 namespace PulseAPK.Core.Models;
 
 public sealed record PatchRequest
@@ -12,6 +14,8 @@ public sealed record PatchRequest
     public string? WorkingDirectory { get; init; }
     public bool KeepIntermediateFiles { get; init; }
     public bool PreserveOriginalDexFiles { get; init; } = true;
+    public DexPreservationMode DexPreservationMode { get; init; } = DexPreservationMode.Disabled;
+    public bool ConfirmDangerousDexReplacement { get; init; }
     public bool EnsureInternetPermission { get; init; } = true;
     public bool EnsureExtractNativeLibs { get; init; } = true;
     public string? PreferredActivityName { get; init; }

--- a/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
+++ b/src/PulseAPK.Core/Services/Patching/DexMergeService.cs
@@ -22,6 +22,8 @@ public sealed class DexMergeService : IDexMergeService
 
         switch (mode)
         {
+            case DexPreservationMode.Disabled:
+                return Task.FromResult<(bool Success, string? Error)>((true, null));
             case DexPreservationMode.ReplaceAllDexFiles:
                 ReplaceAllDexFiles(rebuilt, sourceDexEntries);
                 break;

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -160,30 +160,39 @@ public sealed class PatchPipelineService : IPatchPipelineService
 
             result.StageSummaries.Add(new PatchStageSummary("build", true, "APK rebuilt successfully."));
 
-            if (request.PreserveOriginalDexFiles)
+            var dexMode = request.DexPreservationMode;
+            if (dexMode == DexPreservationMode.Disabled && request.PreserveOriginalDexFiles)
             {
-                if (smaliInjectionApplied)
-                {
-                    const string skipMessage = "Dex preservation skipped because smali injection modified classes.dex; raw original-dex replacement would discard injected changes.";
-                    result.Warnings.Add(skipMessage);
-                    result.StageSummaries.Add(new PatchStageSummary("dex-preservation", true, skipMessage));
-                }
-                else
-                {
-                    var dexResult = await _dexMergeService.PreserveOriginalDexFilesAsync(
-                        request.InputApkPath,
-                        request.OutputApkPath,
-                        DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles,
-                        cancellationToken);
-                    if (!dexResult.Success)
-                    {
-                        result.Errors.Add(dexResult.Error ?? "DEX merge failed.");
-                        result.StageSummaries.Add(new PatchStageSummary("dex-preservation", false, result.Errors.Last()));
-                        return result;
-                    }
+                // Backward compatibility for callers still setting PreserveOriginalDexFiles.
+                dexMode = DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles;
+            }
 
-                    result.StageSummaries.Add(new PatchStageSummary("dex-preservation", true, "Original non-modified secondary dex files preserved."));
+            if (dexMode != DexPreservationMode.Disabled)
+            {
+                if (dexMode == DexPreservationMode.ReplaceAllDexFiles && smaliInjectionApplied && !request.ConfirmDangerousDexReplacement)
+                {
+                    const string dangerousModeError = "Dex replacement mode 'replace all dex' is blocked because smali injection was applied. Confirm dangerous mode explicitly to continue; replacing all dex may discard injected smali changes.";
+                    result.Errors.Add(dangerousModeError);
+                    result.StageSummaries.Add(new PatchStageSummary("dex-preservation", false, dangerousModeError));
+                    return result;
                 }
+
+                var dexResult = await _dexMergeService.PreserveOriginalDexFilesAsync(
+                    request.InputApkPath,
+                    request.OutputApkPath,
+                    dexMode,
+                    cancellationToken);
+                if (!dexResult.Success)
+                {
+                    result.Errors.Add(dexResult.Error ?? "DEX merge failed.");
+                    result.StageSummaries.Add(new PatchStageSummary("dex-preservation", false, result.Errors.Last()));
+                    return result;
+                }
+
+                var dexMessage = dexMode == DexPreservationMode.ReplaceAllDexFiles
+                    ? "All dex files were replaced from the original APK (dangerous mode)."
+                    : "Original non-modified secondary dex files preserved.";
+                result.StageSummaries.Add(new PatchStageSummary("dex-preservation", true, dexMessage));
             }
 
             if (request.SignOutput)

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -10,6 +10,9 @@ using Properties = PulseAPK.Core.Properties;
 
 namespace PulseAPK.Core.ViewModels;
 
+
+public sealed record DexPreservationOption(string Label, DexPreservationMode Mode);
+
 public partial class PatchViewModel : ObservableObject
 {
     [ObservableProperty]
@@ -38,6 +41,9 @@ public partial class PatchViewModel : ObservableObject
     private bool _useAapt2ForBuild;
 
     [ObservableProperty]
+    private DexPreservationOption _selectedDexPreservationOption = new("Disabled (default)", DexPreservationMode.Disabled);
+
+    [ObservableProperty]
     private string _consoleLog;
 
     [ObservableProperty]
@@ -51,6 +57,13 @@ public partial class PatchViewModel : ObservableObject
 
     public bool IsHintVisible => string.IsNullOrWhiteSpace(ApkPath);
 
+    public IReadOnlyList<DexPreservationOption> DexPreservationOptions { get; } =
+    [
+        new("Disabled (default)", DexPreservationMode.Disabled),
+        new("Preserve unmodified secondary dex", DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles),
+        new("Replace all dex (dangerous)", DexPreservationMode.ReplaceAllDexFiles)
+    ];
+
     public PatchViewModel(
         IFilePickerService filePickerService,
         ISettingsService settingsService,
@@ -63,6 +76,8 @@ public partial class PatchViewModel : ObservableObject
         _dialogService = dialogService;
 
         _consoleLog = Properties.Resources.WaitingForCommand;
+
+        SelectedDexPreservationOption = DexPreservationOptions[0];
 
         OutputFolderPath = EnsureCompiledDirectory();
         OutputApkName = "patched.apk";
@@ -98,6 +113,7 @@ public partial class PatchViewModel : ObservableObject
     partial void OnDecodeResourcesChanged(bool value) => UpdateCommandPreview();
     partial void OnDecodeSourcesChanged(bool value) => UpdateCommandPreview();
     partial void OnUseAapt2ForBuildChanged(bool value) => UpdateCommandPreview();
+    partial void OnSelectedDexPreservationOptionChanged(DexPreservationOption value) => UpdateCommandPreview();
 
     [RelayCommand]
     private async Task BrowseApk()
@@ -144,6 +160,20 @@ public partial class PatchViewModel : ObservableObject
             return;
         }
 
+        var selectedDexMode = SelectedDexPreservationOption.Mode;
+        var confirmedDangerousDexMode = false;
+        if (selectedDexMode == DexPreservationMode.ReplaceAllDexFiles)
+        {
+            confirmedDangerousDexMode = await _dialogService.ShowQuestionAsync(
+                "Replace all dex can discard injected smali changes. Continue only if you understand this risk.",
+                "Dangerous dex replacement");
+            if (!confirmedDangerousDexMode)
+            {
+                AppendLog("[WARN] Dangerous dex replacement was cancelled by user.");
+                return;
+            }
+        }
+
         IsRunning = true;
         SetConsoleLog("Starting patch pipeline...");
 
@@ -159,7 +189,9 @@ public partial class PatchViewModel : ObservableObject
                 UseAapt2ForBuild = UseAapt2ForBuild,
                 WorkingDirectory = Path.Combine(Path.GetTempPath(), "pulseapk-patch-ui"),
                 KeepIntermediateFiles = false,
-                PreserveOriginalDexFiles = false
+                PreserveOriginalDexFiles = false,
+                DexPreservationMode = selectedDexMode,
+                ConfirmDangerousDexReplacement = confirmedDangerousDexMode
             };
 
             AppendLog(BuildRunSummary(request));
@@ -270,12 +302,13 @@ public partial class PatchViewModel : ObservableObject
         builder.AppendLine($"Decode resources: {DecodeResources}");
         builder.AppendLine($"Decode sources: {DecodeSources}");
         builder.AppendLine($"Use AAPT2: {UseAapt2ForBuild}");
+        builder.AppendLine($"Dex preservation: {SelectedDexPreservationOption.Label}");
         builder.Append($"Sign output: {SignApk}");
         ConsoleLog = builder.ToString();
     }
 
     private static string BuildRunSummary(PatchRequest request)
     {
-        return $"Patching '{request.InputApkPath}' -> '{request.OutputApkPath}' (sign={request.SignOutput}, decodeRes={request.DecodeResources}, decodeSrc={request.DecodeSources}, aapt2={request.UseAapt2ForBuild})";
+        return $"Patching '{request.InputApkPath}' -> '{request.OutputApkPath}' (sign={request.SignOutput}, decodeRes={request.DecodeResources}, decodeSrc={request.DecodeSources}, aapt2={request.UseAapt2ForBuild}, dexMode={request.DexPreservationMode})";
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -39,47 +39,118 @@ public class PatchPipelineServiceTests
 
 
     [Fact]
-    public async Task RunAsync_DoesNotOverwriteDex_WhenSmaliInjectionApplied()
+    public async Task RunAsync_SkipsDexMerge_WhenDexModeDisabled()
     {
         var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
         await File.WriteAllTextAsync(inputApk, "apk");
         var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
 
-        var pipeline = CreatePipeline();
+        var fakeDexMergeService = new FakeDexMergeService(shouldFail: false);
+        var pipeline = CreatePipeline(fakeDexMergeService: fakeDexMergeService);
 
         var result = await pipeline.RunAsync(new PatchRequest
         {
             InputApkPath = inputApk,
             OutputApkPath = outputApk,
             SignOutput = false,
-            PreserveOriginalDexFiles = true
+            DexPreservationMode = DexPreservationMode.Disabled
         });
 
         Assert.True(result.Success);
-        Assert.DoesNotContain(result.Errors, static e => e.Contains("DEX merge", StringComparison.OrdinalIgnoreCase));
-
-        var dexStage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-preservation"));
-        Assert.True(dexStage.Success);
-        Assert.Contains("smali injection", dexStage.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(result.Warnings, static warning => warning.Contains("smali injection", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, fakeDexMergeService.CallCount);
+        Assert.DoesNotContain(result.StageSummaries, static stage => stage.Stage == "dex-preservation");
     }
 
     [Fact]
-    public async Task RunAsync_EmitsClearFailure_WhenExplicitDexPreserveModeFailsWithoutSmaliInjection()
+    public async Task RunAsync_PreservesSecondaryDex_WhenModeRequested()
     {
         var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
         await File.WriteAllTextAsync(inputApk, "apk");
         var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
 
-        var pipeline = CreatePipeline(dexMergeShouldFail: true);
+        var fakeDexMergeService = new FakeDexMergeService(shouldFail: false);
+        var pipeline = CreatePipeline(fakeDexMergeService: fakeDexMergeService);
 
         var result = await pipeline.RunAsync(new PatchRequest
         {
             InputApkPath = inputApk,
             OutputApkPath = outputApk,
             SignOutput = false,
-            DecodeSources = false,
-            PreserveOriginalDexFiles = true
+            DexPreservationMode = DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(1, fakeDexMergeService.CallCount);
+        Assert.Equal(DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles, fakeDexMergeService.LastMode);
+        var dexStage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-preservation"));
+        Assert.True(dexStage.Success);
+    }
+
+    [Fact]
+    public async Task RunAsync_BlocksReplaceAllDex_WhenSmaliInjectionAppliedWithoutDangerousConfirmation()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var fakeDexMergeService = new FakeDexMergeService(shouldFail: false);
+        var pipeline = CreatePipeline(fakeDexMergeService: fakeDexMergeService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = false,
+            DexPreservationMode = DexPreservationMode.ReplaceAllDexFiles
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal(0, fakeDexMergeService.CallCount);
+        var dexStage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-preservation"));
+        Assert.False(dexStage.Success);
+        Assert.Contains("discard injected smali changes", dexStage.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsync_AllowsReplaceAllDex_WhenDangerousModeExplicitlyConfirmed()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var fakeDexMergeService = new FakeDexMergeService(shouldFail: false);
+        var pipeline = CreatePipeline(fakeDexMergeService: fakeDexMergeService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = false,
+            DexPreservationMode = DexPreservationMode.ReplaceAllDexFiles,
+            ConfirmDangerousDexReplacement = true
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(1, fakeDexMergeService.CallCount);
+        Assert.Equal(DexPreservationMode.ReplaceAllDexFiles, fakeDexMergeService.LastMode);
+    }
+
+    [Fact]
+    public async Task RunAsync_EmitsClearFailure_WhenDexPreserveModeFails()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var fakeDexMergeService = new FakeDexMergeService(shouldFail: true);
+        var pipeline = CreatePipeline(fakeDexMergeService: fakeDexMergeService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = false,
+            DexPreservationMode = DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles
         });
 
         Assert.False(result.Success);
@@ -88,8 +159,10 @@ public class PatchPipelineServiceTests
         Assert.Contains("DEX merge failed", dexStage.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static PatchPipelineService CreatePipeline(bool dexMergeShouldFail = false)
+    private static PatchPipelineService CreatePipeline(bool dexMergeShouldFail = false, FakeDexMergeService? fakeDexMergeService = null)
     {
+        fakeDexMergeService ??= new FakeDexMergeService(dexMergeShouldFail);
+
         return new PatchPipelineService(
             new PatchRequestValidatorService(),
             new FakeArchitectureService(),
@@ -99,7 +172,7 @@ public class PatchPipelineServiceTests
             new FakeManifestPatchService(),
             new FakeGadgetInjectionService(),
             new FakeSmaliPatchService(),
-            new FakeDexMergeService(dexMergeShouldFail),
+            fakeDexMergeService,
             new FakeSigningService());
     }
 
@@ -166,8 +239,15 @@ public class PatchPipelineServiceTests
             _shouldFail = shouldFail;
         }
 
+        public int CallCount { get; private set; }
+
+        public DexPreservationMode? LastMode { get; private set; }
+
         public Task<(bool Success, string? Error)> PreserveOriginalDexFilesAsync(string originalApkPath, string rebuiltApkPath, DexPreservationMode mode = DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles, CancellationToken cancellationToken = default)
         {
+            CallCount++;
+            LastMode = mode;
+
             if (_shouldFail)
             {
                 return Task.FromResult((false, (string?)"DEX merge failed in explicit preserve mode."));


### PR DESCRIPTION
### Motivation
- Provide users an explicit UI choice for dex preservation with a safe default and a dangerous "replace all dex" option that requires confirmation to avoid discarding injected smali changes.
- Ensure the patch pipeline uses the selected dex preservation mode and prevents accidental data loss when smali injection was applied.

### Description
- Introduced `DexPreservationMode.Disabled` and extended `PatchRequest` with `DexPreservationMode` and `ConfirmDangerousDexReplacement` to carry the selected UI mode and explicit confirmation through the pipeline.
- Updated `PatchPipelineService` to honor `DexPreservationMode`, keep backward compatibility with `PreserveOriginalDexFiles`, block `ReplaceAllDexFiles` if smali injection was applied unless `ConfirmDangerousDexReplacement` is true, and emit mode-specific stage messages.
- Made `DexMergeService` treat `Disabled` as a no-op success so disabling dex preservation does not attempt any merge work.
- Added UI controls and explanatory text: a `ComboBox` with `Disabled (default)`, `Preserve unmodified secondary dex`, and `Replace all dex (dangerous)` in `PatchView.axaml`, plus a confirmation prompt and preview text in `PatchViewModel` to pass the selected mode into the `PatchRequest`.
- Expanded `PatchPipelineServiceTests` to cover the new behaviors: disabled (skips merge), preserve-secondary (invokes merge), replace-all blocked when smali injection occurs without confirmation, replace-all allowed with explicit confirmation, and merge failure propagation.

### Testing
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs` exercising each mode and guardrail; tests compile-time presence verified but were not executed here due to missing runtime.
- Attempted to run `dotnet test --filter PatchPipelineServiceTests`, but `dotnet` is not available in this environment so tests could not be executed (no failures reported from test run).
- Attempted a UI screenshot via Playwright, but no local app server was reachable at `127.0.0.1:3000`, so visual validation was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80b8d93348322a5e1841982050393)