### PR TITLE
Harden dex marker verification with raw-byte fallback

### DIFF
--- a/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
+++ b/src/PulseAPK.Core/Services/Patching/FinalDexInspectionService.cs
@@ -144,6 +144,12 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
             }
             catch (Exception ex)
             {
+                if (ContainsStringInRawDexBytes(dexData, markerLiteral))
+                {
+                    return (true,
+                        $"Marker literal '{markerLiteral}' found in '{dexEntry.FullName}' ({dexData.Length} bytes) via raw byte scan fallback.");
+                }
+
                 parseFailures.Add($"warning '{dexEntry.FullName}': {ex.Message}");
             }
         }
@@ -181,6 +187,17 @@ public sealed class FinalDexInspectionService : IFinalDexInspectionService
         return stringItems.Any(item =>
             GetStringMember(item, "StringData", "Value", "Data", "Text") is { } stringData &&
             stringData.Contains(markerLiteral, StringComparison.Ordinal));
+    }
+
+    private static bool ContainsStringInRawDexBytes(byte[] dexData, string markerLiteral)
+    {
+        if (dexData.Length == 0 || string.IsNullOrEmpty(markerLiteral))
+        {
+            return false;
+        }
+
+        var markerBytes = System.Text.Encoding.UTF8.GetBytes(markerLiteral);
+        return markerBytes.Length > 0 && dexData.AsSpan().IndexOf(markerBytes) >= 0;
     }
 
     private static object[]? GetObjectArray(object source, string memberName)

--- a/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs
@@ -154,6 +154,22 @@ public sealed class FinalDexInspectionServiceTests
         Assert.Contains("warning 'classes2.dex'", diagnostics);
     }
 
+    [Fact]
+    public async Task ContainsStringMarkerAsync_ReturnsTrue_WhenParserFailsButRawDexContainsMarker()
+    {
+        var apkPath = CreateApkWithDexPayloads(new Dictionary<string, byte[]>
+        {
+            ["classes.dex"] = [0x00, 0x01, .. System.Text.Encoding.UTF8.GetBytes("/dev/pulseapk-fake-root-42"), 0x00]
+        });
+
+        var service = new FinalDexInspectionService(new FakeDexMethodLookupService(new Dictionary<string, LookupOutcome>()));
+
+        var (found, diagnostics) = await service.ContainsStringMarkerAsync(apkPath, "/dev/pulseapk-fake-root-");
+
+        Assert.True(found);
+        Assert.Contains("raw byte scan fallback", diagnostics);
+    }
+
     private static string CreateApkWithDexPayloads(IReadOnlyDictionary<string, byte[]> dexPayloads)
     {
         var apkPath = Path.Combine(Path.GetTempPath(), $"final-dex-inspection-{Guid.NewGuid():N}.apk");


### PR DESCRIPTION
### Motivation
- Final DEX marker verification can fail with parser-specific errors (e.g., "Dex string pool is missing") even when the patched marker literal exists in the dex payload bytes.
- Prevent false-negative patch pipeline failures during root-check path bypass verification by making string-marker detection more resilient.

### Description
- Add a raw-byte fallback scan in `FinalDexInspectionService.ContainsStringMarkerAsync` that searches the dex payload bytes for the UTF-8 marker literal when parsing throws an exception.
- Introduce helper `ContainsStringInRawDexBytes(byte[] dexData, string markerLiteral)` which performs a UTF-8 byte sequence search using `Span`/`IndexOf`.
- Ensure the fallback is applied only to the string-marker inspection path and preserve existing parse-failure diagnostics when appropriate.
- Add a unit test `ContainsStringMarkerAsync_ReturnsTrue_WhenParserFailsButRawDexContainsMarker` in `FinalDexInspectionServiceTests.cs` that constructs an APK with malformed dex bytes containing the marker and asserts the fallback path succeeds with the expected diagnostic text.

### Testing
- Added unit test `tests/unit/PulseAPK.Tests/Services/Patching/FinalDexInspectionServiceTests.cs` that verifies the raw-byte fallback path returns success and emits a "raw byte scan fallback" diagnostic.
- Attempted to run the test filter with `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --filter FinalDexInspectionServiceTests`, but the environment could not execute it because `dotnet` is not installed (tests were not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb9561289483228a655419d4d09a0d)