### PR TITLE
Normalize Frida helper signature for static onCreate calls

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -282,15 +282,14 @@ public sealed class SmaliPatchService : ISmaliPatchService
             return content;
         }
 
-        var modifiers = match.Groups["modifiers"].Value;
-        if (Regex.IsMatch(modifiers, @"(^|\s)static(\s|$)"))
-        {
-            return content;
-        }
-
-        var normalizedModifiers = string.Join(" ", modifiers.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        var modifiers = match.Groups["modifiers"].Value
+            .Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)
+            .Where(token => !string.Equals(token, "static", StringComparison.Ordinal))
+            .ToList();
+        modifiers.Add("static");
+        var normalizedModifiers = string.Join(" ", modifiers);
         var indent = match.Groups["indent"].Value;
-        var updatedSignature = $"{indent}.method {normalizedModifiers} static {methodName}()V";
+        var updatedSignature = $"{indent}.method {normalizedModifiers} {methodName}()V";
         return content[..match.Index] + updatedSignature + content[(match.Index + match.Length)..];
     }
 

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -350,6 +350,43 @@ public class SmaliPatchServiceTests
         Assert.DoesNotContain(".method private loadFridaGadget ()V", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task PatchAsync_NormalizesExistingStaticHelperSignature_WhenInvokeStaticIsUsedInOnCreate()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-static-helper-spaced-signature-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "zed", "rainxch", "githubstore");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lzed/rainxch/githubstore/MainActivity;
+.super Landroid/app/Activity;
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 0
+    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
+    invoke-static {}, Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V
+    return-void
+.end method
+
+.method private static loadFridaGadget ()V
+    .locals 1
+    const-string v0, ""frida-gadget""
+    invoke-static {v0}, Ljava/lang/System;->loadLibrary(Ljava/lang/String;)V
+    return-void
+.end method
+
+.end class");
+
+        var service = new SmaliPatchService();
+        var result = await service.PatchAsync(root, "zed.rainxch.githubstore.MainActivity", useDelayedLoad: false);
+        var output = await File.ReadAllTextAsync(file);
+
+        Assert.True(result.Success);
+        Assert.Contains("invoke-static {}, Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V", output, StringComparison.Ordinal);
+        Assert.Contains(".method private static loadFridaGadget()V", output, StringComparison.Ordinal);
+        Assert.DoesNotContain(".method private static loadFridaGadget ()V", output, StringComparison.Ordinal);
+    }
+
 
     [Fact]
     public async Task PatchAsync_AcceptsTabIndentedEndClassAndExistingStaticHelper()


### PR DESCRIPTION
### Motivation
- Ensure injected `invoke-static` calls (e.g. in `onCreate`) have a byte-for-byte matching helper definition signature in the same class.
- Normalize irregular/static helper declarations (extra spaces or variant ordering) so the method descriptor is canonical (`loadFridaGadget()V` / `loadFridaGadgetIfNeeded()V`).
- Prevent mismatches between call sites and definitions that could break smali patches or leave inconsistent outputs.

### Description
- Reworked `EnsureHelperMethodIsStatic` to parse existing modifier tokens, remove duplicate `static` tokens, append a single `static` token and emit a canonical signature format using `"{methodName}()V"` so spacing is normalized. (`src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs`)
- Removed the previous early-return for already-static declarations and replaced it with normalization logic that handles spaces and tabs when splitting modifiers.
- Adjusted the emitted updated signature to avoid duplicating the `static` token in the output signature.
- Added a regression unit test `PatchAsync_NormalizesExistingStaticHelperSignature_WhenInvokeStaticIsUsedInOnCreate` that exercises `Lzed/rainxch/githubstore/MainActivity;` where `onCreate` contains an injected `invoke-static` and the existing helper is declared as `.method private static loadFridaGadget ()V`, asserting normalization to `.method private static loadFridaGadget()V`. (`tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs`)

### Testing
- Attempted to run unit tests with `dotnet test tests/unit/PulseAPK.Tests/ --filter SmaliPatchServiceTests`, but the command could not be executed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- Added new regression test verifying normalization behavior; test added but not executed here due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec5543a788322875880fa74235bd8)