### PR TITLE
Fix compile errors from char overload usage in activity name checks

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ActivityDetectionService.cs
@@ -90,12 +90,12 @@ public sealed class ActivityDetectionService : IActivityDetectionService
             return null;
         }
 
-        if (activityName.StartsWith('.', StringComparison.Ordinal))
+        if (activityName.StartsWith(".", StringComparison.Ordinal))
         {
             return string.IsNullOrWhiteSpace(packageName) ? null : packageName + activityName;
         }
 
-        if (activityName.Contains('.', StringComparison.Ordinal))
+        if (activityName.Contains(".", StringComparison.Ordinal))
         {
             return activityName;
         }

--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -139,7 +139,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
     private static string NormalizeActivityName(string decompiledDirectory, string activityName)
     {
         var trimmedActivityName = activityName.Trim();
-        if (trimmedActivityName.StartsWith('.', StringComparison.Ordinal))
+        if (trimmedActivityName.StartsWith(".", StringComparison.Ordinal))
         {
             var packageName = ReadPackageName(decompiledDirectory);
             if (!string.IsNullOrWhiteSpace(packageName))
@@ -150,7 +150,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return trimmedActivityName;
         }
 
-        if (trimmedActivityName.Contains('.', StringComparison.Ordinal))
+        if (trimmedActivityName.Contains(".", StringComparison.Ordinal))
         {
             return trimmedActivityName;
         }


### PR DESCRIPTION
### Motivation
- Fix CS1503 compile errors caused by using the `char` overloads of `StartsWith`/`Contains` together with `StringComparison`.

### Description
- Replace `StartsWith('.', StringComparison.Ordinal)` and `Contains('.', StringComparison.Ordinal)` with `StartsWith(".", StringComparison.Ordinal)` and `Contains(".", StringComparison.Ordinal)` in `ActivityDetectionService` and `SmaliPatchService` to ensure the string overload is used.

### Testing
- Attempted `dotnet build src/PulseAPK.Core/PulseAPK.Core.csproj -c Release` but the build could not be executed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80fd550ac83228b20eedab181408b)