### PR TITLE
Fix delayed-load DEX verification to check the correct helper method

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -241,7 +241,10 @@ public sealed class PatchPipelineService : IPatchPipelineService
             if (smaliInjectionApplied)
             {
                 var classDescriptor = ToClassDescriptor(activityName);
-                var methodReference = $"{classDescriptor}->loadFridaGadget()V";
+                var helperMethodName = request.UseDelayedLoad
+                    ? "loadFridaGadgetIfNeeded"
+                    : "loadFridaGadget";
+                var methodReference = $"{classDescriptor}->{helperMethodName}()V";
                 var foundInFinalDex = await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
                 if (!foundInFinalDex)
                 {

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -403,6 +403,32 @@ public class PatchPipelineServiceTests
         Assert.Contains("loadFridaGadget()V", Assert.Single(result.Errors), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task RunAsync_UsesDelayedLoadHelperForFinalDexVerification_WhenDelayedLoadIsEnabled()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+        var fakeFinalDexInspectionService = new FakeFinalDexInspectionService();
+
+        var pipeline = CreatePipeline(fakeFinalDexInspectionService: fakeFinalDexInspectionService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            SignOutput = true,
+            UseDelayedLoad = true
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(
+            "Lcom/example/MainActivity;->loadFridaGadgetIfNeeded()V",
+            fakeFinalDexInspectionService.LastMethodReference);
+        var stage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-verification"));
+        Assert.Contains("loadFridaGadgetIfNeeded()V", stage.Message, StringComparison.Ordinal);
+    }
+
     private static void AssertStageSequence(PatchResult result, IReadOnlyList<string> expectedStages)
     {
         Assert.Equal(expectedStages, result.StageSummaries.Select(static summary => summary.Stage));
@@ -592,6 +618,7 @@ public class PatchPipelineServiceTests
     private sealed class FakeFinalDexInspectionService : IFinalDexInspectionService
     {
         private readonly bool _containsMethodReference;
+        public string? LastMethodReference { get; private set; }
 
         public FakeFinalDexInspectionService(bool containsMethodReference = true)
         {
@@ -599,6 +626,9 @@ public class PatchPipelineServiceTests
         }
 
         public Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
-            => Task.FromResult(_containsMethodReference);
+        {
+            LastMethodReference = methodReference;
+            return Task.FromResult(_containsMethodReference);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Final DEX verification always checked for the immediate helper `loadFridaGadget()V`, causing false `dex-verification` failures when smali patching injected the delayed helper `loadFridaGadgetIfNeeded()V` (when `UseDelayedLoad` is enabled).

### Description
- Update `PatchPipelineService` to choose the helper name based on `request.UseDelayedLoad` and verify `loadFridaGadgetIfNeeded()V` for delayed mode or `loadFridaGadget()V` for immediate mode.
- Add unit test `RunAsync_UsesDelayedLoadHelperForFinalDexVerification_WhenDelayedLoadIsEnabled` in `PatchPipelineServiceTests` to assert the delayed helper reference is passed to the final DEX inspection step.
- Extend the test `FakeFinalDexInspectionService` to capture the last `methodReference` inspected so the new assertion can validate which helper was checked.
- Modified files: `src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs` and `tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs`.

### Testing
- Attempted to run focused unit tests with `dotnet test /workspace/PulseAPK-Core/tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter "PatchPipelineServiceTests|FinalDexInspectionServiceTests"`, but the execution failed because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beead5f6c08322b616788b68cd70d1)