### PR TITLE
Add Open button for Patch output folder

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -94,6 +94,10 @@
                 </Grid>
                 <TextBox Text="{Binding OutputApkName}"
                          Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputApkNamePlaceholder]}" />
+                <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Open]}"
+                        Command="{Binding OpenOutputFolderCommand}"
+                        Width="100"
+                        HorizontalAlignment="Left" />
             </StackPanel>
         </Grid>
 

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -56,6 +56,7 @@ public partial class PatchViewModel : ObservableObject
     private readonly IPatchPipelineService _patchPipelineService;
     private readonly IDialogService _dialogService;
     private readonly LocalizationService _localizationService;
+    private readonly ISystemService _systemService;
 
     public bool IsHintVisible => string.IsNullOrWhiteSpace(ApkPath);
 
@@ -68,13 +69,15 @@ public partial class PatchViewModel : ObservableObject
         ISettingsService settingsService,
         IPatchPipelineService patchPipelineService,
         IDialogService dialogService,
-        LocalizationService localizationService)
+        LocalizationService localizationService,
+        ISystemService systemService)
     {
         _filePickerService = filePickerService;
         _settingsService = settingsService;
         _patchPipelineService = patchPipelineService;
         _dialogService = dialogService;
         _localizationService = localizationService;
+        _systemService = systemService;
 
         DexPreservationOptions =
         [
@@ -156,6 +159,25 @@ public partial class PatchViewModel : ObservableObject
         {
             OutputFolderPath = folder;
         }
+    }
+
+    [RelayCommand]
+    private async Task OpenOutputFolder()
+    {
+        var folder = OutputFolderPath;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            await _dialogService.ShowWarningAsync(Properties.Resources.Error_OutputFolderNotSet);
+            return;
+        }
+
+        if (!Directory.Exists(folder))
+        {
+            await _dialogService.ShowWarningAsync(string.Format(Properties.Resources.Error_FolderNotFound, folder));
+            return;
+        }
+
+        _systemService.OpenFolder(folder);
     }
 
     [RelayCommand(CanExecute = nameof(CanRunPatch))]


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to open the folder where compiled/patched APKs are written from the Patching tab (under the output file field). 

### Description
- Added an `Open` button to `src/PulseAPK.Avalonia/Views/PatchView.axaml` bound to `OpenOutputFolderCommand` so the folder can be opened from the UI. 
- Implemented `OpenOutputFolder` in `PatchViewModel` which validates the `OutputFolderPath`, shows warnings using `IDialogService` if the path is empty or missing, and opens the folder via the injected `ISystemService`; the `PatchViewModel` constructor was updated to accept `ISystemService`.

### Testing
- Attempted to run unit tests with `dotnet test` but the command failed because `dotnet` is not available in this environment (tests were not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf31b2b5a48322ab53e5f3a6eab07e)