### PR TITLE
Localize untranslated strings in Patch APK tab

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -7,7 +7,7 @@
     <Grid RowDefinitions="Auto,Auto,Auto,*"
           RowSpacing="16"
           Margin="20">
-        <TextBlock Text="Patch APK"
+        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchHeader]}"
                    FontSize="24"
                    FontWeight="SemiBold" />
 
@@ -19,7 +19,7 @@
                 Padding="12">
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                 <StackPanel Spacing="6">
-                    <TextBlock Text="Select APK"
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
                                FontWeight="SemiBold" />
                     <TextBox Text="{Binding ApkPath}"
                              Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApkPathPlaceholder]}"
@@ -52,9 +52,9 @@
 
         <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
             <StackPanel Spacing="8">
-                <CheckBox Content="Sign output APK (ubersigner)"
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
                           IsChecked="{Binding SignApk}" />
-                <TextBlock Text="Script profile"
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptProfile]}"
                            FontWeight="SemiBold"
                            Margin="0,8,0,0" />
                 <ComboBox ItemsSource="{Binding ScriptInjectionOptions}"
@@ -66,7 +66,7 @@
                         </DataTemplate>
                     </ComboBox.ItemTemplate>
                 </ComboBox>
-                <TextBlock Text="DEX preservation mode"
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchDexPreservationMode]}"
                            FontWeight="SemiBold"
                            Margin="0,8,0,0" />
                 <ComboBox ItemsSource="{Binding DexPreservationOptions}"
@@ -79,7 +79,7 @@
                 </ComboBox>
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
-                <TextBlock Text="Output"
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputLabel]}"
                            FontWeight="SemiBold" />
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
                     <TextBox Text="{Binding OutputFolderPath}" />
@@ -88,7 +88,8 @@
                             Command="{Binding BrowseOutputFolderCommand}"
                             Width="100" />
                 </Grid>
-                <TextBox Text="{Binding OutputApkName}" Watermark="patched.apk" />
+                <TextBox Text="{Binding OutputApkName}"
+                         Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputApkNamePlaceholder]}" />
             </StackPanel>
         </Grid>
 

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -316,6 +316,106 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Tip: Click Browse to choose a project folder.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Patch APK</value>
+  </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Patch APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Sign output APK (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Script profile</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>DEX preservation mode</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Output</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Inject frida-gadget</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Disabled (default)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Preserve unmodified secondary dex</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Replace all dex (dangerous)</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Please select an APK file to patch.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>Missing APK</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Replace all dex can discard injected smali changes. Continue only if you understand this risk.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Dangerous dex replacement</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] Dangerous dex replacement was cancelled by user.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Starting patch pipeline...</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>Patched APK created: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Patch completed successfully.
+Output: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Patch complete</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Patch failed. See console output for details.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Patch failed</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Patch preview:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>Input APK: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;select apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>Output APK: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;output apk&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Decode resources: True (required)</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Decode sources: True (required)</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Use AAPT2: False (default)</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Script profile: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Dex preservation: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Sign output: {0}</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Theme</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -316,6 +316,106 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Подсказка: нажмите «Обзор», чтобы выбрать папку проекта.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Патч APK</value>
+  </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Патч APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Подписывать выходной APK (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Профиль скрипта</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>Режим сохранения DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Вывод</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Внедрить frida-gadget</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Отключено (по умолчанию)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Сохранять неизменённые secondary dex</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Заменить все dex (опасно)</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Пожалуйста, выберите APK-файл для патча.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>APK не выбран</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Режим замены всех dex может отбросить внедрённые smali-изменения. Продолжайте только если понимаете риск.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Опасная замена dex</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] Опасная замена dex отменена пользователем.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Запуск конвейера патчинга...</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>Создан патченный APK: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Патчинг успешно завершён.
+Выходной файл: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Патчинг завершён</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Патчинг не удался. Подробности смотрите в консоли.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Сбой патчинга</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Предпросмотр патча:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>Входной APK: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;выберите apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>Выходной APK: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;выходной apk&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Декодирование ресурсов: True (обязательно)</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Декодирование исходников: True (обязательно)</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Использование AAPT2: False (по умолчанию)</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Профиль скрипта: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Сохранение dex: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Подпись результата: {0}</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Тема</value>
   </data>

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -23,7 +23,7 @@ public partial class MainViewModel : ObservableObject
 
     public string MenuDecompileLabel => _localizationService["MenuDecompile"];
     public string MenuBuildLabel => _localizationService["MenuBuild"];
-    public string MenuPatchLabel => "Patch APK";
+    public string MenuPatchLabel => _localizationService["MenuPatch"];
     public string MenuAnalyserLabel => _localizationService["MenuAnalyser"];
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
@@ -113,6 +113,7 @@ public partial class MainViewModel : ObservableObject
         WindowTitle = _localizationService["AppTitle"];
         OnPropertyChanged(nameof(MenuDecompileLabel));
         OnPropertyChanged(nameof(MenuBuildLabel));
