### PR TITLE
Add ABI injection scope and optional DEX validation bypass to patch flow

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -54,6 +54,10 @@
             <StackPanel Spacing="8">
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
                           IsChecked="{Binding SignApk}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
+                          IsChecked="{Binding InjectLibForAllArchitectures}" />
+                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
+                          IsChecked="{Binding SkipDexValidation}" />
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptProfile]}"
                            FontWeight="SemiBold"
                            Margin="0,8,0,0" />

--- a/src/PulseAPK.Core/Models/PatchRequest.cs
+++ b/src/PulseAPK.Core/Models/PatchRequest.cs
@@ -24,4 +24,6 @@ public sealed record PatchRequest
     public bool DecodeResources { get; init; } = true;
     public bool DecodeSources { get; init; } = true;
     public bool UseAapt2ForBuild { get; init; }
+    public bool InjectForAllArchitectures { get; init; }
+    public bool SkipDexValidation { get; init; }
 }

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -325,6 +325,12 @@
   <data name="PatchSignOutputApk" xml:space="preserve">
     <value>Sign output APK (ubersigner)</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Inject lib for all architectures</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Skip DEX validation</value>
+  </data>
   <data name="PatchScriptProfile" xml:space="preserve">
     <value>Script profile</value>
   </data>
@@ -409,6 +415,12 @@ Output: {0}</value>
   </data>
   <data name="PatchPreviewScriptProfile" xml:space="preserve">
     <value>Script profile: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Inject for all architectures: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>Skip DEX validation: {0}</value>
   </data>
   <data name="PatchPreviewDexPreservation" xml:space="preserve">
     <value>Dex preservation: {0}</value>

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -124,7 +124,7 @@ public sealed class PatchPipelineService : IPatchPipelineService
 
             result.StageSummaries.Add(new PatchStageSummary("manifest-patch", true, "Manifest patched."));
 
-            var injectionArchitectures = ResolveInjectionArchitectures(decompiledDirectory, architecture);
+            var injectionArchitectures = ResolveInjectionArchitectures(decompiledDirectory, architecture, request.InjectForAllArchitectures);
             foreach (var targetArchitecture in injectionArchitectures)
             {
                 var gadgetResolution = await _fridaArtifactService.ResolveGadgetAsync(request, targetArchitecture, cancellationToken);
@@ -239,7 +239,13 @@ public sealed class PatchPipelineService : IPatchPipelineService
                 finalArtifactPath = signResult.SignedApkPath!;
             }
 
-            if (smaliInjectionApplied)
+            if (smaliInjectionApplied && request.SkipDexValidation)
+            {
+                const string skippedDexValidationMessage = "Final DEX verification was skipped by user request.";
+                result.Warnings.Add(skippedDexValidationMessage);
+                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, skippedDexValidationMessage));
+            }
+            else if (smaliInjectionApplied)
             {
                 var classDescriptor = ToClassDescriptor(activityName);
                 var helperMethodName = request.UseDelayedLoad
@@ -311,8 +317,13 @@ public sealed class PatchPipelineService : IPatchPipelineService
         return path;
     }
 
