### PR TITLE
Inject Frida gadget for all discovered APK ABIs

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -5,6 +5,14 @@ namespace PulseAPK.Core.Services.Patching;
 
 public sealed class PatchPipelineService : IPatchPipelineService
 {
+    private static readonly HashSet<string> SupportedArchitectures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "arm64-v8a",
+        "armeabi-v7a",
+        "x86",
+        "x86_64"
+    };
+
     private readonly PatchRequestValidatorService _requestValidator;
     private readonly IArchitectureDetectionService _architectureDetectionService;
     private readonly IFridaArtifactService _fridaArtifactService;
@@ -70,14 +78,6 @@ public sealed class PatchPipelineService : IPatchPipelineService
         var architecture = architectureResolution.Architecture;
         result.StageSummaries.Add(new PatchStageSummary("architecture", true, $"Using architecture '{architecture}'."));
 
-        var gadgetResolution = await _fridaArtifactService.ResolveGadgetAsync(request, architecture, cancellationToken);
-        if (gadgetResolution.Error is not null || gadgetResolution.GadgetPath is null)
-        {
-            result.Errors.Add(gadgetResolution.Error ?? "Unable to resolve Frida gadget artifact.");
-            result.StageSummaries.Add(new PatchStageSummary("artifact-resolution", false, result.Errors.Last()));
-            return result;
-        }
-
         var decompiledDirectory = PrepareWorkingDirectory(request);
         var cleanupDirectory = !request.KeepIntermediateFiles ? decompiledDirectory : null;
 
@@ -123,15 +123,35 @@ public sealed class PatchPipelineService : IPatchPipelineService
 
             result.StageSummaries.Add(new PatchStageSummary("manifest-patch", true, "Manifest patched."));
 
-            var gadgetInject = await _gadgetInjectionService.InjectAsync(decompiledDirectory, request, architecture, gadgetResolution.GadgetPath, cancellationToken);
-            if (!gadgetInject.Success)
+            var injectionArchitectures = ResolveInjectionArchitectures(decompiledDirectory, architecture);
+            foreach (var targetArchitecture in injectionArchitectures)
             {
-                result.Errors.Add(gadgetInject.Error ?? "Gadget injection failed.");
-                result.StageSummaries.Add(new PatchStageSummary("gadget-injection", false, result.Errors.Last()));
-                return result;
+                var gadgetResolution = await _fridaArtifactService.ResolveGadgetAsync(request, targetArchitecture, cancellationToken);
+                if (gadgetResolution.Error is not null || gadgetResolution.GadgetPath is null)
+                {
+                    result.Errors.Add(gadgetResolution.Error ?? "Unable to resolve Frida gadget artifact.");
+                    result.StageSummaries.Add(new PatchStageSummary("artifact-resolution", false, result.Errors.Last()));
+                    return result;
+                }
+
+                var gadgetInject = await _gadgetInjectionService.InjectAsync(
+                    decompiledDirectory,
+                    request,
+                    targetArchitecture,
+                    gadgetResolution.GadgetPath,
+                    cancellationToken);
+                if (!gadgetInject.Success)
+                {
+                    result.Errors.Add(gadgetInject.Error ?? "Gadget injection failed.");
+                    result.StageSummaries.Add(new PatchStageSummary("gadget-injection", false, result.Errors.Last()));
+                    return result;
+                }
             }
 
