### PR TITLE
Add sidebar feature flags

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -48,24 +48,31 @@
                            Margin="0,0,0,20"/>
                 
                 <Button Command="{Binding NavigateToDecompileCommand}"
+                        IsVisible="{Binding IsDecompileEnabled}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuDecompile]}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToBuildCommand}"
+                        IsVisible="{Binding IsBuildEnabled}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToPatchCommand}"
+                        IsVisible="{Binding IsPatchEnabled}"
                         Content="{Binding MenuPatchLabel}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToAnalyserCommand}"
+                        IsVisible="{Binding IsAnalyserEnabled}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToDeviceToolsCommand}"
+                        IsVisible="{Binding IsDeviceToolsEnabled}"
                         Content="{Binding MenuDeviceToolsLabel}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToSettingsCommand}"
+                        IsVisible="{Binding IsSettingsEnabled}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuSettings]}"
                         HorizontalAlignment="Stretch"/>
                 <Button Command="{Binding NavigateToAboutCommand}"
+                        IsVisible="{Binding IsAboutEnabled}"
                         Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAbout]}"
                         HorizontalAlignment="Stretch"/>
             </StackPanel>

--- a/src/PulseAPK.Core/FeatureFlags.cs
+++ b/src/PulseAPK.Core/FeatureFlags.cs
@@ -1,0 +1,17 @@
+namespace PulseAPK.Core;
+
+/// <summary>
+/// Controls which top-level features are available in the application shell.
+/// Set a flag to false to hide its left-menu button and prevent startup/navigation
+/// from opening that feature.
+/// </summary>
+public static class FeatureFlags
+{
+    public const bool Decompile = true;
+    public const bool BuildApk = true;
+    public const bool PatchApk = true;
+    public const bool ApkAnalyser = true;
+    public const bool DeviceTools = true;
+    public const bool Settings = true;
+    public const bool About = true;
+}

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.ComponentModel;
 using PulseAPK.Core.Abstractions;
+using PulseAPK.Core;
 using PulseAPK.Core.Services;
 using Properties = PulseAPK.Core.Properties;
 
@@ -29,63 +30,122 @@ public partial class MainViewModel : ObservableObject
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
 
+    public bool IsDecompileEnabled => FeatureFlags.Decompile;
+    public bool IsBuildEnabled => FeatureFlags.BuildApk;
+    public bool IsPatchEnabled => FeatureFlags.PatchApk;
+    public bool IsAnalyserEnabled => FeatureFlags.ApkAnalyser;
+    public bool IsDeviceToolsEnabled => FeatureFlags.DeviceTools;
+    public bool IsSettingsEnabled => FeatureFlags.Settings;
+    public bool IsAboutEnabled => FeatureFlags.About;
+
     public MainViewModel(IServiceProvider serviceProvider, LocalizationService localizationService)
     {
         _serviceProvider = serviceProvider;
         _localizationService = localizationService;
         WindowTitle = _localizationService["AppTitle"];
         _localizationService.PropertyChanged += HandleLocalizationChanged;
-        // Initial view
-        SetCurrentView(Resolve<DecompileViewModel>());
+        SetInitialView();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToDecompile))]
     private void NavigateToDecompile()
     {
+        if (!CanNavigateToDecompile()) return;
         SetCurrentView(Resolve<DecompileViewModel>());
         SelectedMenu = "Decompile";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToSettings))]
     private void NavigateToSettings()
     {
+        if (!CanNavigateToSettings()) return;
         SetCurrentView(Resolve<SettingsViewModel>());
         SelectedMenu = "Settings";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToBuild))]
     private void NavigateToBuild()
     {
+        if (!CanNavigateToBuild()) return;
         SetCurrentView(Resolve<BuildViewModel>());
         SelectedMenu = "Build";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToPatch))]
     private void NavigateToPatch()
     {
+        if (!CanNavigateToPatch()) return;
         SetCurrentView(Resolve<PatchViewModel>());
         SelectedMenu = "Patch";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToAnalyser))]
     private void NavigateToAnalyser()
     {
+        if (!CanNavigateToAnalyser()) return;
         SetCurrentView(Resolve<AnalyserViewModel>());
         SelectedMenu = "Analyser";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToDeviceTools))]
     private void NavigateToDeviceTools()
     {
+        if (!CanNavigateToDeviceTools()) return;
         SetCurrentView(Resolve<DeviceToolsViewModel>());
         SelectedMenu = "DeviceTools";
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanNavigateToAbout))]
     private void NavigateToAbout()
     {
+        if (!CanNavigateToAbout()) return;
         SetCurrentView(Resolve<AboutViewModel>());
         SelectedMenu = "About";
+    }
+
+    private static bool CanNavigateToDecompile() => FeatureFlags.Decompile;
+    private static bool CanNavigateToBuild() => FeatureFlags.BuildApk;
+    private static bool CanNavigateToPatch() => FeatureFlags.PatchApk;
+    private static bool CanNavigateToAnalyser() => FeatureFlags.ApkAnalyser;
+    private static bool CanNavigateToDeviceTools() => FeatureFlags.DeviceTools;
+    private static bool CanNavigateToSettings() => FeatureFlags.Settings;
+    private static bool CanNavigateToAbout() => FeatureFlags.About;
+
+    private void SetInitialView()
+    {
+        if (FeatureFlags.Decompile)
+        {
+            NavigateToDecompile();
+        }
+        else if (FeatureFlags.BuildApk)
+        {
+            NavigateToBuild();
+        }
+        else if (FeatureFlags.PatchApk)
+        {
+            NavigateToPatch();
+        }
+        else if (FeatureFlags.ApkAnalyser)
+        {
+            NavigateToAnalyser();
+        }
+        else if (FeatureFlags.DeviceTools)
+        {
+            NavigateToDeviceTools();
+        }
+        else if (FeatureFlags.Settings)
+        {
+            NavigateToSettings();
+        }
+        else if (FeatureFlags.About)
+        {
+            NavigateToAbout();
+        }
+        else
+        {
+            CurrentView = "No features are enabled.";
+            SelectedMenu = string.Empty;
+        }
     }
 
     private void SetCurrentView(object nextView)


### PR DESCRIPTION
### Motivation
- Provide a single place to enable/disable top-level left-menu features so the app shell can be configured without editing UI/XAML. 
- Ensure the app respects those flags on startup and prevents navigation to disabled features.

### Description
- Added `src/PulseAPK.Core/FeatureFlags.cs` containing boolean flags for `Decompile`, `BuildApk`, `PatchApk`, `ApkAnalyser`, `DeviceTools`, `Settings`, and `About`, all enabled by default. 
- Exposed boolean properties on `MainViewModel` (`IsDecompileEnabled`, `IsBuildEnabled`, `IsPatchEnabled`, `IsAnalyserEnabled`, `IsDeviceToolsEnabled`, `IsSettingsEnabled`, `IsAboutEnabled`) that reflect the feature flags. 
- Gated navigation commands with `CanExecute` checks and early returns so disabled features cannot be opened, and added `SetInitialView()` to select the first enabled feature on startup. 
- Updated `src/PulseAPK.Avalonia/MainWindow.axaml` to bind each left-sidebar `Button` `IsVisible` to the corresponding `Is*Enabled` property so buttons are hidden when features are disabled.

### Testing
- Attempted an automated build with `dotnet build`, but it could not be run in this environment because the `dotnet` executable is not installed, so no compile/tests were executed. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0575ac7c83229f3f0f3f258672b2)