### PR TITLE
Remove redundant OutputApkPath field from Patch view

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -77,7 +77,6 @@
                             Width="100" />
                 </Grid>
                 <TextBox Text="{Binding OutputApkName}" Watermark="patched.apk" />
-                <TextBox Text="{Binding OutputApkPath}" IsReadOnly="True" />
             </StackPanel>
         </Grid>
 


### PR DESCRIPTION
### Motivation
- The Patch view contained a read-only `OutputApkPath` textbox that duplicated information already expressed by the output folder and filename fields and added unnecessary visual clutter.

### Description
- Deleted the read-only `TextBox` bound to `OutputApkPath` from `src/PulseAPK.Avalonia/Views/PatchView.axaml`, leaving the output folder selector and `OutputApkName` field intact.

### Testing
- Attempted to run `dotnet build PulseAPK.sln -v minimal`, but the build could not be executed because `dotnet` is not available in this environment (no automated build/test run was completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8152ac7788322b4031e9b80c04c7b)