### PR TITLE
Localize Patch tab strings and change Patch open button to "Open folder"

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>الوضع الفاتح</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>حقن لجميع البنى المعمارية</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>تخطي التحقق من Dex النهائي</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>فتح المجلد</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>حقن أداة Frida (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Heller Modus</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Für alle Architekturen injizieren</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Finale Dex-Prüfung überspringen</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Ordner öffnen</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Frida-Gadget injizieren (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Modo claro</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Inyectar para todas las arquitecturas</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Omitir validación final de Dex</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Abrir carpeta</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Inyectar Frida gadget (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Mode clair</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Injecter pour toutes les architectures</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Ignorer la validation Dex finale</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Ouvrir le dossier</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Injecter le gadget Frida (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Modo claro</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Injetar para todas as arquiteturas</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Ignorar validação final de Dex</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Abrir pasta</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Injetar gadget Frida (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -425,4 +425,25 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Светлая тема</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Инжектировать для всех архитектур</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Пропустить финальную проверку Dex</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Открыть папку</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>Профиль скрипта: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Патчинг '{0}' -> '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>- Инжектировать для всех архитектур: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>- Пропустить финальную проверку Dex: {0}</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Світла тема</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>Інжектувати для всіх архітектур</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>Пропустити фінальну перевірку Dex</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>Відкрити папку</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>Інжектувати Frida gadget (MainActivity + Gadget.loadLibrary)</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -349,4 +349,19 @@
   <data name="ThemeModeLight" xml:space="preserve">
     <value>浅色模式</value>
   </data>
+  <data name="PatchInjectForAllArchitectures" xml:space="preserve">
+    <value>为所有架构注入</value>
+  </data>
+  <data name="PatchSkipDexValidation" xml:space="preserve">
+    <value>跳过最终 Dex 校验</value>
+  </data>
+  <data name="PatchOpenFolder" xml:space="preserve">
+    <value>打开文件夹</value>
+  </data>
+  <data name="PatchOutputApkNamePlaceholder" xml:space="preserve">
+    <value>patched.apk</value>
+  </data>
+  <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
+    <value>注入 Frida Gadget（MainActivity + Gadget.loadLibrary）</value>
+  </data>
 </root>


### PR DESCRIPTION
### Motivation
- Make the Patching tab clearer by changing the output-folder button label from the generic "Open" to "Open folder" and provide localized equivalents to avoid falling back to English and to surface translated option/preview text.

### Description
- Added missing localization entries used by the Patch UI (`PatchInjectForAllArchitectures`, `PatchSkipDexValidation`, `PatchOpenFolder`, `PatchOutputApkNamePlaceholder`, `PatchScriptInjectFridaGadget`) into `Resources.{ar-SA,de-DE,es-ES,fr-FR,pt-BR,uk-UA,zh-CN}.resx`.
- Added Russian translations for patch logging/preview keys (`PatchLogScriptProfile`, `PatchLogRunSummary`, `PatchPreviewInjectAllArchitectures`, `PatchPreviewSkipDexValidation`) so the Patch flow no longer falls back to English in those messages.
- The Patch view now uses the localized `PatchOpenFolder` label so the button shows "Open folder" in English and the appropriate translated text in other locales.

### Testing
- Validated the updated `.resx` files are well-formed by parsing them with `xml.etree.ElementTree.parse` (succeeded).
- Verified the presence of the new localization keys across the modified resource files using script-based checks (succeeded).
- Attempted to run `dotnet test` for the unit test project but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf3478b6d083229f1f0518a84a73f6)