### PR TITLE
Deterministic onCreate injection using invoke-super anchor

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -326,13 +326,21 @@ public sealed class SmaliPatchService : ISmaliPatchService
             }
 
             var call = "    invoke-static {}, " + classDescriptor + $"->{helperMethodName}()V";
-            var superCallPattern = new Regex($@"(?m)^\s*invoke-super \{{[^\n]+\}}, [^\n]+->{methodName}{Regex.Escape(methodSignature)}\s*$");
-            if (superCallPattern.IsMatch(body))
+            var superCallPattern = new Regex($@"(?m)^(?<indent>\s*)invoke-super \{{[^\n]+\}}, [^\n]+->{methodName}{Regex.Escape(methodSignature)}\s*$");
+            var superCallMatch = superCallPattern.Match(body);
+            if (superCallMatch.Success)
             {
-                body = superCallPattern.Replace(body, m => m.Value + Environment.NewLine + call, 1);
+                var superCallEndIndex = superCallMatch.Index + superCallMatch.Length;
+                var callLine = Environment.NewLine + superCallMatch.Groups["indent"].Value + call.TrimStart();
+                body = body.Insert(superCallEndIndex, callLine);
             }
             else
             {
+                if (methodName == "onCreate")
+                {
+                    return content;
+                }
+
                 var split = body.Split(Environment.NewLine);
                 var insertAt = Array.FindIndex(split, line => line.TrimStart().StartsWith(".locals", StringComparison.Ordinal) || line.TrimStart().StartsWith(".registers", StringComparison.Ordinal));
                 if (insertAt >= 0)

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -445,4 +445,61 @@ public class SmaliPatchServiceTests
         Assert.Equal("Patched smali references Frida helper methods that are missing static definitions.", result.Error);
     }
 
+    [Fact]
+    public async Task PatchAsync_InsertsImmediateLoadCallImmediatelyAfterSuperOnCreate()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-deterministic-oncreate-anchor-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+.super Landroid/app/Activity;
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 1
+    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
+    const/4 v0, 0x0
+    invoke-virtual {p0, v0}, Lcom/example/MainActivity;->setRequestedOrientation(I)V
+    return-void
+.end method
+
+.end class");
+
+        var service = new SmaliPatchService();
+        var result = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+        var output = await File.ReadAllTextAsync(file);
+
+        Assert.True(result.Success);
+        Assert.Contains(
+            "invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V\n    invoke-static {}, Lcom/example/MainActivity;->loadFridaGadget()V\n    const/4 v0, 0x0",
+            output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PatchAsync_FailsWhenOnCreateHasNoSuperOnCreateAnchor()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"smali-patch-missing-oncreate-anchor-{Guid.NewGuid():N}");
+        var smaliPath = Path.Combine(root, "smali", "com", "example");
+        Directory.CreateDirectory(smaliPath);
+
+        var file = Path.Combine(smaliPath, "MainActivity.smali");
+        await File.WriteAllTextAsync(file, @".class public Lcom/example/MainActivity;
+.super Landroid/app/Activity;
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 0
+    return-void
+.end method
+
+.end class");
+
+        var service = new SmaliPatchService();
+        var result = await service.PatchAsync(root, "com.example.MainActivity", useDelayedLoad: false);
+
+        Assert.False(result.Success);
+        Assert.Equal("Unable to find an injection point in activity smali file.", result.Error);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Ensure the helper invocation is inserted immediately after the `super.onCreate(...)` call so it runs before app logic and does not accidentally expand try/catch or label scopes. 
- Avoid non-deterministic fallback insertion for `onCreate` that could break method register/local declarations or alter existing label/indent flow.

### Description
- Updated `SmaliPatchService.InjectCallIntoLifecycleMethod` to match `invoke-super ...->onCreate(Landroid/os/Bundle;)V` with a capturing `indent` group and insert the `invoke-static` helper immediately after that exact anchor while preserving indentation. 
- Added a guard to prevent the `.locals/.registers` fallback insertion for `onCreate`, returning unchanged content when no `super-onCreate` anchor is found. 
- Kept existing behavior for `onResume` and for other insertion fallbacks untouched, and preserved method/register signatures and label flow. 
- Added two unit tests in `SmaliPatchServiceTests`: `PatchAsync_InsertsImmediateLoadCallImmediatelyAfterSuperOnCreate` and `PatchAsync_FailsWhenOnCreateHasNoSuperOnCreateAnchor` to verify deterministic insertion and failure behavior.

### Testing
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs` covering the new deterministic insertion and the missing-anchor failure. 
- Attempted to run `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter SmaliPatchServiceTests` but the command could not be executed in this environment because `dotnet` is not installed, so tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec6db266483229da11d535fcf69ba)