### PR TITLE
Use exact DEX method_id matching in FinalDexInspectionService

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -1,5 +1,4 @@
 using System.IO.Compression;
-using System.Text;
 using System.Text.RegularExpressions;
 using PulseAPK.Core.Abstractions.Patching;
 
@@ -32,15 +31,7 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
             using var buffer = new MemoryStream();
             await dexStream.CopyToAsync(buffer, cancellationToken);
 
-            var dexText = Encoding.Latin1.GetString(buffer.ToArray());
-
-            // DEX stores method components (class descriptor, name, proto/signature) as separate strings.
-            // Searching for the full smali reference literal is unreliable in compiled binaries.
-            var hasClassDescriptor = dexText.Contains(classDescriptor, StringComparison.Ordinal);
-            var hasMethodName = dexText.Contains(methodName, StringComparison.Ordinal);
-            var hasSignature = dexText.Contains(signature, StringComparison.Ordinal);
-
-            if (hasClassDescriptor && hasMethodName && hasSignature)
+            if (DexContainsMethodReference(buffer.ToArray(), classDescriptor, methodName, signature))
             {
                 return true;
             }
@@ -71,5 +62,244 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
         signature = match.Groups[3].Value;
 
         return true;
+    }
+
+    private static bool DexContainsMethodReference(byte[] dexData, string classDescriptor, string methodName, string signature)
+    {
+        if (dexData.Length < 0x70)
+        {
+            return false;
+        }
+
+        using var stream = new MemoryStream(dexData, writable: false);
+        using var reader = new BinaryReader(stream);
+
+        var stringIdsSize = ReadUInt32At(reader, 0x38);
+        var stringIdsOff = ReadUInt32At(reader, 0x3C);
+        var typeIdsSize = ReadUInt32At(reader, 0x40);
+        var typeIdsOff = ReadUInt32At(reader, 0x44);
+        var protoIdsSize = ReadUInt32At(reader, 0x4C);
+        var protoIdsOff = ReadUInt32At(reader, 0x50);
+        var methodIdsSize = ReadUInt32At(reader, 0x58);
+        var methodIdsOff = ReadUInt32At(reader, 0x5C);
+
+        if (!TryReadStringTable(dexData, reader, stringIdsSize, stringIdsOff, out var strings) ||
+            !TryReadTypeTable(dexData, reader, typeIdsSize, typeIdsOff, strings, out var types) ||
+            !TryReadProtoTable(dexData, reader, protoIdsSize, protoIdsOff, types, out var protos) ||
+            !IsInBounds(dexData, methodIdsOff, methodIdsSize, 8))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < methodIdsSize; i++)
+        {
+            var methodIdOff = (int)(methodIdsOff + (uint)(i * 8));
+            var classIdx = ReadUInt16At(reader, methodIdOff);
+            var protoIdx = ReadUInt16At(reader, methodIdOff + 2);
+            var nameIdx = ReadUInt32At(reader, methodIdOff + 4);
+
+            if (classIdx >= types.Length || protoIdx >= protos.Length || nameIdx >= strings.Length)
+            {
+                continue;
+            }
+
+            if (!string.Equals(types[classIdx], classDescriptor, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!string.Equals(strings[nameIdx], methodName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(protos[protoIdx], signature, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryReadStringTable(byte[] dexData, BinaryReader reader, uint stringIdsSize, uint stringIdsOff, out string[] strings)
+    {
+        strings = Array.Empty<string>();
+        if (!IsInBounds(dexData, stringIdsOff, stringIdsSize, 4))
+        {
+            return false;
+        }
+
+        strings = new string[stringIdsSize];
+        for (var i = 0; i < stringIdsSize; i++)
+        {
+            var stringIdOff = (int)(stringIdsOff + (uint)(i * 4));
+            var stringDataOff = ReadUInt32At(reader, stringIdOff);
+            if (!TryReadDexString(dexData, stringDataOff, out strings[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadTypeTable(byte[] dexData, BinaryReader reader, uint typeIdsSize, uint typeIdsOff, string[] strings, out string[] types)
+    {
+        types = Array.Empty<string>();
+        if (!IsInBounds(dexData, typeIdsOff, typeIdsSize, 4))
+        {
+            return false;
+        }
+
+        types = new string[typeIdsSize];
+        for (var i = 0; i < typeIdsSize; i++)
+        {
+            var typeIdOff = (int)(typeIdsOff + (uint)(i * 4));
+            var descriptorIdx = ReadUInt32At(reader, typeIdOff);
+            if (descriptorIdx >= strings.Length)
+            {
+                return false;
+            }
+
+            types[i] = strings[descriptorIdx];
+        }
+
+        return true;
+    }
+
+    private static bool TryReadProtoTable(byte[] dexData, BinaryReader reader, uint protoIdsSize, uint protoIdsOff, string[] types, out string[] protos)
+    {
+        protos = Array.Empty<string>();
+        if (!IsInBounds(dexData, protoIdsOff, protoIdsSize, 12))
+        {
+            return false;
+        }
+
+        protos = new string[protoIdsSize];
+        for (var i = 0; i < protoIdsSize; i++)
+        {
+            var protoOff = (int)(protoIdsOff + (uint)(i * 12));
+            var returnTypeIdx = ReadUInt32At(reader, protoOff + 4);
+            var parametersOff = ReadUInt32At(reader, protoOff + 8);
+            if (returnTypeIdx >= types.Length)
+            {
+                return false;
+            }
+
+            if (!TryReadTypeList(dexData, reader, parametersOff, types, out var parameterTypes))
+            {
+                return false;
+            }
+
+            protos[i] = $"({string.Concat(parameterTypes)}){types[returnTypeIdx]}";
+        }
+
+        return true;
+    }
+
+    private static bool TryReadTypeList(byte[] dexData, BinaryReader reader, uint typeListOff, string[] types, out string[] parameterTypes)
+    {
+        parameterTypes = Array.Empty<string>();
+        if (typeListOff == 0)
+        {
+            return true;
+        }
+
+        if (!IsInBounds(dexData, typeListOff, 1, 4))
+        {
+            return false;
+        }
+
+        var size = ReadUInt32At(reader, (int)typeListOff);
+        if (!IsInBounds(dexData, typeListOff + 4, size, 2))
+        {
+            return false;
+        }
+
+        parameterTypes = new string[size];
+        for (var i = 0; i < size; i++)
+        {
+            var typeIdx = ReadUInt16At(reader, (int)(typeListOff + 4 + (i * 2)));
+            if (typeIdx >= types.Length)
+            {
+                return false;
+            }
+
+            parameterTypes[i] = types[typeIdx];
+        }
+
+        return true;
+    }
+
+    private static bool TryReadDexString(byte[] dexData, uint stringDataOff, out string value)
+    {
+        value = string.Empty;
+        if (stringDataOff >= dexData.Length)
+        {
+            return false;
+        }
+
+        var index = (int)stringDataOff;
+        if (!TryReadUleb128(dexData, ref index, out _))
+        {
+            return false;
+        }
+
+        var start = index;
+        while (index < dexData.Length && dexData[index] != 0)
+        {
+            index++;
+        }
+
+        if (index >= dexData.Length)
+        {
+            return false;
+        }
+
+        value = System.Text.Encoding.UTF8.GetString(dexData, start, index - start);
+        return true;
+    }
+
+    private static bool TryReadUleb128(byte[] data, ref int index, out uint value)
+    {
+        value = 0;
+        var shift = 0;
+        while (shift < 35)
+        {
+            if (index >= data.Length)
+            {
+                return false;
+            }
+
+            var b = data[index++];
+            value |= (uint)(b & 0x7F) << shift;
+            if ((b & 0x80) == 0)
+            {
+                return true;
+            }
+
+            shift += 7;
+        }
+
+        return false;
+    }
+
+    private static uint ReadUInt32At(BinaryReader reader, int offset)
+    {
+        reader.BaseStream.Position = offset;
+        return reader.ReadUInt32();
+    }
+
+    private static ushort ReadUInt16At(BinaryReader reader, int offset)
+    {
+        reader.BaseStream.Position = offset;
+        return reader.ReadUInt16();
+    }
+
+    private static bool IsInBounds(byte[] data, uint offset, uint count, uint elementSize)
+    {
+        var length = (ulong)count * elementSize;
+        return (ulong)offset + length <= (ulong)data.Length;
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
@@ -1,5 +1,4 @@
 using System.IO.Compression;
-using System.Text;
 using PulseAPK.Core.Services.Patching;
 
 namespace PulseAPK.Tests.Services.Patching;
@@ -7,9 +6,19 @@ namespace PulseAPK.Tests.Services.Patching;
 public sealed class FinalDexInspectionServiceTests
 {
     [Fact]
-    public async Task ContainsMethodReferenceAsync_ReturnsTrue_WhenDexContainsSplitMethodComponents()
+    public async Task ContainsMethodReferenceAsync_ReturnsTrue_WhenDexContainsExactMethodTuple()
     {
-        var apkPath = CreateApkWithDexPayload(Encoding.ASCII.GetBytes("Lzed/rainxch/githubstore/MainActivity;\0loadFridaGadget\0()V\0"));
+        var apkPath = CreateApkWithDexPayload(CreateDexPayload(
+            strings:
+            [
+                "Lzed/rainxch/githubstore/MainActivity;",
+                "V",
+                "loadFridaGadget"
+            ],
+            typeDescriptorStringIndexes: [0, 1],
+            protoDefinitions: [new ProtoDefinition(1, [])],
+            methodDefinitions: [new MethodDefinition(0, 0, 2)]));
+
         var service = new FinalDexInspectionService();
 
         var found = await service.ContainsMethodReferenceAsync(
@@ -20,9 +29,54 @@ public sealed class FinalDexInspectionServiceTests
     }
 
     [Fact]
+    public async Task ContainsMethodReferenceAsync_ReturnsFalse_WhenStringsExistButNotAsSameMethodIdTuple()
+    {
+        var apkPath = CreateApkWithDexPayload(CreateDexPayload(
+            strings:
+            [
+                "Lzed/rainxch/githubstore/MainActivity;",
+                "Lzed/rainxch/githubstore/OtherActivity;",
+                "V",
+                "I",
+                "loadFridaGadget",
+                "noop",
+                "()V"
+            ],
+            typeDescriptorStringIndexes: [0, 1, 2, 3],
+            protoDefinitions:
+            [
+                new ProtoDefinition(2, []),
+                new ProtoDefinition(3, [])
+            ],
+            methodDefinitions:
+            [
+                new MethodDefinition(0, 1, 4),
+                new MethodDefinition(1, 0, 5)
+            ]));
+
+        var service = new FinalDexInspectionService();
+
+        var found = await service.ContainsMethodReferenceAsync(
+            apkPath,
+            "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
+
+        Assert.False(found);
+    }
+
+    [Fact]
     public async Task ContainsMethodReferenceAsync_ReturnsFalse_WhenSignatureIsInvalid()
     {
-        var apkPath = CreateApkWithDexPayload(Encoding.ASCII.GetBytes("Lzed/rainxch/githubstore/MainActivity;\0loadFridaGadget\0()V\0"));
+        var apkPath = CreateApkWithDexPayload(CreateDexPayload(
+            strings:
+            [
+                "Lzed/rainxch/githubstore/MainActivity;",
+                "V",
+                "loadFridaGadget"
+            ],
+            typeDescriptorStringIndexes: [0, 1],
+            protoDefinitions: [new ProtoDefinition(1, [])],
+            methodDefinitions: [new MethodDefinition(0, 0, 2)]));
+
         var service = new FinalDexInspectionService();
 
         var found = await service.ContainsMethodReferenceAsync(
@@ -41,4 +95,118 @@ public sealed class FinalDexInspectionServiceTests
         stream.Write(dexPayload, 0, dexPayload.Length);
         return apkPath;
     }
+
+    private static byte[] CreateDexPayload(
+        string[] strings,
+        int[] typeDescriptorStringIndexes,
+        ProtoDefinition[] protoDefinitions,
+        MethodDefinition[] methodDefinitions)
+    {
+        const int headerSize = 0x70;
+        var bytes = new List<byte>(new byte[headerSize]);
+
+        var stringIdsOff = bytes.Count;
+        bytes.AddRange(new byte[strings.Length * 4]);
+
+        var typeIdsOff = bytes.Count;
+        foreach (var stringIndex in typeDescriptorStringIndexes)
+        {
+            bytes.AddRange(BitConverter.GetBytes((uint)stringIndex));
+        }
+
+        var protoIdsOff = bytes.Count;
+        bytes.AddRange(new byte[protoDefinitions.Length * 12]);
+
+        var methodIdsOff = bytes.Count;
+        foreach (var method in methodDefinitions)
+        {
+            bytes.AddRange(BitConverter.GetBytes((ushort)method.ClassTypeIndex));
+            bytes.AddRange(BitConverter.GetBytes((ushort)method.ProtoIndex));
+            bytes.AddRange(BitConverter.GetBytes((uint)method.NameStringIndex));
+        }
+
+        var typeListOffsets = new uint[protoDefinitions.Length];
+        for (var i = 0; i < protoDefinitions.Length; i++)
+        {
+            var parameters = protoDefinitions[i].ParameterTypeIndexes;
+            if (parameters.Length == 0)
+            {
+                typeListOffsets[i] = 0;
+                continue;
+            }
+
+            typeListOffsets[i] = (uint)bytes.Count;
+            bytes.AddRange(BitConverter.GetBytes((uint)parameters.Length));
+            foreach (var parameter in parameters)
+            {
+                bytes.AddRange(BitConverter.GetBytes((ushort)parameter));
+            }
+
+            if ((bytes.Count & 1) != 0)
+            {
+                bytes.Add(0);
+            }
+        }
+
+        var stringDataOffsets = new uint[strings.Length];
+        for (var i = 0; i < strings.Length; i++)
+        {
+            stringDataOffsets[i] = (uint)bytes.Count;
+            WriteUleb128(bytes, (uint)strings[i].Length);
+            bytes.AddRange(System.Text.Encoding.UTF8.GetBytes(strings[i]));
+            bytes.Add(0);
+        }
+
+        WriteUInt32(bytes, 0x38, (uint)strings.Length);
+        WriteUInt32(bytes, 0x3C, (uint)stringIdsOff);
+        WriteUInt32(bytes, 0x40, (uint)typeDescriptorStringIndexes.Length);
+        WriteUInt32(bytes, 0x44, (uint)typeIdsOff);
+        WriteUInt32(bytes, 0x4C, (uint)protoDefinitions.Length);
+        WriteUInt32(bytes, 0x50, (uint)protoIdsOff);
+        WriteUInt32(bytes, 0x58, (uint)methodDefinitions.Length);
+        WriteUInt32(bytes, 0x5C, (uint)methodIdsOff);
+
+        for (var i = 0; i < stringDataOffsets.Length; i++)
+        {
+            WriteUInt32(bytes, stringIdsOff + (i * 4), stringDataOffsets[i]);
+        }
+
+        for (var i = 0; i < protoDefinitions.Length; i++)
+        {
+            var protoBase = protoIdsOff + (i * 12);
+            WriteUInt32(bytes, protoBase, 0);
+            WriteUInt32(bytes, protoBase + 4, (uint)protoDefinitions[i].ReturnTypeIndex);
+            WriteUInt32(bytes, protoBase + 8, typeListOffsets[i]);
+        }
+
+        return bytes.ToArray();
+    }
+
+    private static void WriteUInt32(List<byte> bytes, int offset, uint value)
+    {
+        var raw = BitConverter.GetBytes(value);
+        bytes[offset] = raw[0];
+        bytes[offset + 1] = raw[1];
+        bytes[offset + 2] = raw[2];
+        bytes[offset + 3] = raw[3];
+    }
+
+    private static void WriteUleb128(List<byte> bytes, uint value)
+    {
+        do
+        {
+            var current = (byte)(value & 0x7F);
+            value >>= 7;
+            if (value != 0)
+            {
+                current |= 0x80;
+            }
+
+            bytes.Add(current);
+        } while (value != 0);
+    }
+
+    private sealed record ProtoDefinition(int ReturnTypeIndex, int[] ParameterTypeIndexes);
+
+    private sealed record MethodDefinition(int ClassTypeIndex, int ProtoIndex, int NameStringIndex);
 }


### PR DESCRIPTION
### Motivation
- The previous Latin1 substring heuristic produced false positives because DEX stores method components as separate strings and loose token matching can correlate unrelated strings.
- This change aims to reliably detect method references by validating the actual `method_id` tuple (declaring class descriptor + method name + proto) inside DEX metadata.

### Description
- Replaced the substring-based check in `FinalDexInspectionService.ContainsMethodReferenceAsync` with a DEX metadata reader that parses `string_ids`, `type_ids`, `proto_ids`, and `method_ids` and verifies the exact tuple for each `method_id` entry via `DexContainsMethodReference` and helper methods.
- Implemented lightweight DEX readers: `TryReadStringTable`, `TryReadTypeTable`, `TryReadProtoTable`, `TryReadTypeList`, `TryReadDexString`, `TryReadUleb128`, and safe readers `ReadUInt32At`/`ReadUInt16At` with bounds checks.
- Kept the public API `ContainsMethodReferenceAsync` unchanged so it still returns `false` only when an exact correlated method reference is absent.
- Extended `FinalDexInspectionServiceTests` to synthesize minimal DEX payloads via `CreateDexPayload` and added tests for an exact tuple match, an invalid reference format, and a new false-positive guard case where the strings exist separately but do not form the same `method_id` tuple.

### Testing
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs` covering true-positive, false-positive, and invalid-format scenarios; these tests were created but not executed here.
- Attempted to run the `FinalDexInspectionServiceTests` via `dotnet test --filter FinalDexInspectionServiceTests`, but execution failed in this environment because `dotnet` is not installed.
- Recommend running the test suite in CI or a local environment with the .NET SDK to validate the new parser and test cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee95025948322bb497f8b9ef40b90)