### PR TITLE
Add marker-based DEX verification for RootCheckPathBypass profile

### DIFF
--- a/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Abstractions/Patching/IFinalDexInspectionService.cs
@@ -3,4 +3,6 @@ namespace PulseAPK.Core.Abstractions.Patching;
 public interface IFinalDexInspectionService
 {
     Task<(bool Found, string Diagnostics)> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default);
+
+    Task<(bool Found, string Diagnostics)> ContainsStringMarkerAsync(string apkPath, string markerLiteral, CancellationToken cancellationToken = default);
 }

--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -1,5 +1,7 @@
 using System.IO.Compression;
 using System.Text.RegularExpressions;
+using AlphaOmega.Debug;
+using AlphaOmega.Debug.Dex;
 using PulseAPK.Core.Abstractions.Patching;
 
 namespace PulseAPK.Core.Services.Patching;
@@ -91,6 +93,91 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
         return (false,
             $"Inspection failed for all {totalDexEntries} dex entries. " +
             $"Parse failures: {string.Join("; ", parseFailures)}");
+    }
+
+    public async Task<(bool Found, string Diagnostics)> ContainsStringMarkerAsync(string apkPath, string markerLiteral, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(apkPath) || !File.Exists(apkPath))
+        {
+            return (false, $"APK path is missing or file does not exist: '{apkPath}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(markerLiteral))
+        {
+            return (false, "Marker literal is required.");
+        }
+
+        using var stream = File.OpenRead(apkPath);
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
+
+        var dexEntries = archive.Entries
+            .Where(entry => entry.FullName.StartsWith("classes", StringComparison.OrdinalIgnoreCase) &&
+                            entry.FullName.EndsWith(".dex", StringComparison.OrdinalIgnoreCase));
+
+        var totalDexEntries = 0;
+        var successfulDexEntries = 0;
+        var parseFailures = new List<string>();
+        foreach (var dexEntry in dexEntries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            totalDexEntries++;
+            await using var dexStream = dexEntry.Open();
+            using var buffer = new MemoryStream();
+            await dexStream.CopyToAsync(buffer, cancellationToken);
+
+            var dexData = buffer.ToArray();
+            try
+            {
+                var found = ContainsStringInDexStringPool(dexData, markerLiteral);
+                if (found)
+                {
+                    return (true, $"Marker literal '{markerLiteral}' found in '{dexEntry.FullName}' ({dexData.Length} bytes).");
+                }
+
+                successfulDexEntries++;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                parseFailures.Add($"warning '{dexEntry.FullName}': {ex.Message}");
+            }
+        }
+
+        if (totalDexEntries == 0)
+        {
+            return (false, "No classes*.dex entries were found in the APK.");
+        }
+
+        if (successfulDexEntries > 0)
+        {
+            if (parseFailures.Count == 0)
+            {
+                return (false, $"Marker literal '{markerLiteral}' not found in any of the {totalDexEntries} dex entries.");
+            }
+
+            return (false,
+                $"Marker literal '{markerLiteral}' not found in any of the {totalDexEntries} dex entries. " +
+                $"Non-fatal parse failures: {string.Join("; ", parseFailures)}");
+        }
+
+        return (false,
+            $"Marker inspection failed for all {totalDexEntries} dex entries. " +
+            $"Parse failures: {string.Join("; ", parseFailures)}");
+    }
+
+    private static bool ContainsStringInDexStringPool(byte[] dexData, string markerLiteral)
+    {
+        using var stream = new MemoryStream(dexData, writable: false);
+        using var streamLoader = new StreamLoader(stream);
+        using var dexFile = new DexFile(streamLoader);
+        var stringItems = dexFile.StringIdItems ?? throw new InvalidDataException("Dex string pool is missing.");
+        return stringItems.Any(item =>
+            item.StringData is not null &&
+            item.StringData.Contains(markerLiteral, StringComparison.Ordinal));
     }
 
     private static bool TryParseMethodReference(string methodReference, out string classDescriptor, out string methodName, out string signature)

--- a/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
+++ b/src/PulseAPK.Core/Services/Patching/PatchPipelineService.cs
@@ -369,21 +369,26 @@ public sealed class PatchPipelineService : IPatchPipelineService
             else if (smaliInjectionApplied)
             {
                 var classDescriptor = ToClassDescriptor(activityName);
+                const string rootBypassMarkerLiteral = "/dev/pulseapk-fake-root-";
+                var isRootBypassVerification = request.ScriptInjectionProfile == ScriptInjectionProfile.RootCheckPathBypass;
                 var methodReference = request.ScriptInjectionProfile != ScriptInjectionProfile.SampleInjection && !activitySmaliPatchApplied
                     ? ResolveApplicationMethodReference(decompiledDirectory)
                     : request.ScriptInjectionProfile == ScriptInjectionProfile.SampleInjection
-                    ? "logSampleInjectionApplied"
-                    : request.ScriptInjectionProfile == ScriptInjectionProfile.RootCheckPathBypass
-                    ? $"{classDescriptor}->onCreate(Landroid/os/Bundle;)V"
-                    : request.UseDelayedLoad
-                        ? "loadFridaGadgetIfNeeded"
-                        : "loadFridaGadget";
+                        ? "logSampleInjectionApplied"
+                        : request.UseDelayedLoad
+                            ? "loadFridaGadgetIfNeeded"
+                            : "loadFridaGadget";
                 methodReference = methodReference.Contains("->", StringComparison.Ordinal)
                     ? methodReference
                     : $"{classDescriptor}->{methodReference}()V";
-                var inspection = await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
+
+                var verificationTarget = isRootBypassVerification ? rootBypassMarkerLiteral : methodReference;
+                var inspection = isRootBypassVerification
+                    ? await _finalDexInspectionService.ContainsStringMarkerAsync(finalArtifactPath, rootBypassMarkerLiteral, cancellationToken)
+                    : await _finalDexInspectionService.ContainsMethodReferenceAsync(finalArtifactPath, methodReference, cancellationToken);
                 var diagnosticSummary = SummarizeDexDiagnostics(inspection.Diagnostics);
-                result.Warnings.Add($"DEX verification target: '{methodReference}' in '{finalArtifactPath}'.");
+                var verificationTargetLabel = isRootBypassVerification ? "marker literal" : "method reference";
+                result.Warnings.Add($"DEX verification target ({verificationTargetLabel}): '{verificationTarget}' in '{finalArtifactPath}'.");
                 result.Warnings.Add(
                     $"DEX verification diagnostics: {inspection.Diagnostics} " +
                     $"(parsed dex entries: {diagnosticSummary.ParsedDexEntries}, failed dex entries: {diagnosticSummary.FailedDexEntries}).");
@@ -394,22 +399,24 @@ public sealed class PatchPipelineService : IPatchPipelineService
                     {
                         const string inconclusiveMessage = "Final DEX verification inconclusive due to dex parse errors.";
                         result.Errors.Add(
-                            $"{inconclusiveMessage} Unable to reliably verify '{methodReference}'. {inspection.Diagnostics}");
+                            $"{inconclusiveMessage} Unable to reliably verify '{verificationTarget}'. {inspection.Diagnostics}");
                         result.StageSummaries.Add(
                             new PatchStageSummary("dex-verification", false, $"{inconclusiveMessage} {inspection.Diagnostics}"));
                     }
-                    else if (diagnosticSummary.ParsedDexEntries > 0 && diagnosticSummary.TupleSearchCompleted)
+                    else if (diagnosticSummary.ParsedDexEntries > 0 && diagnosticSummary.SearchCompleted)
                     {
-                        const string guidance = "Smali helper missing in final dex artifact. Ensure smali mutation runs after any transform that regenerates classes.dex, or disable that transform for patched classes.";
-                        result.Errors.Add($"Final DEX verification failed: '{methodReference}' was not found. {inspection.Diagnostics} {guidance}");
-                    result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, $"{inspection.Diagnostics} {guidance}"));
-                }
-                else
-                {
-                    result.Errors.Add(
-                            $"Final DEX verification failed before tuple search completed for '{methodReference}'. {inspection.Diagnostics}");
+                        var guidance = isRootBypassVerification
+                            ? "Root check path marker missing in final dex artifact. Ensure root-path rewrite smali changes run after dex/regeneration transforms."
+                            : "Smali helper missing in final dex artifact. Ensure smali mutation runs after any transform that regenerates classes.dex, or disable that transform for patched classes.";
+                        result.Errors.Add($"Final DEX verification failed: '{verificationTarget}' was not found. {inspection.Diagnostics} {guidance}");
+                        result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, $"{inspection.Diagnostics} {guidance}"));
+                    }
+                    else
+                    {
+                        result.Errors.Add(
+                            $"Final DEX verification failed before search completed for '{verificationTarget}'. {inspection.Diagnostics}");
                         result.StageSummaries.Add(new PatchStageSummary("dex-verification", false, inspection.Diagnostics));
-                }
+                    }
 
                     result.OutputApkPath = PublishArtifactWithRetry(finalArtifactPath, finalOutputPath);
                     result.SelectedArchitecture = architecture;
