### PR TITLE
Handle non-fatal dex parse failures in FinalDexInspectionService

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -26,6 +26,8 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
                             entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase));
 
         var totalDexEntries = 0;
+        var successfulDexEntries = 0;
+        var parseFailures = new List<string>();
         foreach (var dexEntry in dexEntries)
         {
             totalDexEntries++;
@@ -42,8 +44,11 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
 
             if (!string.IsNullOrWhiteSpace(reason))
             {
-                return (false, $"Inspection failed on '{dexEntry.FullName}': {reason}");
+                parseFailures.Add($"'{dexEntry.FullName}': {reason}");
+                continue;
             }
+
+            successfulDexEntries++;
         }
 
         if (totalDexEntries == 0)
@@ -51,7 +56,21 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
             return (false, "No classes*.dex entries were found in the APK.");
         }
 
-        return (false, $"Method tuple not found in any of the {totalDexEntries} dex entries.");
+        if (successfulDexEntries > 0)
+        {
+            if (parseFailures.Count == 0)
+            {
+                return (false, $"Method tuple not found in any of the {totalDexEntries} dex entries.");
+            }
+
+            return (false,
+                $"Method tuple not found in any of the {totalDexEntries} dex entries. " +
+                $"Non-fatal parse failures: {string.Join("; ", parseFailures)}");
+        }
+
+        return (false,
+            $"Inspection failed for all {totalDexEntries} dex entries. " +
+            $"Parse failures: {string.Join("; ", parseFailures)}");
     }
 
     private static bool TryParseMethodReference(string methodReference, out string classDescriptor, out string methodName, out string signature)

--- a/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
@@ -86,15 +86,103 @@ public sealed class FinalDexInspectionServiceTests
         Assert.False(found);
     }
 
+    [Fact]
+    public async Task ContainsMethodReferenceAsync_ReturnsTrue_WhenClasses2IsMalformedAndClassesContainsMethod()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = CreateDexPayload(
+                strings:
+                [
+                    "Lzed/rainxch/githubstore/MainActivity;",
+                    "V",
+                    "loadFridaGadget"
+                ],
+                typeDescriptorStringIndexes: [0, 1],
+                protoDefinitions: [new ProtoDefinition(1, [])],
+                methodDefinitions: [new MethodDefinition(0, 0, 2)]),
+            ["classes2.dex"] = CreateMalformedDexPayload()
+        });
+
+        var service = new FinalDexInspectionService();
+
+        var (found, diagnostics) = await service.ContainsMethodReferenceAsync(
+            apkPath,
+            "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
+
+        Assert.True(found);
+        Assert.Contains("classes.dex", diagnostics);
+    }
+
+    [Fact]
+    public async Task ContainsMethodReferenceAsync_ReturnsTrue_WhenClassesIsMalformedAndClasses2ContainsMethod()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = CreateMalformedDexPayload(),
+            ["classes2.dex"] = CreateDexPayload(
+                strings:
+                [
+                    "Lzed/rainxch/githubstore/MainActivity;",
+                    "V",
+                    "loadFridaGadget"
+                ],
+                typeDescriptorStringIndexes: [0, 1],
+                protoDefinitions: [new ProtoDefinition(1, [])],
+                methodDefinitions: [new MethodDefinition(0, 0, 2)])
+        });
+
+        var service = new FinalDexInspectionService();
+
+        var (found, diagnostics) = await service.ContainsMethodReferenceAsync(
+            apkPath,
+            "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
+
+        Assert.True(found);
+        Assert.Contains("classes2.dex", diagnostics);
+    }
+
+    [Fact]
+    public async Task ContainsMethodReferenceAsync_ReturnsFalse_WithAggregatedDiagnostics_WhenAllDexEntriesMalformed()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = CreateMalformedDexPayload(),
+            ["classes2.dex"] = CreateMalformedDexPayload()
+        });
+
+        var service = new FinalDexInspectionService();
+
+        var (found, diagnostics) = await service.ContainsMethodReferenceAsync(
+            apkPath,
+            "Lzed/rainxch/githubstore/MainActivity;->loadFridaGadget()V");
+
+        Assert.False(found);
+        Assert.Contains("Inspection failed for all 2 dex entries", diagnostics);
+        Assert.Contains("'classes.dex':", diagnostics);
+        Assert.Contains("'classes2.dex':", diagnostics);
+    }
+
     private static string CreateApkWithDexPayload(byte[] dexPayload)
+    {
+        return CreateApkWithDexPayloads(new Dictionary<string, byte[]> { ["classes.dex"] = dexPayload });
+    }
+
+    private static string CreateApkWithDexPayloads(IReadOnlyDictionary<string, byte[]> dexPayloads)
     {
         var apkPath = Path.Combine(Path.GetTempPath(), $"final-dex-inspection-{Guid.NewGuid():N}.apk");
         using var archive = ZipFile.Open(apkPath, ZipArchiveMode.Create);
-        var dex = archive.CreateEntry("classes.dex", CompressionLevel.NoCompression);
-        using var stream = dex.Open();
-        stream.Write(dexPayload, 0, dexPayload.Length);
+        foreach (var dexPayload in dexPayloads)
+        {
+            var dex = archive.CreateEntry(dexPayload.Key, CompressionLevel.NoCompression);
+            using var stream = dex.Open();
+            stream.Write(dexPayload.Value, 0, dexPayload.Value.Length);
+        }
+
         return apkPath;
     }
+
+    private static byte[] CreateMalformedDexPayload() => [0x64, 0x65, 0x78];
 
     private static byte[] CreateDexPayload(
         string[] strings,


### PR DESCRIPTION
### Motivation
- Ensure `FinalDexInspectionService.ContainsMethodReferenceAsync` does not abort scanning on the first malformed `classes*.dex` entry so other dex entries can still be inspected for the target method tuple. 
- Provide clearer diagnostics by aggregating per-entry parse failures while preserving an immediate success return when a matching method tuple is found.

### Description
- Added `successfulDexEntries` and `parseFailures` tracking and changed the per-entry error handling to `parseFailures.Add(...)` and `continue` instead of returning immediately in `ContainsMethodReferenceAsync` in `src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs`.
- Increment `successfulDexEntries` for dex entries that parsed successfully but did not contain the tuple, and still return immediately when a tuple match is found. 
- Implemented final outcome logic so that if at least one dex parsed successfully the service returns a not-found message plus non-fatal parse diagnostics when applicable, and if all dex entries failed parsing the service returns a consolidated parse-failure message. 
- Added unit tests and helpers in `tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs` that add multi-dex APKs and malformed dex payloads, including tests for malformed `classes2.dex` + valid `classes.dex`, malformed `classes.dex` + valid `classes2.dex`, and both dex entries malformed with aggregated diagnostics.

### Testing
- Attempted to run the new tests with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter FinalDexInspectionServiceTests`, but the run failed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).
- The repository now contains the new unit tests that should be executed in a CI environment with `dotnet` available to validate the behavior described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf227c670c8322b121c16b16960156)