### PR TITLE
Add missing Patch APK tab translations across locales

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>تلميح: انقر على "استعراض" لاختيار مجلد المشروع.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>ترقيع APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>توقيع APK الناتج (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>ملف تعريف السكربت</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>وضع الحفاظ على DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>المخرجات</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>معطّل (افتراضي)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>الحفاظ على dex الثانوي غير المعدّل</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>استبدال كل dex (خطير)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>السمة</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Tipp: Klicken Sie auf „Durchsuchen“, um einen Projektordner auszuwählen.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>APK patchen</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Ausgabe-APK signieren (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Skriptprofil</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>DEX-Erhaltungsmodus</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Ausgabe</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Deaktiviert (Standard)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Unveränderte sekundäre DEX beibehalten</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Alle DEX ersetzen (gefährlich)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Thema</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Sugerencia: haz clic en Examinar para seleccionar una carpeta de proyecto.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Parchear APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Firmar APK de salida (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Perfil de script</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>Modo de preservación de DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Salida</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Desactivado (predeterminado)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Conservar DEX secundario sin modificar</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Reemplazar todos los DEX (peligroso)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Tema</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Astuce : cliquez sur Parcourir pour choisir un dossier de projet.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Patcher l'APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Signer l'APK de sortie (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Profil de script</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>Mode de préservation DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Sortie</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Désactivé (par défaut)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Préserver les DEX secondaires non modifiés</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Remplacer tous les DEX (dangereux)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Thème</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Dica: clique em Procurar para escolher uma pasta de projeto.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Aplicar patch no APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Assinar APK de saída (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Perfil de script</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>Modo de preservação de DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Saída</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Desativado (padrão)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Preservar DEX secundário não modificado</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Substituir todos os DEX (perigoso)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Tema</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>Порада: натисніть «Огляд», щоб вибрати папку проєкту.</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>Патчити APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>Підписувати вихідний APK (ubersigner)</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>Профіль скрипту</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>Режим збереження DEX</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>Вивід</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>Вимкнено (типово)</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>Зберігати незмінені secondary DEX</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>Замінити всі DEX (небезпечно)</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>Тема</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -316,6 +316,30 @@
   <data name="BrowseProjectFolderTip" xml:space="preserve">
     <value>提示：点击“浏览”以选择项目文件夹。</value>
   </data>
+  <data name="PatchHeader" xml:space="preserve">
+    <value>修补 APK</value>
+  </data>
+  <data name="PatchSignOutputApk" xml:space="preserve">
+    <value>签名输出 APK（ubersigner）</value>
+  </data>
+  <data name="PatchScriptProfile" xml:space="preserve">
+    <value>脚本配置</value>
+  </data>
+  <data name="PatchDexPreservationMode" xml:space="preserve">
+    <value>DEX 保留模式</value>
+  </data>
+  <data name="PatchOutputLabel" xml:space="preserve">
+    <value>输出</value>
+  </data>
+  <data name="PatchDexDisabledDefault" xml:space="preserve">
+    <value>禁用（默认）</value>
+  </data>
+  <data name="PatchDexPreserveUnmodifiedSecondary" xml:space="preserve">
+    <value>保留未修改的次要 DEX</value>
+  </data>
+  <data name="PatchDexReplaceAllDangerous" xml:space="preserve">
+    <value>替换所有 DEX（危险）</value>
+  </data>
   <data name="ThemeLabel" xml:space="preserve">
     <value>主题</value>
   </data>


### PR DESCRIPTION
### Motivation

- Several non-Russian locales were missing localization keys for the Patch APK tab, causing UI labels to fall back to English; this change adds the requested translations for `Script profile`, `Output`, `Sign output APK`, `DEX preservation mode` and its option strings. 
- `PatchHeader` was also missing in those locales so the tab title was not localized, which is addressed by this update.

### Description

- Added the following resource keys and translations to the locale files: `PatchHeader`, `PatchSignOutputApk`, `PatchScriptProfile`, `PatchDexPreservationMode`, `PatchOutputLabel`, `PatchDexDisabledDefault`, `PatchDexPreserveUnmodifiedSecondary`, and `PatchDexReplaceAllDangerous`.
- Updated the resource files: `src/PulseAPK.Core/Properties/Resources.ar-SA.resx`, `Resources.de-DE.resx`, `Resources.es-ES.resx`, `Resources.fr-FR.resx`, `Resources.pt-BR.resx`, `Resources.uk-UA.resx`, and `Resources.zh-CN.resx` with the new strings.
- Changes were inserted near the existing UI labels block to keep resource ordering consistent and committed to the repository.

### Testing

- Ran a Python resource-check script that verifies the required `Patch*` keys exist in each updated locale file and it reported all updated files as `OK`.
- Attempted `dotnet build PulseAPK.sln` to validate the project but the `dotnet` CLI is unavailable in this environment, so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81c467680832283a93cc5ffaadd5e)