### PR TITLE
Remove DEX preservation hint text from Patch view

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -65,10 +65,6 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <TextBlock Text="Disabled: no dex copy. Preserve unmodified secondary dex: keeps additional original classes*.dex not produced during rebuild. Replace all dex (dangerous): restores every original dex and may discard injected smali changes."
-                           TextWrapping="Wrap"
-                           FontSize="12"
-                           Opacity="0.75" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
                 <TextBlock Text="Output"


### PR DESCRIPTION
### Motivation
- The long explanatory hint under the "DEX preservation mode" selector made the left column taller and prevented the right-side `Output` section from fitting neatly.

### Description
- Remove the `TextBlock` with the DEX preservation explanatory hint from `src/PulseAPK.Avalonia/Views/PatchView.axaml` to make the Patch view layout more compact.

### Testing
- Ran `dotnet build PulseAPK.sln` to validate the solution, which failed in this environment because `dotnet` is not installed, so no build/test artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b813c723588322b5a58b7dcaee5591)