### PR TITLE
Fix Frida smali patch regex parsing for lifecycle methods

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -201,7 +201,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
     private static string InjectCallIntoLifecycleMethod(string content, string classDescriptor, string methodName, string methodSignature, string superClassDescriptor)
     {
         var helperMethodName = methodName == "onResume" ? "loadFridaGadgetIfNeeded" : "loadFridaGadget";
-        var methodPattern = new Regex($@"(?ms)(\.method[^\n]* {methodName}\{Regex.Escape(methodSignature)}\s+)(.*?)(\.end method)");
+        var methodPattern = new Regex($@"(?ms)(\.method[^\n]* {methodName}{Regex.Escape(methodSignature)}\s+)(.*?)(\.end method)");
         var match = methodPattern.Match(content);
 
         if (match.Success)
@@ -213,7 +213,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
             }
 
             var call = "    invoke-static {}, " + classDescriptor + $"->{helperMethodName}()V";
-            var superCallPattern = new Regex($@"(?m)^\s*invoke-super \{{[^\n]+\}}, [^\n]+->{methodName}\{Regex.Escape(methodSignature)}\s*$");
+            var superCallPattern = new Regex($@"(?m)^\s*invoke-super \{{[^\n]+\}}, [^\n]+->{methodName}{Regex.Escape(methodSignature)}\s*$");
             if (superCallPattern.IsMatch(body))
             {
                 body = superCallPattern.Replace(body, m => m.Value + Environment.NewLine + call, 1);


### PR DESCRIPTION
### Motivation
- Frida patching failed with an "Invalid pattern" error because the smali lifecycle regex contained unintended backslashes before interpolated `Regex.Escape(methodSignature)`, producing malformed patterns for signatures like `onCreate(Landroid/os/Bundle;)V`.

### Description
- Removed the stray backslashes in the lifecycle matchers in `src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs` by updating the `methodPattern` and `superCallPattern` to interpolate `Regex.Escape(methodSignature)` without the extra `\` so the generated regex is valid.

### Testing
- Attempted to run the unit tests for the smali patching logic with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter SmaliPatchServiceTests`, but the environment does not have `dotnet` installed so automated tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81129cdc88322b2115c47040370f2)