### PR TITLE
Return diagnostics from final DEX inspection and surface results in patch pipeline

### DIFF
--- a/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
@@ -2,5 +2,5 @@ namespace PulseAPK.Core.Abstractions.Patching;
 
 public interface IFinalDexInspectionService
 {
-    Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default);
+    Task<(bool Found, string Diagnostics)> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default);
 }

--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -6,16 +6,16 @@ namespace PulseAPK.Core.Services.Patching;
 
 public sealed class FinalDexInspectionService : IFinalDexInspectionService
 {
-    public async Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
+    public async Task<(bool Found, string Diagnostics)> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(apkPath) || !File.Exists(apkPath))
         {
-            return false;
+            return (false, $"APK path is missing or file does not exist: '{apkPath}'.");
         }
 
         if (!TryParseMethodReference(methodReference, out var classDescriptor, out var methodName, out var signature))
         {
-            return false;
+            return (false, $"Method reference '{methodReference}' is invalid.");
         }
 
         using var stream = File.OpenRead(apkPath);
@@ -25,19 +25,33 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
             .Where(entry => entry.FullName.StartsWith("classes", StringComparison.OrdinalIgnoreCase) &&
                             entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase));
 
+        var totalDexEntries = 0;
         foreach (var dexEntry in dexEntries)
         {
+            totalDexEntries++;
             await using var dexStream = dexEntry.Open();
             using var buffer = new MemoryStream();
             await dexStream.CopyToAsync(buffer, cancellationToken);
 
-            if (DexContainsMethodReference(buffer.ToArray(), classDescriptor, methodName, signature))
+            var dexData = buffer.ToArray();
+            var (found, reason) = DexContainsMethodReference(dexData, classDescriptor, methodName, signature);
+            if (found)
             {
-                return true;
+                return (true, $"Found in '{dexEntry.FullName}' ({dexData.Length} bytes).");
+            }
+
+            if (!string.IsNullOrWhiteSpace(reason))
+            {
+                return (false, $"Inspection failed on '{dexEntry.FullName}': {reason}");
             }
         }
 
-        return false;
+        if (totalDexEntries == 0)
+        {
+            return (false, "No classes*.dex entries were found in the APK.");
+        }
+
+        return (false, $"Method tuple not found in any of the {totalDexEntries} dex entries.");
     }
 
     private static bool TryParseMethodReference(string methodReference, out string classDescriptor, out string methodName, out string signature)
@@ -64,11 +78,11 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
         return true;
     }
 
-    private static bool DexContainsMethodReference(byte[] dexData, string classDescriptor, string methodName, string signature)
+    private static (bool Found, string? Error) DexContainsMethodReference(byte[] dexData, string classDescriptor, string methodName, string signature)
     {
         if (dexData.Length < 0x70)
         {
-            return false;
+            return (false, $"DEX payload too small ({dexData.Length} bytes).");
         }
 
         using var stream = new MemoryStream(dexData, writable: false);
@@ -88,7 +102,7 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
             !TryReadProtoTable(dexData, reader, protoIdsSize, protoIdsOff, types, out var protos) ||
             !IsInBounds(dexData, methodIdsOff, methodIdsSize, 8))
         {
-            return false;
+            return (false, "DEX header tables are out of bounds or malformed.");
         }
 
         for (var i = 0; i < methodIdsSize; i++)
@@ -115,11 +129,11 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
 
             if (string.Equals(protos[protoIdx], signature, StringComparison.Ordinal))
             {
-                return true;
+                return (true, null);
             }
         }
 
-        return false;
+        return (false, null);
     }
 
     private static bool TryReadStringTable(byte[] dexData, BinaryReader reader, uint stringIdsSize, uint stringIdsOff, out string[] strings)

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -245,19 +245,22 @@ public sealed class PatchPipelineService : IPatchPipelineService
                     ? "loadFridaGadgetIfNeeded"
                     : "loadFridaGadget";
                 var methodReference = $"{classDescriptor}->{helperMethodName}()V";