-            result.StageSummaries.Add(new PatchStageSummary("gadget-injection", true, "Frida gadget injected."));
+            var injectionMessage = injectionArchitectures.Count == 1
+                ? $"Frida gadget injected for ABI '{injectionArchitectures[0]}'."
+                : $"Frida gadget injected for ABIs: {string.Join(", ", injectionArchitectures)}.";
+            result.StageSummaries.Add(new PatchStageSummary("gadget-injection", true, injectionMessage));
 
             if (!request.DecodeSources)
             {
@@ -261,6 +281,32 @@ public sealed class PatchPipelineService : IPatchPipelineService
         var path = Path.Combine(root!, $"job-{Guid.NewGuid():N}", "decompiled");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static List<string> ResolveInjectionArchitectures(string decompiledDirectory, string selectedArchitecture)
+    {
+        var architectures = new List<string>();
+
+        if (Directory.Exists(Path.Combine(decompiledDirectory, "lib")))
+        {
+            foreach (var abiPath in Directory.EnumerateDirectories(Path.Combine(decompiledDirectory, "lib")))
+            {
+                var abi = Path.GetFileName(abiPath);
+                if (!string.IsNullOrWhiteSpace(abi) &&
+                    SupportedArchitectures.Contains(abi) &&
+                    !architectures.Contains(abi, StringComparer.OrdinalIgnoreCase))
+                {
+                    architectures.Add(abi);
+                }
+            }
+        }
+
+        if (!architectures.Contains(selectedArchitecture, StringComparer.OrdinalIgnoreCase))
+        {
+            architectures.Insert(0, selectedArchitecture);
+        }
+
+        return architectures;
     }
 
     private static string GetSignedPath(string outputApkPath)

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -257,6 +257,36 @@ public class PatchPipelineServiceTests
     }
 
     [Fact]