@@ -417,7 +424,10 @@ public sealed class PatchPipelineService : IPatchPipelineService
                     return result;
                 }
 
-                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, $"Confirmed '{methodReference}' in final APK dex. {inspection.Diagnostics}"));
+                var successMessage = isRootBypassVerification
+                    ? $"Confirmed marker literal '{verificationTarget}' in final APK dex. {inspection.Diagnostics}"
+                    : $"Confirmed '{verificationTarget}' in final APK dex. {inspection.Diagnostics}";
+                result.StageSummaries.Add(new PatchStageSummary("dex-verification", true, successMessage));
             }
 
             result.Success = true;
@@ -578,29 +588,48 @@ public sealed class PatchPipelineService : IPatchPipelineService
             return summary;
         }
 
-        var tupleSearchMatch = Regex.Match(diagnostics, @"Method tuple not found in any of the (\d+) dex entries\.", RegexOptions.CultureInvariant);
-        if (tupleSearchMatch.Success &&
-            int.TryParse(tupleSearchMatch.Groups[1].Value, out var tupleSearchTotalDexEntries))
+        var methodSearchMatch = Regex.Match(diagnostics, @"Method tuple not found in any of the (\d+) dex entries\.", RegexOptions.CultureInvariant);
+        if (methodSearchMatch.Success &&
+            int.TryParse(methodSearchMatch.Groups[1].Value, out var methodSearchTotalDexEntries))
         {
             var failedDexEntries = Regex.Matches(diagnostics, "warning '", RegexOptions.CultureInvariant).Count;
-            failedDexEntries = Math.Clamp(failedDexEntries, 0, tupleSearchTotalDexEntries);
+            failedDexEntries = Math.Clamp(failedDexEntries, 0, methodSearchTotalDexEntries);
             return new DexDiagnosticsSummary(
-                ParsedDexEntries: tupleSearchTotalDexEntries - failedDexEntries,
+                ParsedDexEntries: methodSearchTotalDexEntries - failedDexEntries,
                 FailedDexEntries: failedDexEntries,
-                TupleSearchCompleted: true);
+                SearchCompleted: true);
+        }
+
+        var markerSearchMatch = Regex.Match(diagnostics, @"Marker literal '.*' not found in any of the (\d+) dex entries\.", RegexOptions.CultureInvariant);
+        if (markerSearchMatch.Success &&
+            int.TryParse(markerSearchMatch.Groups[1].Value, out var markerSearchTotalDexEntries))
+        {
+            var failedDexEntries = Regex.Matches(diagnostics, "warning '", RegexOptions.CultureInvariant).Count;
+            failedDexEntries = Math.Clamp(failedDexEntries, 0, markerSearchTotalDexEntries);
+            return new DexDiagnosticsSummary(
+                ParsedDexEntries: markerSearchTotalDexEntries - failedDexEntries,
+                FailedDexEntries: failedDexEntries,
+                SearchCompleted: true);
         }
 
         var inspectionFailedMatch = Regex.Match(diagnostics, @"Inspection failed for all (\d+) dex entries\.", RegexOptions.CultureInvariant);
         if (inspectionFailedMatch.Success &&
             int.TryParse(inspectionFailedMatch.Groups[1].Value, out var failedAllDexEntries))
         {
-            return new DexDiagnosticsSummary(ParsedDexEntries: 0, FailedDexEntries: failedAllDexEntries, TupleSearchCompleted: false);
+            return new DexDiagnosticsSummary(ParsedDexEntries: 0, FailedDexEntries: failedAllDexEntries, SearchCompleted: false);
+        }
+
+        var markerInspectionFailedMatch = Regex.Match(diagnostics, @"Marker inspection failed for all (\d+) dex entries\.", RegexOptions.CultureInvariant);
+        if (markerInspectionFailedMatch.Success &&
+            int.TryParse(markerInspectionFailedMatch.Groups[1].Value, out var markerFailedAllDexEntries))
+        {
+            return new DexDiagnosticsSummary(ParsedDexEntries: 0, FailedDexEntries: markerFailedAllDexEntries, SearchCompleted: false);
         }
 
         return summary;
     }
 
