### PR TITLE
Verify patched loadFridaGadget survives rebuild/signing in final dex

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -66,6 +66,7 @@ public partial class App : Application
         services.AddTransient<ISmaliPatchService, SmaliPatchService>();
         services.AddTransient<IDexMergeService, DexMergeService>();
         services.AddTransient<ISigningService, SigningService>();
+        services.AddTransient<IFinalDexInspectionService, FinalDexInspectionService>();
         services.AddTransient<IPatchPipelineService, PatchPipelineService>();
 
         // Avalonia Services

--- a/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
@@ -1,0 +1,6 @@
+namespace PulseAPK.Core.Abstractions.Patching;
+
+public interface IFinalDexInspectionService
+{
+    Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default);
+}

--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -1,0 +1,38 @@
+using System.IO.Compression;
+using System.Text;
+using PulseAPK.Core.Abstractions.Patching;
+
+namespace PulseAPK.Core.Services.Patching;
+
+public sealed class FinalDexInspectionService : IFinalDexInspectionService
+{
+    public async Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(apkPath) || !File.Exists(apkPath))
+        {
+            return false;
+        }
+
+        using var stream = File.OpenRead(apkPath);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+
+        var dexEntries = archive.Entries
+            .Where(entry => entry.FullName.StartsWith("classes", StringComparison.OrdinalIgnoreCase) &&
+                            entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var dexEntry in dexEntries)
+        {
+            await using var dexStream = dexEntry.Open();
+            using var buffer = new MemoryStream();
+            await dexStream.CopyToAsync(buffer, cancellationToken);
+
+            var dexText = Encoding.Latin1.GetString(buffer.ToArray());
+            if (dexText.Contains(methodReference, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -15,6 +15,7 @@ public sealed class PatchPipelineService : IPatchPipelineService
     private readonly ISmaliPatchService _smaliPatchService;
     private readonly IDexMergeService _dexMergeService;
     private readonly ISigningService _signingService;
+    private readonly IFinalDexInspectionService _finalDexInspectionService;
 
     public PatchPipelineService(
         PatchRequestValidatorService requestValidator,
@@ -26,7 +27,8 @@ public sealed class PatchPipelineService : IPatchPipelineService
         IGadgetInjectionService gadgetInjectionService,
         ISmaliPatchService smaliPatchService,
         IDexMergeService dexMergeService,
-        ISigningService signingService)
+        ISigningService signingService,
+        IFinalDexInspectionService finalDexInspectionService)
     {
         _requestValidator = requestValidator;
         _architectureDetectionService = architectureDetectionService;
@@ -38,6 +40,7 @@ public sealed class PatchPipelineService : IPatchPipelineService
         _smaliPatchService = smaliPatchService;
         _dexMergeService = dexMergeService;
         _signingService = signingService;
+        _finalDexInspectionService = finalDexInspectionService;
     }
 
     public async Task<PatchResult> RunAsync(PatchRequest request, CancellationToken cancellationToken = default)
@@ -195,6 +198,8 @@ public sealed class PatchPipelineService : IPatchPipelineService
                 result.StageSummaries.Add(new PatchStageSummary("dex-preservation", true, dexMessage));
             }
 
+            var finalArtifactPath = request.OutputApkPath;
+
             if (request.SignOutput)
             {
                 var signedPath = GetSignedPath(request.OutputApkPath);
@@ -210,17 +215,32 @@ public sealed class PatchPipelineService : IPatchPipelineService
                 }
 
                 result.StageSummaries.Add(new PatchStageSummary("signing", true, "Signed APK created."));
-                result.Success = true;
-                result.UsedSigning = true;
-                result.OutputApkPath = signResult.SignedApkPath;
-                result.SelectedArchitecture = architecture;
-                return result;
+                finalArtifactPath = signResult.SignedApkPath!;
+            }
+
+            if (smaliInjectionApplied)
+            {
+                var classDescriptor = ToClassDescriptor(activityName);
+                var methodReference = $"{classDescriptor}->loadFridaGadget()V";
+                var foundInFinalDex = await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
+                if (!foundInFinalDex)
+                {
+                    const string guidance = "Smali helper was present during patching but missing in the final DEX artifact. Ensure smali mutation runs after any transform that regenerates classes.dex, or disable that transform for patched classes.";
+                    result.Errors.Add($"Final DEX verification failed: '{methodReference}' was not found. {guidance}");
+                    result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, guidance));
+                    result.OutputApkPath = finalArtifactPath;
+                    result.SelectedArchitecture = architecture;
+                    result.UsedSigning = request.SignOutput;
+                    return result;
+                }
+
+                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, $"Confirmed '{methodReference}' in final APK dex."));
             }
 
             result.Success = true;
