### PR TITLE
Simplify Patch APK tab by removing decode/build toggles

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -54,13 +54,6 @@
             <StackPanel Spacing="8">
                 <CheckBox Content="Sign output APK (ubersigner)"
                           IsChecked="{Binding SignApk}" />
-                <CheckBox Content="Decode resources"
-                          IsChecked="{Binding DecodeResources}" />
-                <CheckBox Content="Decode sources"
-                          IsChecked="{Binding DecodeSources}" />
-                <CheckBox Content="Use AAPT2 for build"
-                          IsChecked="{Binding UseAapt2ForBuild}" />
-
                 <TextBlock Text="DEX preservation mode"
                            FontWeight="SemiBold"
                            Margin="0,8,0,0" />

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -32,15 +32,6 @@ public partial class PatchViewModel : ObservableObject
     private bool _signApk = true;
 
     [ObservableProperty]
-    private bool _decodeResources = true;
-
-    [ObservableProperty]
-    private bool _decodeSources = true;
-
-    [ObservableProperty]
-    private bool _useAapt2ForBuild;
-
-    [ObservableProperty]
     private DexPreservationOption _selectedDexPreservationOption = new("Disabled (default)", DexPreservationMode.Disabled);
 
     [ObservableProperty]
@@ -110,9 +101,6 @@ public partial class PatchViewModel : ObservableObject
 
     partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
     partial void OnSignApkChanged(bool value) => UpdateCommandPreview();
-    partial void OnDecodeResourcesChanged(bool value) => UpdateCommandPreview();
-    partial void OnDecodeSourcesChanged(bool value) => UpdateCommandPreview();
-    partial void OnUseAapt2ForBuildChanged(bool value) => UpdateCommandPreview();
     partial void OnSelectedDexPreservationOptionChanged(DexPreservationOption value) => UpdateCommandPreview();
 
     [RelayCommand]
@@ -184,9 +172,9 @@ public partial class PatchViewModel : ObservableObject
                 InputApkPath = ApkPath,
                 OutputApkPath = OutputApkPath,
                 SignOutput = SignApk,
-                DecodeResources = DecodeResources,
-                DecodeSources = DecodeSources,
-                UseAapt2ForBuild = UseAapt2ForBuild,
+                DecodeResources = true,
+                DecodeSources = true,
+                UseAapt2ForBuild = false,
                 WorkingDirectory = Path.Combine(Path.GetTempPath(), "pulseapk-patch-ui"),
                 KeepIntermediateFiles = false,
                 PreserveOriginalDexFiles = false,
@@ -299,9 +287,9 @@ public partial class PatchViewModel : ObservableObject
         builder.AppendLine("Patch preview:");
         builder.AppendLine($"Input APK: {(string.IsNullOrWhiteSpace(ApkPath) ? "<select apk>" : ApkPath)}");
         builder.AppendLine($"Output APK: {(string.IsNullOrWhiteSpace(OutputApkPath) ? "<output apk>" : OutputApkPath)}");
-        builder.AppendLine($"Decode resources: {DecodeResources}");
-        builder.AppendLine($"Decode sources: {DecodeSources}");
-        builder.AppendLine($"Use AAPT2: {UseAapt2ForBuild}");
+        builder.AppendLine("Decode resources: True (required)");
+        builder.AppendLine("Decode sources: True (required)");
+        builder.AppendLine("Use AAPT2: False (default)");
         builder.AppendLine($"Dex preservation: {SelectedDexPreservationOption.Label}");
         builder.Append($"Sign output: {SignApk}");
         ConsoleLog = builder.ToString();


### PR DESCRIPTION
### Motivation
- The `Decode resources`, `Decode sources`, and `Use AAPT2 for build` options on the Patch tab are unnecessary for the patch pipeline because smali injection and manifest/resource modifications require decoded sources/resources and the patch flow should use a consistent build mode.
- Removing these toggles reduces UI clutter and avoids exposing options that could cause inconsistent or unsafe patch results.

### Description
- Removed the three checkboxes from the Patch UI in `src/PulseAPK.Avalonia/Views/PatchView.axaml`.
- Removed the corresponding observable properties and change handlers for `DecodeResources`, `DecodeSources`, and `UseAapt2ForBuild` from `src/PulseAPK.Core/ViewModels/PatchViewModel.cs`.
- Hardcoded `PatchRequest` creation to use `DecodeResources = true`, `DecodeSources = true`, and `UseAapt2ForBuild = false` in `PatchViewModel`, and updated the preview text to reflect the fixed behavior.
- Left dex preservation and signing controls intact while simplifying the patch flow defaults.

### Testing
- Ran `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj`, but the command failed because `dotnet` is not installed in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81246da50832286ad4ed94c40ddf0)