+    public async Task RunAsync_InsertsGadgetIntoAllDiscoveredAbis()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+
+        var fakeArtifactService = new FakeArtifactService();
+        var fakeGadgetInjectionService = new FakeGadgetInjectionService();
+        var fakeApktoolService = new FakeApktoolService(libAbis: ["arm64-v8a", "armeabi-v7a"]);
+        var pipeline = CreatePipeline(
+            fakeArtifactService: fakeArtifactService,
+            fakeGadgetInjectionService: fakeGadgetInjectionService,
+            fakeApktoolService: fakeApktoolService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = false
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(["arm64-v8a", "armeabi-v7a"], fakeArtifactService.ResolvedArchitectures);
+        Assert.Equal(["arm64-v8a", "armeabi-v7a"], fakeGadgetInjectionService.InjectedArchitectures);
+        Assert.Contains(result.StageSummaries, static stage =>
+            stage.Stage == "gadget-injection" &&
+            stage.Message.Contains("arm64-v8a, armeabi-v7a", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task RunAsync_ReturnsFailedStageAndError_WhenDecompileFails()
     {
         var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
@@ -382,24 +412,28 @@ public class PatchPipelineServiceTests
         bool dexMergeShouldFail = false,
         FakeDexMergeService? fakeDexMergeService = null,
         FakeArchitectureService? fakeArchitectureService = null,
+        FakeArtifactService? fakeArtifactService = null,
         FakeApktoolService? fakeApktoolService = null,
+        FakeGadgetInjectionService? fakeGadgetInjectionService = null,
         FakeSigningService? fakeSigningService = null,
         FakeFinalDexInspectionService? fakeFinalDexInspectionService = null)
     {
         fakeDexMergeService ??= new FakeDexMergeService(dexMergeShouldFail);
         fakeArchitectureService ??= new FakeArchitectureService();
+        fakeArtifactService ??= new FakeArtifactService();
         fakeApktoolService ??= new FakeApktoolService();
+        fakeGadgetInjectionService ??= new FakeGadgetInjectionService();
         fakeSigningService ??= new FakeSigningService();
         fakeFinalDexInspectionService ??= new FakeFinalDexInspectionService();
 
         return new PatchPipelineService(
             new PatchRequestValidatorService(),
             fakeArchitectureService,
-            new FakeArtifactService(),
+            fakeArtifactService,
             fakeApktoolService,
             new FakeActivityDetectionService(),
             new FakeManifestPatchService(),
-            new FakeGadgetInjectionService(),
+            fakeGadgetInjectionService,
             new FakeSmaliPatchService(),
             fakeDexMergeService,
             fakeSigningService,
@@ -421,19 +455,26 @@ public class PatchPipelineServiceTests
 
     private sealed class FakeArtifactService : IFridaArtifactService
     {
+        public List<string> ResolvedArchitectures { get; } = [];
+
         public Task<(string? GadgetPath, string? Error)> ResolveGadgetAsync(PatchRequest request, string architecture, CancellationToken cancellationToken = default)
-            => Task.FromResult<(string?, string?)>((request.InputApkPath, null));
+        {
+            ResolvedArchitectures.Add(architecture);
+            return Task.FromResult<(string?, string?)>((request.InputApkPath, null));
+        }
     }
 
     private sealed class FakeApktoolService : IApktoolService
     {
         private readonly int _decompileExitCode;
         private readonly int _buildExitCode;
+        private readonly IReadOnlyList<string> _libAbis;
 
-        public FakeApktoolService(int decompileExitCode = 0, int buildExitCode = 0)
+        public FakeApktoolService(int decompileExitCode = 0, int buildExitCode = 0, IReadOnlyList<string>? libAbis = null)
         {
             _decompileExitCode = decompileExitCode;
             _buildExitCode = buildExitCode;
+            _libAbis = libAbis ?? [];
         }
 
         public Task<int> DecompileAsync(string apkPath, string outputDirectory, bool decodeResources, bool decodeSources, CancellationToken cancellationToken = default)
@@ -447,6 +488,11 @@ public class PatchPipelineServiceTests
             File.WriteAllText(Path.Combine(outputDirectory, "AndroidManifest.xml"), "<manifest xmlns:android='http://schemas.android.com/apk/res/android'><application><activity android:name='com.example.MainActivity' /></application></manifest>");
             Directory.CreateDirectory(Path.Combine(outputDirectory, "smali", "com", "example"));
             File.WriteAllText(Path.Combine(outputDirectory, "smali", "com", "example", "MainActivity.smali"), ".class public Lcom/example/MainActivity;\n.super Landroid/app/Activity;\n\n.end class");
+            foreach (var abi in _libAbis)
+            {
+                Directory.CreateDirectory(Path.Combine(outputDirectory, "lib", abi));
+            }
+
             return Task.FromResult(0);
         }
 
@@ -480,8 +526,13 @@ public class PatchPipelineServiceTests
 
     private sealed class FakeGadgetInjectionService : IGadgetInjectionService
     {
+        public List<string> InjectedArchitectures { get; } = [];
+
         public Task<(bool Success, string? Error)> InjectAsync(string decompiledDirectory, PatchRequest request, string architecture, string gadgetSourcePath, CancellationToken cancellationToken = default)
-            => Task.FromResult((true, (string?)null));
+        {
+            InjectedArchitectures.Add(architecture);
+            return Task.FromResult((true, (string?)null));
+        }
     }
 
     private sealed class FakeSmaliPatchService : ISmaliPatchService


### PR DESCRIPTION
### Motivation
- Some APKs include multiple native ABIs or run under an ABI different from the one selected during patching, causing runtime errors like `UnsatisfiedLinkError: dlopen failed: library "libfrida-gadget.so" not found` when only one ABI is patched.

### Description
- Update the patch pipeline to discover supported ABIs under `decompiled/lib/*` and resolve/inject `libfrida-gadget.so` per discovered ABI instead of resolving once for a single architecture (`src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs`).
- Add `SupportedArchitectures` and `ResolveInjectionArchitectures` helper to prefer discovered ABIs while still including the originally selected architecture as a fallback (`PatchPipelineService`).
- Change gadget-injection flow to loop through target ABIs, call `IFridaArtifactService.ResolveGadgetAsync` per ABI, and call `IGadgetInjectionService.InjectAsync` per ABI; update the `gadget-injection` stage message to include the list of patched ABIs.
- Add unit test `RunAsync_InsertsGadgetIntoAllDiscoveredAbis` and extend test fakes so tests can assert per-ABI artifact resolution and injection and simulate `lib/<abi>` directories (`tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs`).

### Testing
- Added unit test `RunAsync_InsertsGadgetIntoAllDiscoveredAbis` that verifies artifact resolution and injection are called for discovered ABIs (test file updated: `tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs`).
- Attempted to run `dotnet test --filter PatchPipelineServiceTests` in this environment but `dotnet` is not installed, so automated tests could not be executed here (command failed: `dotnet: command not found`).
- Repository changes were committed locally after modification (source and tests updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becfd061548322a9050511ef32b9d3)