-            result.OutputApkPath = request.OutputApkPath;
+            result.OutputApkPath = finalArtifactPath;
             result.SelectedArchitecture = architecture;
-            result.UsedSigning = false;
+            result.UsedSigning = request.SignOutput;
             return result;
         }
         finally
@@ -250,4 +270,7 @@ public sealed class PatchPipelineService : IPatchPipelineService
         var extension = Path.GetExtension(outputApkPath);
         return Path.Combine(directory, $"{name}_signed{extension}");
     }
+
+    private static string ToClassDescriptor(string activityName)
+        => $"L{activityName.Replace('.', '/')};";
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -1,6 +1,8 @@
 using PulseAPK.Core.Abstractions.Patching;
 using PulseAPK.Core.Models;
 using PulseAPK.Core.Services.Patching;
+using System.IO.Compression;
+using System.Text;
 
 namespace PulseAPK.Tests.Services.Patching;
 
@@ -14,7 +16,8 @@ public class PatchPipelineServiceTests
         "manifest-patch",
         "gadget-injection",
         "smali-patch",
-        "build"
+        "build",
+        "dex-verification"
     ];
 
     private static readonly string[] SuccessfulStagesWithSigning =
@@ -26,7 +29,8 @@ public class PatchPipelineServiceTests
         "gadget-injection",
         "smali-patch",
         "build",
-        "signing"
+        "signing",
+        "dex-verification"
     ];
 
     [Fact]
@@ -333,7 +337,40 @@ public class PatchPipelineServiceTests
         Assert.Contains("Signing failed", stage.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(result.Errors, error => error.Contains("Signing failed", StringComparison.OrdinalIgnoreCase));
         Assert.Contains(result.Warnings, warning => warning.Contains("Unsigned rebuilt APK", StringComparison.OrdinalIgnoreCase));
-        AssertStageSequence(result, SuccessfulStagesWithSigning);
+        AssertStageSequence(result,
+        [
+            "architecture",
+            "decompile",
+            "activity-detection",
+            "manifest-patch",
+            "gadget-injection",
+            "smali-patch",
+            "build",
+            "signing"
+        ]);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsFailure_WhenInjectedMethodMissingInFinalDexArtifact()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var pipeline = CreatePipeline(fakeFinalDexInspectionService: new FakeFinalDexInspectionService(containsMethodReference: false));
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = true
+        });
+
+        Assert.False(result.Success);
+        var stage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-verification"));
+        Assert.False(stage.Success);
+        Assert.Contains("regenerates classes.dex", stage.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("loadFridaGadget()V", Assert.Single(result.Errors), StringComparison.Ordinal);
     }
 
     private static void AssertStageSequence(PatchResult result, IReadOnlyList<string> expectedStages)
@@ -346,12 +383,14 @@ public class PatchPipelineServiceTests
         FakeDexMergeService? fakeDexMergeService = null,
         FakeArchitectureService? fakeArchitectureService = null,
         FakeApktoolService? fakeApktoolService = null,
