### PR TITLE
Update Russian text for Patch APK menu and header

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -317,10 +317,10 @@
     <value>Подсказка: нажмите «Обзор», чтобы выбрать папку проекта.</value>
   </data>
   <data name="MenuPatch" xml:space="preserve">
-    <value>Патч APK</value>
+    <value>Пропатчить APK</value>
   </data>
   <data name="PatchHeader" xml:space="preserve">
-    <value>Патч APK</value>
+    <value>Пропатчить APK</value>
   </data>
   <data name="PatchSignOutputApk" xml:space="preserve">
     <value>Подписывать выходной APK (ubersigner)</value>


### PR DESCRIPTION
### Motivation
- Change the Russian localization from the noun phrase to the verb phrase so the menu and tab header read as an action (`Пропатчить APK`) instead of `Патч APK`.

### Description
- Updated `MenuPatch` value in `src/PulseAPK.Core/Properties/Resources.ru-RU.resx` from `Патч APK` to `Пропатчить APK`.
- Updated `PatchHeader` value in `src/PulseAPK.Core/Properties/Resources.ru-RU.resx` from `Патч APK` to `Пропатчить APK`.
- No other resource keys or languages were modified.

### Testing
- Ran `rg -n "Патч APK|Patch APK|Пропатчить APK" .` to locate occurrences and confirmed the updated values; command succeeded.
- Inspected the file region with `nl -ba src/PulseAPK.Core/Properties/Resources.ru-RU.resx | sed -n '316,328p'` to verify replacements; command succeeded.
- Committed the change with `git commit -m "Update Russian Patch APK label text"`; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81e5f275883228a61e9c4e7e0c096)