### PR TITLE
Localize Patching tab strings and rename Open action to "Open folder"

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -94,7 +94,7 @@
                 </Grid>
                 <TextBox Text="{Binding OutputApkName}"
                          Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputApkNamePlaceholder]}" />
-                <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Open]}"
+                <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOpenFolder]}"
                         Command="{Binding OpenOutputFolderCommand}"
                         Width="100"
                         HorizontalAlignment="Left" />

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -340,6 +340,9 @@
   <data name="PatchOutputLabel" xml:space="preserve">
     <value>Output</value>
   </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Open folder</value>
+  </data>
   <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
     <value>patched.apk</value>
   </data>
@@ -372,6 +375,12 @@
   </data>
   <data name="PatchLogStartingPipeline" xml:space="preserve">
     <value>Starting patch pipeline...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Script profile: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Patching '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
   </data>
   <data name="PatchLogCreated" xml:space="preserve">
     <value>Patched APK created: {0}</value>

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -135,7 +135,7 @@ public partial class PatchViewModel : ObservableObject
     [RelayCommand]
     private async Task BrowseApk()
     {
-        var file = await _filePickerService.OpenFileAsync("APK Files (*.apk)|*.apk|All Files (*.*)|*.*");
+        var file = await _filePickerService.OpenFileAsync(Properties.Resources.FileFilter_Apk);
         if (file is null)
         {
             return;
@@ -144,7 +144,7 @@ public partial class PatchViewModel : ObservableObject
         var (isValid, message) = FileSanitizer.ValidateApk(file);
         if (!isValid)
         {
-            await _dialogService.ShowErrorAsync(message, "Invalid APK File");
+            await _dialogService.ShowErrorAsync(message, Properties.Resources.Error_InvalidApkFile);
             return;
         }
 
@@ -233,7 +233,7 @@ public partial class PatchViewModel : ObservableObject
             };
 
             AppendLog(BuildRunSummary(request));
-            AppendLog($"[INFO] Script profile: {SelectedScriptInjectionOption.Label}");
+            AppendLog(string.Format(L("PatchLogScriptProfile"), SelectedScriptInjectionOption.Label));
 
             var result = await _patchPipelineService.RunAsync(request);
 
@@ -352,8 +352,16 @@ public partial class PatchViewModel : ObservableObject
 
     private string L(string key) => _localizationService[key];
 
-    private static string BuildRunSummary(PatchRequest request)
+    private string BuildRunSummary(PatchRequest request)
     {
-        return $"Patching '{request.InputApkPath}' -> '{request.OutputApkPath}' (sign={request.SignOutput}, decodeRes={request.DecodeResources}, decodeSrc={request.DecodeSources}, aapt2={request.UseAapt2ForBuild}, dexMode={request.DexPreservationMode})";
+        return string.Format(
+            L("PatchLogRunSummary"),
+            request.InputApkPath,
+            request.OutputApkPath,
+            request.SignOutput,
+            request.DecodeResources,
+            request.DecodeSources,
+            request.UseAapt2ForBuild,
+            request.DexPreservationMode);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure all user-facing text in the Patching tab is localized and consistent, and make the output-folder action label clearer by changing `Open` to `Open folder`.

### Description
- Updated the Patching view to use a new localization key `PatchOpenFolder` for the output-folder button label in `PatchView.axaml`.
- Replaced hardcoded strings in `PatchViewModel` with localized resource usages: the APK file picker filter now uses `Properties.Resources.FileFilter_Apk`, and the invalid APK dialog title uses `Properties.Resources.Error_InvalidApkFile`.
- Localized patch logging lines by adding and using `PatchLogScriptProfile` for the script profile line and `PatchLogRunSummary` for the run summary, and changed `BuildRunSummary` from a static interpolated string to an instance method using `L("PatchLogRunSummary")`.
- Added new resource entries in `src/PulseAPK.Core/Properties/Resources.resx`: `PatchOpenFolder`, `PatchLogScriptProfile`, and `PatchLogRunSummary`.

### Testing
- Attempted to build the solution with `dotnet build PulseAPK.sln`, but the environment does not have the .NET SDK installed so the build could not be executed (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf330dc04c83228a07c7b1e67192af)