-        FakeSigningService? fakeSigningService = null)
+        FakeSigningService? fakeSigningService = null,
+        FakeFinalDexInspectionService? fakeFinalDexInspectionService = null)
     {
         fakeDexMergeService ??= new FakeDexMergeService(dexMergeShouldFail);
         fakeArchitectureService ??= new FakeArchitectureService();
         fakeApktoolService ??= new FakeApktoolService();
         fakeSigningService ??= new FakeSigningService();
+        fakeFinalDexInspectionService ??= new FakeFinalDexInspectionService();
 
         return new PatchPipelineService(
             new PatchRequestValidatorService(),
@@ -363,7 +402,8 @@ public class PatchPipelineServiceTests
             new FakeGadgetInjectionService(),
             new FakeSmaliPatchService(),
             fakeDexMergeService,
-            fakeSigningService);
+            fakeSigningService,
+            fakeFinalDexInspectionService);
     }
 
     private sealed class FakeArchitectureService : IArchitectureDetectionService
@@ -417,7 +457,11 @@ public class PatchPipelineServiceTests
                 return Task.FromResult(_buildExitCode);
             }
 
-            File.WriteAllText(outputApkPath, "built");
+            using var stream = File.Create(outputApkPath);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: false);
+            var dexEntry = archive.CreateEntry("classes.dex");
+            using var writer = new BinaryWriter(dexEntry.Open(), Encoding.UTF8, leaveOpen: false);
+            writer.Write(Encoding.ASCII.GetBytes("Lcom/example/MainActivity;->loadFridaGadget()V"));
             return Task.FromResult(0);
         }
     }
@@ -483,8 +527,27 @@ public class PatchPipelineServiceTests
         }
 
         public Task<(bool Success, string? SignedApkPath, string? Error)> SignAsync(string inputApkPath, string outputApkPath, CancellationToken cancellationToken = default)
-            => Task.FromResult(_shouldFail
-                ? (false, (string?)null, (string?)"Signing failed in fake service.")
-                : (true, outputApkPath, (string?)null));
+        {
+            if (_shouldFail)
+            {
+                return Task.FromResult((false, (string?)null, (string?)"Signing failed in fake service."));
+            }
+
+            File.Copy(inputApkPath, outputApkPath, overwrite: true);
+            return Task.FromResult((true, (string?)outputApkPath, (string?)null));
+        }
+    }
+
+    private sealed class FakeFinalDexInspectionService : IFinalDexInspectionService
+    {
+        private readonly bool _containsMethodReference;
+
+        public FakeFinalDexInspectionService(bool containsMethodReference = true)
+        {
+            _containsMethodReference = containsMethodReference;
+        }
+
+        public Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
+            => Task.FromResult(_containsMethodReference);
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent cases where smali mutations (the `loadFridaGadget` helper) appear in intermediate smali output but are lost by later transforms or signing, by checking the final APK's DEX contents.

### Description
- Added a new abstraction `IFinalDexInspectionService` and implementation `FinalDexInspectionService` that opens the rebuilt/signed APK and scans `classes*.dex` entries for a literal method reference using `ContainsMethodReferenceAsync`.
- Updated `PatchPipelineService` to inject and use the final-inspection service, verify the patched activity reference `L<activity>;->loadFridaGadget()V` against the final artifact path (signed APK when signing is enabled), and emit a new `dex-verification` stage that fails with remediation guidance if the reference is missing.
- Wired the new service into DI in `App.axaml.cs` and added `ToClassDescriptor` helper for constructing the class descriptor string.
- Expanded `PatchPipelineServiceTests` to include the `dex-verification` stage in expected sequences, added a new test `RunAsync_ReturnsFailure_WhenInjectedMethodMissingInFinalDexArtifact`, and adjusted fakes to create/copy APK zip artifacts with `classes.dex` entries for realistic verification.

### Testing
- Updated unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs` to cover the new `dex-verification` stage and failure case when the final APK lacks the injected method reference.
- Attempted to run the pipeline tests with `dotnet test --filter PatchPipelineServiceTests`, but the test run could not be executed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec8f826fc832288d087df5b0282e8)