-                var foundInFinalDex = await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
-                if (!foundInFinalDex)
+                var inspection = await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
+                result.Warnings.Add($"DEX verification target: '{methodReference}' in '{finalArtifactPath}'.");
+                result.Warnings.Add($"DEX verification diagnostics: {inspection.Diagnostics}");
+
+                if (!inspection.Found)
                 {
                     const string guidance = "Smali helper was present during patching but missing in the final DEX artifact. Ensure smali mutation runs after any transform that regenerates classes.dex, or disable that transform for patched classes.";
-                    result.Errors.Add($"Final DEX verification failed: '{methodReference}' was not found. {guidance}");
-                    result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, guidance));
+                    result.Errors.Add($"Final DEX verification failed: '{methodReference}' was not found. {inspection.Diagnostics} {guidance}");
+                    result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, $"{inspection.Diagnostics} {guidance}"));
                     result.OutputApkPath = finalArtifactPath;
                     result.SelectedArchitecture = architecture;
                     result.UsedSigning = request.SignOutput;
                     return result;
                 }
 
-                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, $"Confirmed '{methodReference}' in final APK dex."));
+                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, $"Confirmed '{methodReference}' in final APK dex. {inspection.Diagnostics}"));
             }
 
             result.Success = true;

--- a/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
@@ -21,7 +21,7 @@ public sealed class FinalDexInspectionServiceTests
 
         var service = new FinalDexInspectionService();
 
-        var found = await service.ContainsMethodReferenceAsync(
+        var (found, _) = await service.ContainsMethodReferenceAsync(
             apkPath,
             "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
 
@@ -56,7 +56,7 @@ public sealed class FinalDexInspectionServiceTests
 
         var service = new FinalDexInspectionService();
 
-        var found = await service.ContainsMethodReferenceAsync(
+        var (found, _) = await service.ContainsMethodReferenceAsync(
             apkPath,
             "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
 
@@ -79,7 +79,7 @@ public sealed class FinalDexInspectionServiceTests
 
         var service = new FinalDexInspectionService();
 
-        var found = await service.ContainsMethodReferenceAsync(
+        var (found, _) = await service.ContainsMethodReferenceAsync(
             apkPath,
             "Lzed/rainxch/githubstore/MainActivity;loadFridaGadget()V");
 

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -625,10 +625,10 @@ public class PatchPipelineServiceTests
             _containsMethodReference = containsMethodReference;
         }
 
-        public Task<bool> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
+        public Task<(bool Found, string Diagnostics)> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
         {
             LastMethodReference = methodReference;
-            return Task.FromResult(_containsMethodReference);
+            return Task.FromResult((_containsMethodReference, _containsMethodReference ? "Found in fake dex." : "Missing in fake dex."));
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Improve visibility into why final DEX verification succeeds or fails by returning diagnostic context from the DEX inspection routine.
- Surface those diagnostics in the patch pipeline to aid debugging when a smali helper is missing in the rebuilt APK.

### Description

- Change `IFinalDexInspectionService.ContainsMethodReferenceAsync` to return a tuple `(bool Found, string Diagnostics)` instead of just `bool`.
- Update `FinalDexInspectionService` to produce structured diagnostics for invalid input, missing/ malformed DEX tables, small payloads, per-entry failures, and successful matches, and to count processed dex entries.
- Update `PatchPipelineService` to record and log the inspection diagnostics via `result.Warnings` and include diagnostic text in error messages and stage summaries for the `dex-verification` stage.
- Update unit tests including `FinalDexInspectionServiceTests` and `PatchPipelineServiceTests` to accept and use the new tuple return value and adjust the fake inspection service to return diagnostics.

### Testing

- Ran unit tests with `dotnet test` for the modified test projects including `FinalDexInspectionServiceTests` and `PatchPipelineServiceTests`, and they passed.
- Existing and updated unit tests assert both positive and negative inspection outcomes and were updated to deconstruct the `(Found, Diagnostics)` tuple.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef41c76e08322a170051d4b62369a)