-    private readonly record struct DexDiagnosticsSummary(int ParsedDexEntries = 0, int FailedDexEntries = 0, bool TupleSearchCompleted = false);
+    private readonly record struct DexDiagnosticsSummary(int ParsedDexEntries = 0, int FailedDexEntries = 0, bool SearchCompleted = false);
 
     private static bool IsRecoverableActivityPatchFailure(string? error)
         => !string.IsNullOrWhiteSpace(error) &&

--- a/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
@@ -99,6 +99,61 @@ public sealed class FinalDexInspectionServiceTests
         Assert.Contains("is invalid", diagnostics);
     }
 
+    [Fact]
+    public async Task ContainsStringMarkerAsync_ReturnsTrue_WhenMarkerExistsInLaterDexEntry()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = CreateMinimalDexWithStrings("abc"),
+            ["classes2.dex"] = CreateMinimalDexWithStrings("prefix", "/dev/pulseapk-fake-root-1234", "suffix")
+        });
+
+        var service = new FinalDexInspectionService(new FakeDexMethodLookupService(new Dictionary<string, LookupOutcome>()));
+
+        var (found, diagnostics) = await service.ContainsStringMarkerAsync(apkPath, "/dev/pulseapk-fake-root-");
+
+        Assert.True(found);
+        Assert.Contains("classes2.dex", diagnostics);
+        Assert.Contains("Marker literal", diagnostics);
+    }
+
+    [Fact]
+    public async Task ContainsStringMarkerAsync_ReturnsFalse_WhenMarkerMissingAfterSuccessfulParsing()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = CreateMinimalDexWithStrings("abc", "def"),
+            ["classes2.dex"] = CreateMinimalDexWithStrings("ghi")
+        });
+
+        var service = new FinalDexInspectionService(new FakeDexMethodLookupService(new Dictionary<string, LookupOutcome>()));
+
+        var (found, diagnostics) = await service.ContainsStringMarkerAsync(apkPath, "/dev/pulseapk-fake-root-");
+
+        Assert.False(found);
+        Assert.Contains("not found in any of the 2 dex entries", diagnostics);
+        Assert.DoesNotContain("warning", diagnostics, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ContainsStringMarkerAsync_ReturnsFalse_WithParseFailureDiagnostics_WhenAllDexEntriesFailParsing()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = "invalid-one"u8.ToArray(),
+            ["classes2.dex"] = "invalid-two"u8.ToArray()
+        });
+
+        var service = new FinalDexInspectionService(new FakeDexMethodLookupService(new Dictionary<string, LookupOutcome>()));
+
+        var (found, diagnostics) = await service.ContainsStringMarkerAsync(apkPath, "/dev/pulseapk-fake-root-");
+
+        Assert.False(found);
+        Assert.Contains("Marker inspection failed for all 2 dex entries", diagnostics);
+        Assert.Contains("warning 'classes.dex'", diagnostics);
+        Assert.Contains("warning 'classes2.dex'", diagnostics);
+    }
+
     private static string CreateApkWithDexPayloads(IReadOnlyDictionary<string, byte[]> dexPayloads)
     {
         var apkPath = Path.Combine(Path.GetTempPath(), $"final-dex-inspection-{Guid.NewGuid():N}.apk");
@@ -139,5 +194,65 @@ public sealed class FinalDexInspectionServiceTests
         public static LookupOutcome NotFound() => new(false, null);
 
         public static LookupOutcome ParseFailure(Exception exception) => new(false, exception);
+    }
+
+    private static byte[] CreateMinimalDexWithStrings(params string[] values)
+    {
+        static void WriteInt32(byte[] buffer, int offset, int value)
+            => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+
+        static byte[] EncodeUleb128(int value)
+        {
+            var bytes = new List<byte>();
+            uint remaining = (uint)value;
+            do
+            {
+                var next = (byte)(remaining & 0x7Fu);
+                remaining >>= 7;
+                if (remaining != 0)
+                {
+                    next |= 0x80;
+                }
+
+                bytes.Add(next);
+            } while (remaining != 0);
+
+            return bytes.ToArray();
+        }
+
+        static byte[] BuildStringData(string value)
+        {
+            var utf8 = System.Text.Encoding.UTF8.GetBytes(value);
+            var length = EncodeUleb128(value.Length);
+            return [.. length, .. utf8, 0x00];
+        }
+
+        var stringDatas = values.Select(BuildStringData).ToArray();
+        var headerSize = 0x70;
+        var stringIdsOffset = headerSize;
+        var stringIdsSize = values.Length;
+        var stringIdsByteCount = stringIdsSize * 4;
+        var stringDataOffset = stringIdsOffset + stringIdsByteCount;
+        var totalSize = stringDataOffset + stringDatas.Sum(static data => data.Length);
+
+        var buffer = new byte[totalSize];
+        var magic = System.Text.Encoding.ASCII.GetBytes("dex\n035\0");
+        magic.CopyTo(buffer, 0);
+        WriteInt32(buffer, 0x20, totalSize);
+        WriteInt32(buffer, 0x24, headerSize);
+        WriteInt32(buffer, 0x28, 0x12345678);
+        WriteInt32(buffer, 0x38, stringIdsSize);
+        WriteInt32(buffer, 0x3C, stringIdsOffset);
+
+        var cursor = stringDataOffset;
+        for (var i = 0; i < stringDatas.Length; i++)
+        {
+            WriteInt32(buffer, stringIdsOffset + (i * 4), cursor);
+            var data = stringDatas[i];
+            data.CopyTo(buffer, cursor);
+            cursor += data.Length;
+        }
+
+        return buffer;
     }
 }

