### PR TITLE
Improve Device Tools controls

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -73,7 +73,6 @@
                             <Button Grid.Column="2"
                                     Content="Install APK"
                                     Command="{Binding InstallApkCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     MinWidth="100" />
                             <Button Grid.Column="3"
                                     Content="Detect Package"
@@ -110,27 +109,21 @@
                         <WrapPanel>
                             <Button Content="Launch App"
                                     Command="{Binding LaunchAppCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Launch Activity"
                                     Command="{Binding LaunchActivityCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Force Stop"
                                     Command="{Binding ForceStopCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Clear Data"
                                     Command="{Binding ClearDataCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Uninstall"
                                     Command="{Binding UninstallCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Current Activity"
                                     Command="{Binding CurrentActivityCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Clear"
                                     Command="{Binding ClearPackageCommand}"
@@ -152,12 +145,11 @@
                             <Button Grid.Column="1"
                                     Content="Run Shell"
                                     Command="{Binding RunShellCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     MinWidth="110" />
                             <Button Grid.Column="2"
-                                    Content="Run ADB"
+                                    Content="Run ADB Args"
+                                    ToolTip.Tip="Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model."
                                     Command="{Binding RunAdbCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     MinWidth="100" />
                         </Grid>
                     </StackPanel>
@@ -173,51 +165,39 @@
                         <WrapPanel>
                             <Button Content="Model"
                                     Command="{Binding RunModelPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Android Release"
                                     Command="{Binding RunAndroidReleasePresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="SDK"
                                     Command="{Binding RunSdkPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="CPU ABI"
                                     Command="{Binding RunCpuAbiPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="List Packages"
                                     Command="{Binding RunListPackagesPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Third-Party Packages"
                                     Command="{Binding RunThirdPartyPackagesPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Search Package"
                                     Command="{Binding RunSearchPackagePresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="App Path"
                                     Command="{Binding RunAppPathPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Current Activity"
                                     Command="{Binding RunCurrentActivityPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="Reboot"
                                     Command="{Binding RunRebootPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="ADB Root"
                                     Command="{Binding RunAdbRootPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                             <Button Content="ADB Remount"
                                     Command="{Binding RunAdbRemountPresetCommand}"
-                                    IsEnabled="{Binding HasWorkingDevice}"
                                     Margin="0,0,8,8" />
                         </WrapPanel>
                     </StackPanel>
@@ -232,8 +212,14 @@
                 CornerRadius="6"
                 Padding="12">
             <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <TextBlock Text="Console log"
-                           FontWeight="SemiBold" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Text="Console log"
+                               FontWeight="SemiBold" />
+                    <Button Grid.Column="1"
+                            Content="Clear"
+                            Command="{Binding ClearConsoleCommand}"
+                            MinWidth="80" />
+                </Grid>
                 <TextBox Grid.Row="1"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -75,7 +75,6 @@ public partial class DeviceToolsViewModel : ObservableObject
     private string _consoleLog = Properties.Resources.WaitingForCommand;
 
     [ObservableProperty]
-    [NotifyCanExecuteChangedFor(nameof(RefreshDevicesCommand))]
     [NotifyCanExecuteChangedFor(nameof(InstallApkCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectPackageCommand))]
     [NotifyCanExecuteChangedFor(nameof(LaunchAppCommand))]
@@ -112,39 +111,31 @@ public partial class DeviceToolsViewModel : ObservableObject
         _filePickerService = filePickerService;
     }
 