+        OnPropertyChanged(nameof(MenuPatchLabel));
         OnPropertyChanged(nameof(MenuAnalyserLabel));
         OnPropertyChanged(nameof(MenuSettingsLabel));
         OnPropertyChanged(nameof(MenuAboutLabel));

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -49,31 +49,38 @@ public partial class PatchViewModel : ObservableObject
     private readonly ISettingsService _settingsService;
     private readonly IPatchPipelineService _patchPipelineService;
     private readonly IDialogService _dialogService;
+    private readonly LocalizationService _localizationService;
 
     public bool IsHintVisible => string.IsNullOrWhiteSpace(ApkPath);
 
-    public IReadOnlyList<DexPreservationOption> DexPreservationOptions { get; } =
-    [
-        new("Disabled (default)", DexPreservationMode.Disabled),
-        new("Preserve unmodified secondary dex", DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles),
-        new("Replace all dex (dangerous)", DexPreservationMode.ReplaceAllDexFiles)
-    ];
+    public IReadOnlyList<DexPreservationOption> DexPreservationOptions { get; }
 
-    public IReadOnlyList<ScriptInjectionOption> ScriptInjectionOptions { get; } =
-    [
-        new("Inject frida-gadget", false)
-    ];
+    public IReadOnlyList<ScriptInjectionOption> ScriptInjectionOptions { get; }
 
     public PatchViewModel(
         IFilePickerService filePickerService,
         ISettingsService settingsService,
         IPatchPipelineService patchPipelineService,
-        IDialogService dialogService)
+        IDialogService dialogService,
+        LocalizationService localizationService)
     {
         _filePickerService = filePickerService;
         _settingsService = settingsService;
         _patchPipelineService = patchPipelineService;
         _dialogService = dialogService;
+        _localizationService = localizationService;
+
+        DexPreservationOptions =
+        [
+            new(L("PatchDexDisabledDefault"), DexPreservationMode.Disabled),
+            new(L("PatchDexPreserveUnmodifiedSecondary"), DexPreservationMode.PreserveUnmodifiedSecondaryDexFiles),
+            new(L("PatchDexReplaceAllDangerous"), DexPreservationMode.ReplaceAllDexFiles)
+        ];
+
+        ScriptInjectionOptions =
+        [
+            new(L("PatchScriptInjectFridaGadget"), false)
+        ];
 
         _consoleLog = Properties.Resources.WaitingForCommand;
 
@@ -81,7 +88,7 @@ public partial class PatchViewModel : ObservableObject
         SelectedScriptInjectionOption = ScriptInjectionOptions[0];
 
         OutputFolderPath = EnsureCompiledDirectory();
-        OutputApkName = "patched.apk";
+        OutputApkName = L("PatchOutputApkNamePlaceholder");
         UpdateOutputApkPath();
         UpdateCommandPreview();
     }
@@ -148,7 +155,7 @@ public partial class PatchViewModel : ObservableObject
     {
         if (string.IsNullOrWhiteSpace(ApkPath))
         {
-            await _dialogService.ShowWarningAsync("Please select an APK file to patch.", "Missing APK");
+            await _dialogService.ShowWarningAsync(L("PatchErrorSelectApk"), L("PatchErrorMissingApkTitle"));
             return;
         }
 
@@ -164,17 +171,17 @@ public partial class PatchViewModel : ObservableObject
         if (selectedDexMode == DexPreservationMode.ReplaceAllDexFiles)
         {
             confirmedDangerousDexMode = await _dialogService.ShowQuestionAsync(
-                "Replace all dex can discard injected smali changes. Continue only if you understand this risk.",
-                "Dangerous dex replacement");
+                L("PatchDangerousDexConfirmation"),
+                L("PatchDangerousDexTitle"));
             if (!confirmedDangerousDexMode)
             {
-                AppendLog("[WARN] Dangerous dex replacement was cancelled by user.");
+                AppendLog(L("PatchLogDangerousDexCancelled"));
                 return;
             }
         }
 
         IsRunning = true;