--- a/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs
@@ -561,6 +561,57 @@ public class PatchPipelineServiceTests
     }
 
     [Fact]
+    public async Task RunAsync_UsesRootMarkerForFinalDexVerification_WhenRootBypassProfileIsEnabled()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+        var fakeFinalDexInspectionService = new FakeFinalDexInspectionService();
+
+        var pipeline = CreatePipeline(fakeFinalDexInspectionService: fakeFinalDexInspectionService);
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            ScriptInjectionProfile = ScriptInjectionProfile.RootCheckPathBypass,
+            SignOutput = true
+        });
+
+        Assert.True(result.Success);
+        Assert.Null(fakeFinalDexInspectionService.LastMethodReference);
+        Assert.Equal("/dev/pulseapk-fake-root-", fakeFinalDexInspectionService.LastMarkerLiteral);
+        var stage = Assert.Single(result.StageSummaries.Where(static s => s.Stage == "dex-verification"));
+        Assert.Contains("marker literal", stage.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesRootSpecificGuidance_WhenRootMarkerMissingAfterSearchCompletion()
+    {
+        var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
+        await File.WriteAllTextAsync(inputApk, "apk");
+        var outputApk = Path.Combine(Path.GetTempPath(), $"output-{Guid.NewGuid():N}.apk");
+        var diagnostics = "Marker literal '/dev/pulseapk-fake-root-' not found in any of the 2 dex entries.";
+        var pipeline = CreatePipeline(
+            fakeFinalDexInspectionService: new FakeFinalDexInspectionService(
+                containsMethodReference: true,
+                containsMarker: false,
+                markerDiagnostics: diagnostics));
+
+        var result = await pipeline.RunAsync(new PatchRequest
+        {
+            InputApkPath = inputApk,
+            OutputApkPath = outputApk,
+            ScriptInjectionProfile = ScriptInjectionProfile.RootCheckPathBypass
+        });
+
+        Assert.False(result.Success);
+        var error = Assert.Single(result.Errors);
+        Assert.Contains("Root check path marker missing", error, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Smali helper missing", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task RunAsync_ReturnsInconclusiveVerification_WhenDexParsingFailsForSubsetOfEntries()
     {
         var inputApk = Path.Combine(Path.GetTempPath(), $"input-{Guid.NewGuid():N}.apk");
@@ -894,19 +945,34 @@ public class PatchPipelineServiceTests
     private sealed class FakeFinalDexInspectionService : IFinalDexInspectionService
     {
         private readonly bool _containsMethodReference;
-        private readonly string _diagnostics;
+        private readonly string _methodDiagnostics;
+        private readonly bool _containsMarker;
+        private readonly string _markerDiagnostics;
         public string? LastMethodReference { get; private set; }
+        public string? LastMarkerLiteral { get; private set; }
 
-        public FakeFinalDexInspectionService(bool containsMethodReference = true, string? diagnostics = null)
+        public FakeFinalDexInspectionService(
+            bool containsMethodReference = true,
+            string? diagnostics = null,
+            bool containsMarker = true,
+            string? markerDiagnostics = null)
         {
             _containsMethodReference = containsMethodReference;
-            _diagnostics = diagnostics ?? (_containsMethodReference ? "Found in fake dex." : "Missing in fake dex.");
+            _methodDiagnostics = diagnostics ?? (_containsMethodReference ? "Found in fake dex." : "Missing in fake dex.");
+            _containsMarker = containsMarker;
+            _markerDiagnostics = markerDiagnostics ?? (_containsMarker ? "Marker literal '/dev/pulseapk-fake-root-' found in fake dex." : "Marker literal '/dev/pulseapk-fake-root-' missing in fake dex.");
         }
 
         public Task<(bool Found, string Diagnostics)> ContainsMethodReferenceAsync(string apkPath, string methodReference, CancellationToken cancellationToken = default)
         {
             LastMethodReference = methodReference;
-            return Task.FromResult((_containsMethodReference, _diagnostics));
+            return Task.FromResult((_containsMethodReference, _methodDiagnostics));
+        }
+
+        public Task<(bool Found, string Diagnostics)> ContainsStringMarkerAsync(string apkPath, string markerLiteral, CancellationToken cancellationToken = default)
+        {
+            LastMarkerLiteral = markerLiteral;
+            return Task.FromResult((_containsMarker, _markerDiagnostics));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- The RootCheckPathBypass profile should verify insertion by searching for a marker string in DEX string pools rather than forcing the activity `onCreate` method-tuple check.
- Provide clear, profile-specific diagnostics for marker-found, marker-not-found, and parse-failure/inconclusive outcomes.

### Description
- Added a new API `IFinalDexInspectionService.ContainsStringMarkerAsync(string apkPath, string markerLiteral, CancellationToken)` to the final-dex inspection abstraction.
- Implemented `ContainsStringMarkerAsync` in `FinalDexInspectionService` to scan each `classes*.dex` string pool using `AlphaOmega.Debug.Dex` and return distinct diagnostics for found/not-found/parse failures.
- Updated `PatchPipelineService` dex-verification to branch when `ScriptInjectionProfile.RootCheckPathBypass` is selected and use the marker verification (`"/dev/pulseapk-fake-root-"`) while preserving the existing method-tuple checks for other profiles and adjusted messages to be profile-accurate.
- Enhanced diagnostic summarization (`SummarizeDexDiagnostics`) to handle both method-tuple and marker-literal diagnostics and added/updated unit test fakes and expectations to support the new flow.

### Testing
- Added unit tests in `tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs` to cover marker found, marker missing after successful parsing, and parse-failure cases for `ContainsStringMarkerAsync` and in `tests/unit/PulseAPK.Tests/Services/Patching/PatchPipelineServiceTests.cs` to assert the root profile uses marker verification and emits root-specific guidance.
- Attempted to run the targeted unit tests (`PatchPipelineServiceTests` and `FinalDexInspectionServiceTests`) with `dotnet test`, but test execution could not run in this environment because `dotnet` is not installed (`/bin/bash: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb919170088322ae63c67db6011cf3)