-    [RelayCommand(CanExecute = nameof(CanRefreshDevices))]
+    [RelayCommand(AllowConcurrentExecutions = true)]
     private async Task RefreshDevices()
     {
-        IsRunning = true;
-        try
+        var resolvedPath = await _adbService.ResolveAdbPathAsync();
+        IsAdbFound = !string.IsNullOrWhiteSpace(resolvedPath);
+        DetectedAdbPath = resolvedPath ?? string.Empty;
+
+        if (!IsAdbFound)
         {
-            var resolvedPath = await _adbService.ResolveAdbPathAsync();
-            IsAdbFound = !string.IsNullOrWhiteSpace(resolvedPath);
-            DetectedAdbPath = resolvedPath ?? string.Empty;
-
-            if (!IsAdbFound)
-            {
-                AppendLog("ADB was not found. Configure ADB Path in Settings or install Android platform-tools.");
-                Devices.Clear();
-                SelectedDevice = null;
-                return;
-            }
-
-            var result = await RunAdbAndLogAsync(["devices", "-l"]);
-            var devices = AdbService.ParseDevices(result.StandardOutput);
-
+            AppendLog("ADB was not found. Configure ADB Path in Settings or install Android platform-tools.");
             Devices.Clear();
-            foreach (var device in devices)
-            {
-                Devices.Add(device);
-            }
+            SelectedDevice = null;
+            return;
+        }
 
-            SelectedDevice = Devices.FirstOrDefault(device => device.IsUsable) ?? Devices.FirstOrDefault();
-        }
-        finally
+        var result = await RunAdbAndLogAsync(["devices", "-l"]);
+        var devices = AdbService.ParseDevices(result.StandardOutput);
+
+        Devices.Clear();
+        foreach (var device in devices)
         {
-            IsRunning = false;
+            Devices.Add(device);
         }
+
+        SelectedDevice = Devices.FirstOrDefault(device => device.IsUsable) ?? Devices.FirstOrDefault();
     }
 
     [RelayCommand]
@@ -233,6 +224,12 @@ public partial class DeviceToolsViewModel : ObservableObject
         PackageName = string.Empty;
         Activity = string.Empty;
         Activities.Clear();
+    }
+
+    [RelayCommand]
+    private void ClearConsole()
+    {
+        ConsoleLog = Properties.Resources.WaitingForCommand;
     }
 
     [RelayCommand(CanExecute = nameof(CanRunPackageAction))]
@@ -508,7 +505,6 @@ public partial class DeviceToolsViewModel : ObservableObject
         return $"'{value.Replace("'", "'\"'\"'")}'";
     }
 
-    private bool CanRefreshDevices() => !IsRunning;
     private bool CanRunDeviceAction() => !IsRunning && HasWorkingDevice;
     private bool CanInstallApk() => CanRunDeviceAction() && File.Exists(SelectedApkPath);
     private bool CanDetectPackage() => !IsRunning && File.Exists(SelectedApkPath);


### PR DESCRIPTION
### Motivation
- Make the `Refresh Devices` action available at all times so users can re-detect ADB and connected devices even when other operations are running.
- Add a way to clear the console log quickly from the UI.
- Avoid duplicating availability logic on buttons so command `CanExecute` implementations remain the single source of truth for when actions are enabled.
- Clarify what the `Run ADB` action does so users understand it runs raw ADB arguments.

### Description
- Removed per-button `IsEnabled="{Binding HasWorkingDevice}"` bindings from `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` so command `CanExecute` controls availability.
- Added a `Clear` button to the console header and wired it to a new `ClearConsoleCommand` implemented in `src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs` that resets `ConsoleLog` to the default waiting text.
- Made `RefreshDevices` independent from the shared running gate by replacing `[RelayCommand(CanExecute = nameof(CanRefreshDevices))]` with `[RelayCommand(AllowConcurrentExecutions = true)]` and simplified the method to not rely on `IsRunning`.
- Renamed the UI label `Run ADB` to `Run ADB Args` and added a tooltip explaining it runs the entered text as raw `adb` arguments; the view model still splits the text and forwards arguments to `RunPackageActionAsync`/`RunAdbAndLogAsync`.

### Testing
- Ran `git diff --check` to verify changes (no issues reported).
- Attempted to run `dotnet test PulseAPK.sln`, but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e00e14a4483228276fe6547f7006a)