### PR TITLE
Remove ADB test controls from Settings

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -64,31 +64,13 @@
 
         <TextBlock Text="ADB Path"
                    FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
             <TextBox Text="{Binding AdbPath}" Watermark="Auto-detect if empty" />
             <Button Grid.Column="1"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
                     Command="{Binding BrowseAdbCommand}"
                     Width="110" />
-            <Button Grid.Column="2"
-                    Content="Test"
-                    Command="{Binding TestAdbCommand}"
-                    Width="150" />
         </Grid>
-
-        <Border Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="10">
-            <TextBox Text="{Binding AdbTestLog}"
-                     IsReadOnly="True"
-                     AcceptsReturn="True"
-                     TextWrapping="Wrap"
-                     MinHeight="90"
-                     MaxHeight="160"
-                     ScrollViewer.VerticalScrollBarVisibility="Auto" />
-        </Border>
     </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -15,7 +15,6 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private readonly IToolDownloadService _toolDownloadService;
     private readonly LocalizationService _localizationService;
     private readonly IThemeService _themeService;
-    private readonly AdbService _adbService;
     private bool _disposed;
 
     [ObservableProperty]
@@ -26,12 +25,6 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     private string _adbPath;
-
-    [ObservableProperty]
-    private string _adbTestLog = Properties.Resources.WaitingForCommand;
-
-    [ObservableProperty]
-    private bool _isTestingAdb;
 
     [ObservableProperty]
     private bool _isDownloadingTools;
@@ -58,8 +51,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         IToolRepository toolRepository,
         IToolDownloadService toolDownloadService,
         LocalizationService localizationService,
-        IThemeService themeService,
-        AdbService adbService)
+        IThemeService themeService)
     {
         _settingsService = settingsService;
         _filePickerService = filePickerService;
@@ -68,7 +60,6 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _toolDownloadService = toolDownloadService;
         _localizationService = localizationService;
         _themeService = themeService;
-        _adbService = adbService;
 
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
@@ -148,29 +139,6 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         if (file != null)
         {
             AdbPath = file;
-        }
-    }
-
-    [RelayCommand]
-    private async Task TestAdb()
-    {
-        if (IsTestingAdb)
-        {
-            return;
-        }
-
-        IsTestingAdb = true;
-        try
-        {
-            var adbPath = string.IsNullOrWhiteSpace(AdbPath)
-                ? await _adbService.ResolveAdbPathAsync()
-                : AdbPath;
-            var result = await _adbService.RunAdbAsync(adbPath ?? string.Empty, ["version"]);
-            AdbTestLog = CommandLogFormatter.FormatCommandResult(result);
-        }
-        finally
-        {
-            IsTestingAdb = false;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Remove the interactive ADB `Test` UI and the accompanying command output area because the manual test flow is unnecessary and adds UI clutter. 
- Eliminate the unused `AdbService` dependency from the settings view model to simplify the view model surface and reduce coupling. 

### Description
- Removed the `Test` button and the ADB command output box from `src/PulseAPK.Avalonia/Views/SettingsView.axaml`. 
- Removed the `TestAdb` command and the observable properties `AdbTestLog` and `IsTestingAdb` from `src/PulseAPK.Core/ViewModels/SettingsViewModel.cs`. 
- Removed the `AdbService` constructor parameter and related field from `SettingsViewModel`, and updated the constructor signature to match. 

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues. 
- Attempted to run `dotnet test PulseAPK.sln`, but the `dotnet` command is not available in the environment so the test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e036d48948322b886dd6bf6fb7112)