### PR TITLE
docs: add GitHub shields to README header

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,13 @@
 # PulseAPK
 
 <p align="center">
+  <a href="https://github.com/your-org/PulseAPK-Core/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/your-org/PulseAPK-Core?style=for-the-badge" /></a>
+  <a href="https://github.com/your-org/PulseAPK-Core/network/members"><img alt="GitHub forks" src="https://img.shields.io/github/forks/your-org/PulseAPK-Core?style=for-the-badge" /></a>
+  <a href="https://github.com/your-org/PulseAPK-Core/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/your-org/PulseAPK-Core?style=for-the-badge" /></a>
+  <a href="LICENSE.md"><img alt="License" src="https://img.shields.io/github/license/your-org/PulseAPK-Core?style=for-the-badge" /></a>
+  <a href="https://github.com/your-org/PulseAPK-Core/commits"><img alt="Last commit" src="https://img.shields.io/github/last-commit/your-org/PulseAPK-Core?style=for-the-badge" /></a>
+</p>
+<p align="center">
   🌍 <strong>Languages</strong><br>
   <a href="README.md">English</a> |
   <a href="README.de.md">Deutsch</a> |


### PR DESCRIPTION
### Motivation
- Add visible project badges (stars, forks, issues, license, last commit) to the README header to surface repository metadata on the project's landing page.

### Description
- Inserted a centered badge row under the main `# PulseAPK` title in `README.MD` using Shields.io images and links that currently point to `your-org/PulseAPK-Core` and `LICENSE.md`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090cb98cdc832289f6ce29214cf6c7)