### PR TITLE
Add Script profile selector to Patch tab

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -54,6 +54,18 @@
             <StackPanel Spacing="8">
                 <CheckBox Content="Sign output APK (ubersigner)"
                           IsChecked="{Binding SignApk}" />
+                <TextBlock Text="Script profile"
+                           FontWeight="SemiBold"
+                           Margin="0,8,0,0" />
+                <ComboBox ItemsSource="{Binding ScriptInjectionOptions}"
+                          SelectedItem="{Binding SelectedScriptInjectionOption}"
+                          IsEnabled="False">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Label}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
                 <TextBlock Text="DEX preservation mode"
                            FontWeight="SemiBold"
                            Margin="0,8,0,0" />

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -12,6 +12,7 @@ namespace PulseAPK.Core.ViewModels;
 
 
 public sealed record DexPreservationOption(string Label, DexPreservationMode Mode);
+public sealed record ScriptInjectionOption(string Label, bool IsEnabledForSelection);
 
 public partial class PatchViewModel : ObservableObject
 {
@@ -35,6 +36,9 @@ public partial class PatchViewModel : ObservableObject
     private DexPreservationOption _selectedDexPreservationOption = new("Disabled (default)", DexPreservationMode.Disabled);
 
     [ObservableProperty]
+    private ScriptInjectionOption _selectedScriptInjectionOption = new("Inject frida-gadget", false);
+
+    [ObservableProperty]
     private string _consoleLog;
 
     [ObservableProperty]
@@ -55,6 +59,11 @@ public partial class PatchViewModel : ObservableObject
         new("Replace all dex (dangerous)", DexPreservationMode.ReplaceAllDexFiles)
     ];
 
+    public IReadOnlyList<ScriptInjectionOption> ScriptInjectionOptions { get; } =
+    [
+        new("Inject frida-gadget", false)
+    ];
+
     public PatchViewModel(
         IFilePickerService filePickerService,
         ISettingsService settingsService,
@@ -69,6 +78,7 @@ public partial class PatchViewModel : ObservableObject
         _consoleLog = Properties.Resources.WaitingForCommand;
 
         SelectedDexPreservationOption = DexPreservationOptions[0];
+        SelectedScriptInjectionOption = ScriptInjectionOptions[0];
 
         OutputFolderPath = EnsureCompiledDirectory();
         OutputApkName = "patched.apk";
@@ -102,6 +112,7 @@ public partial class PatchViewModel : ObservableObject
     partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
     partial void OnSignApkChanged(bool value) => UpdateCommandPreview();
     partial void OnSelectedDexPreservationOptionChanged(DexPreservationOption value) => UpdateCommandPreview();
+    partial void OnSelectedScriptInjectionOptionChanged(ScriptInjectionOption value) => UpdateCommandPreview();
 
     [RelayCommand]
     private async Task BrowseApk()
@@ -183,6 +194,7 @@ public partial class PatchViewModel : ObservableObject
             };
 
             AppendLog(BuildRunSummary(request));
+            AppendLog($"[INFO] Script profile: {SelectedScriptInjectionOption.Label}");
 
             var result = await _patchPipelineService.RunAsync(request);
 
@@ -290,6 +302,7 @@ public partial class PatchViewModel : ObservableObject
         builder.AppendLine("Decode resources: True (required)");
         builder.AppendLine("Decode sources: True (required)");
         builder.AppendLine("Use AAPT2: False (default)");
+        builder.AppendLine($"Script profile: {SelectedScriptInjectionOption.Label}");
         builder.AppendLine($"Dex preservation: {SelectedDexPreservationOption.Label}");
         builder.Append($"Sign output: {SignApk}");
         ConsoleLog = builder.ToString();


### PR DESCRIPTION
### Motivation
- Introduce a future-extensible "Script profile" control in the patching UI so users can pick a script injection policy (initially only frida-gadget) above the existing DEX preservation setting.
- Surface the chosen script profile in the console preview and run output so the pipeline run clearly records which script profile will be applied.

### Description
- Added a `ScriptInjectionOption` record and `ScriptInjectionOptions` list in `PatchViewModel`, and introduced `SelectedScriptInjectionOption` property initialized to `Inject frida-gadget`.
- Bound the new `Script profile` `ComboBox` in `src/PulseAPK.Avalonia/Views/PatchView.axaml` to `ScriptInjectionOptions` / `SelectedScriptInjectionOption` and set it `IsEnabled="False"` so it appears grayed out currently.
- Updated `UpdateCommandPreview()` to include the selected script profile and appended an `[INFO] Script profile: ...` log entry when a patch run is started.
- Changes are confined to `src/PulseAPK.Core/ViewModels/PatchViewModel.cs` and `src/PulseAPK.Avalonia/Views/PatchView.axaml` and are structured to allow adding more script profiles later.

### Testing
- Ran `dotnet build PulseAPK.sln -v minimal`, which failed in this environment because the `.NET SDK` is not installed (`dotnet: command not found`).
- Attempted a UI capture via the repository browser tooling (`mcp__browser_tools__run_playwright_script`), which timed out because the change targets an Avalonia desktop UI and no web endpoint was available to capture.
- No automated unit tests were executed due to the environment limitations described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8175a20fc8322becc5c352317d250)