-    private static List<string> ResolveInjectionArchitectures(string decompiledDirectory, string selectedArchitecture)
+    private static List<string> ResolveInjectionArchitectures(string decompiledDirectory, string selectedArchitecture, bool injectForAllArchitectures)
     {
+        if (!injectForAllArchitectures)
+        {
+            return [selectedArchitecture];
+        }
+
         var architectures = new List<string>();
 
         if (Directory.Exists(Path.Combine(decompiledDirectory, "lib")))

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -33,6 +33,12 @@ public partial class PatchViewModel : ObservableObject
     private bool _signApk = true;
 
     [ObservableProperty]
+    private bool _injectLibForAllArchitectures;
+
+    [ObservableProperty]
+    private bool _skipDexValidation;
+
+    [ObservableProperty]
     private DexPreservationOption _selectedDexPreservationOption = new("Disabled (default)", DexPreservationMode.Disabled);
 
     [ObservableProperty]
@@ -118,6 +124,8 @@ public partial class PatchViewModel : ObservableObject
 
     partial void OnOutputApkPathChanged(string value) => UpdateCommandPreview();
     partial void OnSignApkChanged(bool value) => UpdateCommandPreview();
+    partial void OnInjectLibForAllArchitecturesChanged(bool value) => UpdateCommandPreview();
+    partial void OnSkipDexValidationChanged(bool value) => UpdateCommandPreview();
     partial void OnSelectedDexPreservationOptionChanged(DexPreservationOption value) => UpdateCommandPreview();
     partial void OnSelectedScriptInjectionOptionChanged(ScriptInjectionOption value) => UpdateCommandPreview();
 
@@ -197,7 +205,9 @@ public partial class PatchViewModel : ObservableObject
                 KeepIntermediateFiles = false,
                 PreserveOriginalDexFiles = false,
                 DexPreservationMode = selectedDexMode,
-                ConfirmDangerousDexReplacement = confirmedDangerousDexMode
+                ConfirmDangerousDexReplacement = confirmedDangerousDexMode,
+                InjectForAllArchitectures = InjectLibForAllArchitectures,
+                SkipDexValidation = SkipDexValidation
             };
 
             AppendLog(BuildRunSummary(request));
@@ -310,6 +320,8 @@ public partial class PatchViewModel : ObservableObject
         builder.AppendLine(L("PatchPreviewDecodeSources"));
         builder.AppendLine(L("PatchPreviewUseAapt2"));
         builder.AppendLine(string.Format(L("PatchPreviewScriptProfile"), SelectedScriptInjectionOption.Label));
+        builder.AppendLine(string.Format(L("PatchPreviewInjectAllArchitectures"), InjectLibForAllArchitectures));
+        builder.AppendLine(string.Format(L("PatchPreviewSkipDexValidation"), SkipDexValidation));
         builder.AppendLine(string.Format(L("PatchPreviewDexPreservation"), SelectedDexPreservationOption.Label));
         builder.Append(string.Format(L("PatchPreviewSignOutput"), SignApk));
         ConsoleLog = builder.ToString();


### PR DESCRIPTION
### Motivation
- Default gadget injection previously placed the Frida gadget for all APK ABIs which is confusing when the runtime ABI is known, so injection should default to the resolved architecture and offer an opt-in to inject into all ABIs. 
- Some users need to bypass the final DEX verification when transforms change the rebuilt APK, so add an explicit option to skip DEX validation.

### Description
- Added two new flags to the patch model: `InjectForAllArchitectures` and `SkipDexValidation` in `PatchRequest` (`src/PulseAPK.Core/Models/PatchRequest.cs`).
- Changed architecture resolution/injection behavior by adding a parameter to `ResolveInjectionArchitectures` and passing `request.InjectForAllArchitectures` so the default is to inject only the resolved ABI while still supporting injection into all detected ABIs when enabled (`src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs`).
- Added conditional bypass of the final DEX verification stage when `SkipDexValidation` is set and smali injection was applied, emitting a warning instead of running verification (`src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs`).
- Exposed two new UI checkboxes and wired them through the view model: `Inject lib for all architectures` and `Skip DEX validation`, with preview lines and request wiring in `PatchViewModel` and `PatchView.axaml` (`src/PulseAPK.Core/ViewModels/PatchViewModel.cs`, `src/PulseAPK.Avalonia/Views/PatchView.axaml`).
- Added localization strings for the new labels and preview lines in `Resources.resx` (`src/PulseAPK.Core/Properties/Resources.resx`).

### Testing
- Attempted to run `dotnet build PulseAPK.sln`, but the build could not be executed in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2b3e472c8322a2dfcf4c9d7f563c)