### PR TITLE
Fix manifest package regex escaping in SmaliPatchService

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -168,7 +168,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
         }
 
         var manifestContent = File.ReadAllText(manifestPath);
-        var packageMatch = Regex.Match(manifestContent, @"\bpackage\s*=\s*['"](?<package>[^'"]+)['"]");
+        var packageMatch = Regex.Match(manifestContent, @"\bpackage\s*=\s*['""](?<package>[^'""]+)['""]");
         return packageMatch.Success ? packageMatch.Groups["package"].Value : null;
     }
 


### PR DESCRIPTION
### Motivation
- Fix a C# compile error caused by a malformed verbatim regex literal in `SmaliPatchService.ReadPackageName` that produced parser errors when parsing the Android manifest.

### Description
- Corrected the regex string in `src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs` to properly escape embedded double quotes in the verbatim string so the package capture group `(?<package>...)` is parsed by the C# compiler.

### Testing
- Attempted `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj -c Release` but `dotnet` is not available in this environment so build validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80f40b738832280787b1101e275ed)