### PR TITLE
Fix final DEX verification by using direct AlphaOmega types

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/DexMethodLookupService.cs
+++ b/src/PulseAPK.Core/Services/Patching/DexMethodLookupService.cs
@@ -1,3 +1,5 @@
+using AlphaOmega.Debug;
+using AlphaOmega.Debug.Dex;
 using System.Reflection;
 using PulseAPK.Core.Abstractions.Patching;
 
@@ -10,13 +12,8 @@ public sealed class DexMethodLookupService : IDexMethodLookupService
         ArgumentNullException.ThrowIfNull(dexData);
 
         using var stream = new MemoryStream(dexData, writable: false);
-        var streamLoaderType = Type.GetType("AlphaOmega.Debug.StreamLoader, AlphaOmega.ApkReader", throwOnError: true)!;
-        using var streamLoader = (IDisposable?)Activator.CreateInstance(streamLoaderType, stream)
-            ?? throw new InvalidOperationException("Unable to construct AlphaOmega.Debug.StreamLoader.");
-
-        var dexFileType = Type.GetType("AlphaOmega.Debug.Dex.DexFile, AlphaOmega.ApkReader", throwOnError: true)!;
-        using var dexFile = (IDisposable?)Activator.CreateInstance(dexFileType, streamLoader)
-            ?? throw new InvalidOperationException("Unable to construct AlphaOmega.Debug.Dex.DexFile.");
+        using var streamLoader = new StreamLoader(stream);
+        using var dexFile = new DexFile(streamLoader);
 
         var methods = GetObjectArray(dexFile, "MethodIdItems");
         if (methods is null || methods.Length == 0)


### PR DESCRIPTION
### Motivation
- Final DEX verification was failing with runtime errors like `Could not load file or assembly 'AlphaOmega.ApkReader'` because types were resolved via `Type.GetType(..., AlphaOmega.ApkReader)` and instantiated reflectively.
- The intent is to make dex parsing robust by avoiding brittle assembly-name runtime resolution so the verification step can actually inspect classes*.dex entries.

### Description
- Replace reflection-based `Type.GetType(..., AlphaOmega.ApkReader)` + `Activator.CreateInstance` usage with direct `StreamLoader` and `DexFile` construction from `AlphaOmega.Debug` in `DexMethodLookupService`.
- Add direct `using AlphaOmega.Debug;` and `using AlphaOmega.Debug.Dex;` and remove the reflective construction code path while keeping the DEX parsing/lookup logic unchanged.
- This change eliminates the dependency on runtime assembly-name resolution while keeping the `AlphaOmega.ApkReader` package dependency in the project.

### Testing
- Attempted to run the unit tests targeted at the patch pipeline with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter "FullyQualifiedName~PatchPipelineServiceTests"`, but the run could not be executed because the environment lacks the `dotnet` SDK (`dotnet: command not found`).
- No automated tests were executed in this environment due to the missing .NET runtime; code change is limited in scope and should be validated by running the test suite in a proper .NET SDK environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf275fec9c8322a2771115791bf615)