### PR TITLE
Disambiguate string.Split in SmaliPatchService to fix CS0121

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -301,7 +301,7 @@ public sealed class SmaliPatchService : ISmaliPatchService
         }
 
         var modifiers = match.Groups["modifiers"].Value
-            .Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)
+            .Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)
             .Where(token => !string.Equals(token, "static", StringComparison.Ordinal))
             .ToList();
         modifiers.Add("static");


### PR DESCRIPTION
### Motivation
- Resolve a compile error `CS0121` in `SmaliPatchService` caused by an ambiguous call to `string.Split` when publishing/building the project.

### Description
- Replace the collection-expression argument in `EnsureHelperMethodIsStatic` with an explicit `char[]` by changing `.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries)` to `.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)` in `src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs`.

### Testing
- Ran the repository build script `./scripts/build-appimage.sh`, which aborted because `dotnet` was not available in `PATH`, so a full compile could not be completed in this environment.
- No automated unit tests were executed here due to the environment limitation preventing a complete build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beca603aa0832280f615b67bfca0fe)