### PR TITLE
Prefer arm64 ABI when selecting Frida gadget for multi-ABI APKs

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/ArchitectureDetectionService.cs
@@ -6,6 +6,14 @@ namespace PulseAPK.Core.Services.Patching;
 
 public sealed class ArchitectureDetectionService : IArchitectureDetectionService
 {
+    private static readonly string[] ArchitecturePreferenceOrder =
+    [
+        "arm64-v8a",
+        "armeabi-v7a",
+        "x86_64",
+        "x86"
+    ];
+
     private static readonly HashSet<string> SupportedArchitectures = new(StringComparer.OrdinalIgnoreCase)
     {
         "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
@@ -31,14 +39,17 @@ public sealed class ArchitectureDetectionService : IArchitectureDetectionService
         }
 
         using var archive = ZipFile.OpenRead(request.InputApkPath);
-        var found = archive.Entries
+        var availableAbis = archive.Entries
             .Select(entry => entry.FullName)
             .Where(path => path.StartsWith("lib/", StringComparison.OrdinalIgnoreCase))
             .Select(path => path.Split('/'))
             .Where(parts => parts.Length >= 3)
             .Select(parts => parts[1])
-            .FirstOrDefault(abi => SupportedArchitectures.Contains(abi));
+            .Where(abi => SupportedArchitectures.Contains(abi))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
+        var found = ArchitecturePreferenceOrder.FirstOrDefault(availableAbis.Contains);
         if (!string.IsNullOrWhiteSpace(found))
         {
             return Task.FromResult<(string?, string?, string?)>((found, null, null));

--- a/tests/unit/PulseAPK.Tests/Services/Patching/ArchitectureDetectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/ArchitectureDetectionServiceTests.cs
@@ -30,6 +30,24 @@ public class ArchitectureDetectionServiceTests
         Assert.Null(result.Error);
     }
 
+    [Fact]
+    public async Task ResolveAsync_PrefersArm64_WhenMultipleArchitecturesExist()
+    {
+        var apkPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.apk");
+        using (var archive = ZipFile.Open(apkPath, ZipArchiveMode.Create))
+        {
+            archive.CreateEntry("lib/armeabi-v7a/libfoo.so");
+            archive.CreateEntry("lib/arm64-v8a/libfoo.so");
+        }
+
+        var service = new ArchitectureDetectionService();
+
+        var result = await service.ResolveAsync(new PatchRequest { InputApkPath = apkPath });
+
+        Assert.Equal("arm64-v8a", result.Architecture);
+        Assert.Null(result.Error);
+    }
+
     private static string CreateApkWithEntry(string entry)
     {
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.apk");


### PR DESCRIPTION
### Motivation
- Prevent runtime `UnsatisfiedLinkError` caused by injecting a Frida gadget for an ABI that is present in the APK but not the preferred runtime ABI, which led to `libfrida-gadget.so not found` on some devices. 
- Make ABI selection deterministic and aligned with typical runtime preference (64-bit where available) instead of depending on ZIP entry ordering.

### Description
- Collect all supported `lib/<abi>/...` entries from the input APK and deduplicate them, rather than picking the first ZIP entry found during scanning. 
- Introduce a deterministic preference order `arm64-v8a`, `armeabi-v7a`, `x86_64`, `x86` and pick the first available ABI from that list when multiple ABIs are present. 
- Preserve existing explicit overrides from `SelectedArchitecture` and `DeviceAbi` so caller-provided choices still take precedence. 
- Add a unit test that constructs a synthetic multi-ABI APK and verifies that `arm64-v8a` is selected when both `armeabi-v7a` and `arm64-v8a` are present. 

### Testing
- Added unit test `ResolveAsync_PrefersArm64_WhenMultipleArchitecturesExist` in `tests/unit/PulseAPK.Tests/Services/Patching/ArchitectureDetectionServiceTests.cs` to validate multi-ABI selection logic. 
- Attempted to run `dotnet test --filter ArchitectureDetectionServiceTests` in this environment but the test run could not be executed because `dotnet` is not installed here. 
- Static inspection and local compilation assumptions verified by running repository updates; unit test was added and should pass in CI where the .NET SDK is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bece6feec88322a89422744c92b5f5)