### PR TITLE
Fix smali helper insertion when `.end class` is missing

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
+++ b/src/PulseAPK.Core/Services/Patching/SmaliPatchService.cs
@@ -319,13 +319,18 @@ public sealed class SmaliPatchService : ISmaliPatchService
 
     private static string InsertLinesBeforeEndClass(string content, IReadOnlyList<string> lines)
     {
+        var method = string.Join(Environment.NewLine, lines) + Environment.NewLine;
         var endClassMatch = FindLastEndClassDirective(content);
         if (endClassMatch is null)
         {
-            return content;
+            if (!content.EndsWith(Environment.NewLine, StringComparison.Ordinal))
+            {
+                content += Environment.NewLine;
+            }
+
+            return content + method;
         }
 
-        var method = string.Join(Environment.NewLine, lines) + Environment.NewLine;
         return content.Insert(endClassMatch.Index, method);
     }
 

--- a/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs
@@ -425,7 +425,7 @@ public class SmaliPatchServiceTests
     }
 
     [Fact]
-    public async Task PatchAsync_Fails_WhenLifecycleCallIsInjectedButStaticHelperCannotBeAdded()
+    public async Task PatchAsync_AppendsStaticHelper_WhenEndClassDirectiveIsMissing()
     {
         var root = Path.Combine(Path.GetTempPath(), $"smali-patch-missing-end-class-{Guid.NewGuid():N}");
         var smaliPath = Path.Combine(root, "smali", "com", "app", "damnvulnerablebank");
@@ -444,8 +444,11 @@ public class SmaliPatchServiceTests
         var service = new SmaliPatchService();
         var result = await service.PatchAsync(root, "com.app.damnvulnerablebank.SplashScreen", useDelayedLoad: false);
 
-        Assert.False(result.Success);
-        Assert.Equal("Patched smali references Frida helper methods that are missing static definitions.", result.Error);
+        var output = await File.ReadAllTextAsync(file);
+
+        Assert.True(result.Success);
+        Assert.Contains("invoke-static {}, Lcom/app/damnvulnerablebank/SplashScreen;->loadFridaGadget()V", output, StringComparison.Ordinal);
+        Assert.Contains(".method private static loadFridaGadget()V", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- The smali patcher could inject a call to a static Frida helper but fail to insert the helper definitions when the target smali file lacked a terminating `.end class` directive, causing the pipeline to report missing static definitions.
- The intent is to make helper insertion robust against malformed or truncated smali files so the patch pipeline does not fail after injecting lifecycle calls.

### Description
- Updated `SmaliPatchService.InsertLinesBeforeEndClass` to append helper method/member lines at EOF when `FindLastEndClassDirective` returns `null`, and to normalize trailing newlines before appending to maintain smali formatting.
- Kept the original insertion behavior when an `.end class` directive is present by inserting before the last `.end class` as before.
- Renamed and updated the unit test `PatchAsync_Fails_WhenLifecycleCallIsInjectedButStaticHelperCannotBeAdded` to `PatchAsync_AppendsStaticHelper_WhenEndClassDirectiveIsMissing` and changed its assertions to verify that the injected call and the appended static helper method are present.

### Testing
- Updated `tests/unit/PulseAPK.Tests/Services/Patching/SmaliPatchServiceTests.cs` to reflect the new behavior for files missing `.end class` and ran a targeted test run command `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter "FullyQualifiedName~SmaliPatchServiceTests"` in the environment.
- Automated test execution could not be completed because `dotnet` is not installed in this environment, so the updated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becb83f2c48322abf31d83bc6f5c59)