-        SetConsoleLog("Starting patch pipeline...");
+        SetConsoleLog(L("PatchLogStartingPipeline"));
 
         try
         {
@@ -211,8 +218,8 @@ public partial class PatchViewModel : ObservableObject
 
             if (result.Success)
             {
-                AppendLog($"Patched APK created: {result.OutputApkPath}");
-                await _dialogService.ShowInfoAsync($"Patch completed successfully.\nOutput: {result.OutputApkPath}", "Patch complete");
+                AppendLog(string.Format(L("PatchLogCreated"), result.OutputApkPath));
+                await _dialogService.ShowInfoAsync(string.Format(L("PatchInfoCompleteMessage"), result.OutputApkPath), L("PatchInfoCompleteTitle"));
             }
             else
             {
@@ -221,13 +228,13 @@ public partial class PatchViewModel : ObservableObject
                     AppendLog($"[ERROR] {error}");
                 }
 
-                await _dialogService.ShowErrorAsync("Patch failed. See console output for details.", "Patch failed");
+                await _dialogService.ShowErrorAsync(L("PatchErrorFailedMessage"), L("PatchErrorFailedTitle"));
             }
         }
         catch (Exception ex)
         {
             AppendLog($"[ERROR] {ex.Message}");
-            await _dialogService.ShowErrorAsync(ex.Message, "Patch failed");
+            await _dialogService.ShowErrorAsync(ex.Message, L("PatchErrorFailedTitle"));
         }
         finally
         {
@@ -273,7 +280,7 @@ public partial class PatchViewModel : ObservableObject
 
     private void AppendLog(string message)
     {
-        if (string.IsNullOrWhiteSpace(ConsoleLog) || ConsoleLog == "Waiting for command...")
+        if (string.IsNullOrWhiteSpace(ConsoleLog) || ConsoleLog == Properties.Resources.WaitingForCommand)
         {
             ConsoleLog = message;
         }
@@ -296,17 +303,20 @@ public partial class PatchViewModel : ObservableObject
         }
 
         var builder = new StringBuilder();
-        builder.AppendLine("Patch preview:");
-        builder.AppendLine($"Input APK: {(string.IsNullOrWhiteSpace(ApkPath) ? "<select apk>" : ApkPath)}");
-        builder.AppendLine($"Output APK: {(string.IsNullOrWhiteSpace(OutputApkPath) ? "<output apk>" : OutputApkPath)}");
-        builder.AppendLine("Decode resources: True (required)");
-        builder.AppendLine("Decode sources: True (required)");
-        builder.AppendLine("Use AAPT2: False (default)");
-        builder.AppendLine($"Script profile: {SelectedScriptInjectionOption.Label}");
-        builder.AppendLine($"Dex preservation: {SelectedDexPreservationOption.Label}");
-        builder.Append($"Sign output: {SignApk}");
+        builder.AppendLine(L("PatchPreviewHeader"));
+        builder.AppendLine(string.Format(L("PatchPreviewInputApk"), string.IsNullOrWhiteSpace(ApkPath) ? L("PatchPreviewSelectApk") : ApkPath));
+        builder.AppendLine(string.Format(L("PatchPreviewOutputApk"), string.IsNullOrWhiteSpace(OutputApkPath) ? L("PatchPreviewOutputApkPlaceholder") : OutputApkPath));
+        builder.AppendLine(L("PatchPreviewDecodeResources"));
+        builder.AppendLine(L("PatchPreviewDecodeSources"));
+        builder.AppendLine(L("PatchPreviewUseAapt2"));
+        builder.AppendLine(string.Format(L("PatchPreviewScriptProfile"), SelectedScriptInjectionOption.Label));
+        builder.AppendLine(string.Format(L("PatchPreviewDexPreservation"), SelectedDexPreservationOption.Label));
+        builder.Append(string.Format(L("PatchPreviewSignOutput"), SignApk));
         ConsoleLog = builder.ToString();
     }
+
+
+    private string L(string key) => _localizationService[key];
 
     private static string BuildRunSummary(PatchRequest request)
     {


### PR DESCRIPTION
### Motivation
- The Patch APK tab contained hardcoded English strings, causing mixed-language UI when a non-English locale (e.g. Russian) is selected. 
- The goal is to route all Patch-related UI labels, preview text and dialog messages through the existing `LocalizationService` so translations are used consistently. 
- Add resource keys for the Patch flow so other locales can provide translations and the UI will fall back to English when needed.

### Description
- Updated `src/PulseAPK.Avalonia/Views/PatchView.axaml` to bind header, section labels, checkbox text, output label and APK name watermark to `LocalizationService` keys instead of hardcoded literals. 
- Reworked `src/PulseAPK.Core/ViewModels/PatchViewModel.cs` to consume `LocalizationService` for option labels, preview text, and patch-related dialog/warning/info strings, added a small `L(string)` helper and injected `LocalizationService` into the view model. 
- Updated `src/PulseAPK.Core/ViewModels/MainViewModel.cs` to localize the Patch menu label and trigger property refresh when the language changes. 
- Added new localization keys to `src/PulseAPK.Core/Properties/Resources.resx` and `src/PulseAPK.Core/Properties/Resources.ru-RU.resx` for all patch-specific UI strings, preview lines and dialog texts so Russian translations (and English defaults) are available.

### Testing
- Validated the updated `.resx` files by parsing them with Python `xml.etree.ElementTree`, which succeeded for both `Resources.resx` and `Resources.ru-RU.resx`. 
- Attempted to run the unit test command `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj`, but the `dotnet` CLI is not available in this environment so the project tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b819c1c30c8322bb58db6eb7585ba7)