### PR TITLE
Organize Device Tools by workflow

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -55,101 +55,110 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="12">
-                    <StackPanel Spacing="8">
-                        <TextBlock Text="Primary Task" FontWeight="SemiBold" />
-                        <ComboBox ItemsSource="{Binding DeviceToolModes}"
-                                  SelectedItem="{Binding SelectedDeviceToolMode}"
-                                  HorizontalAlignment="Stretch">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate x:DataType="vm:DeviceToolModeOption">
-                                    <TextBlock Text="{Binding DisplayName}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </StackPanel>
-                </Border>
+                    <Grid ColumnDefinitions="180,*" ColumnSpacing="16">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="Workflow" FontWeight="SemiBold" />
+                            <ListBox ItemsSource="{Binding DeviceToolModes}"
+                                     SelectedItem="{Binding SelectedDeviceToolMode}"
+                                     HorizontalAlignment="Stretch">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:DeviceToolModeOption">
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
 
-                <Border Background="{DynamicResource CardBackgroundBrush}"
-                        BorderBrush="{DynamicResource CardBorderBrush}"
-                        BorderThickness="1"
-                        CornerRadius="6"
-                        Padding="12">
-                    <Grid>
-                        <StackPanel Spacing="8" IsVisible="{Binding IsInstallApkMode}">
-                            <TextBlock Text="Install APK" FontWeight="SemiBold" />
-                            <TextBlock Text="Choose an APK, install it to the selected device, and optionally detect its package metadata." Opacity="0.8" />
-                            <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="8">
+                        <Grid Grid.Column="1">
+                            <StackPanel Spacing="10" IsVisible="{Binding IsInstallApkMode}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="Install APK" FontWeight="SemiBold" />
+                                    <TextBlock Text="Choose an APK, install it, then detect package metadata when needed." Opacity="0.8" />
+                                </StackPanel>
                                 <TextBox Text="{Binding SelectedApkPath}" Watermark="/path/to/app.apk" />
-                                <Button Grid.Column="1" Content="Browse" Command="{Binding BrowseApkCommand}" MinWidth="90" />
-                                <Button Grid.Column="2" Content="Install APK" Command="{Binding InstallApkCommand}" MinWidth="100" />
-                                <Button Grid.Column="3" Content="Detect Package" Command="{Binding DetectPackageCommand}" MinWidth="120" />
-                            </Grid>
-                            <Button Content="Clear APK Selection"
-                                    Command="{Binding ClearApkCommand}"
-                                    HorizontalAlignment="Left" />
-                        </StackPanel>
+                                <WrapPanel>
+                                    <Button Content="Browse" Command="{Binding BrowseApkCommand}" MinWidth="90" Margin="0,0,8,8" />
+                                    <Button Content="Install APK" Command="{Binding InstallApkCommand}" MinWidth="100" Margin="0,0,8,8" />
+                                    <Button Content="Detect Package" Command="{Binding DetectPackageCommand}" MinWidth="120" Margin="0,0,8,8" />
+                                </WrapPanel>
+                                <Button Content="Clear APK Selection"
+                                        Command="{Binding ClearApkCommand}"
+                                        HorizontalAlignment="Left" />
+                            </StackPanel>
 
-                        <StackPanel Spacing="8" IsVisible="{Binding IsLaunchAppMode}">
-                            <TextBlock Text="Launch App" FontWeight="SemiBold" />
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <StackPanel Spacing="10" IsVisible="{Binding IsLaunchAppMode}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="Launch" FontWeight="SemiBold" />
+                                    <TextBlock Text="Enter a package and optionally choose or type a specific activity." Opacity="0.8" />
+                                </StackPanel>
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                                    <StackPanel Spacing="6">
+                                        <TextBlock Text="Package name" Opacity="0.8" />
+                                        <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1" Spacing="6">
+                                        <TextBlock Text="Activity" Opacity="0.8" />
+                                        <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
+                                        <ComboBox ItemsSource="{Binding Activities}"
+                                                  SelectedItem="{Binding Activity}"
+                                                  Watermark="Detected activities"
+                                                  HorizontalAlignment="Stretch" />
+                                    </StackPanel>
+                                </Grid>
+                                <WrapPanel>
+                                    <Button Content="Launch App" Command="{Binding LaunchAppCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Launch Activity" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
+                                </WrapPanel>
+                            </StackPanel>
+
+                            <StackPanel Spacing="10" IsVisible="{Binding IsAppMaintenanceMode}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="Manage App" FontWeight="SemiBold" />
+                                    <TextBlock Text="Target an installed package, then stop it, reset data, or uninstall it." Opacity="0.8" />
+                                </StackPanel>
+                                <TextBlock Text="Package selector / textbox" Opacity="0.8" />
+                                <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
+                                <WrapPanel>
+                                    <Button Content="Force Stop" Command="{Binding ForceStopCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Clear Data" Command="{Binding ClearDataCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Uninstall" Command="{Binding UninstallCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Search Package" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,8" />
+                                    <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,8" />
+                                    <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
+                                </WrapPanel>
+                            </StackPanel>
+
+                            <StackPanel Spacing="10" IsVisible="{Binding IsShellPresetsMode}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="Shell" FontWeight="SemiBold" />
+                                    <TextBlock Text="Pick a preset to fill the command, or type shell/raw ADB arguments manually." Opacity="0.8" />
+                                </StackPanel>
                                 <StackPanel Spacing="6">
-                                    <TextBlock Text="Package name" Opacity="0.8" />
-                                    <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
+                                    <TextBlock Text="Preset" Opacity="0.8" />
+                                    <ComboBox ItemsSource="{Binding ShellPresets}"
+                                              SelectedItem="{Binding SelectedShellPreset}"
+                                              Watermark="Select preset"
+                                              HorizontalAlignment="Stretch">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate x:DataType="vm:ShellPresetOption">
+                                                <TextBlock Text="{Binding DisplayName}" />
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
                                 </StackPanel>
-                                <StackPanel Grid.Column="1" Spacing="6">
-                                    <TextBlock Text="Activity" Opacity="0.8" />
-                                    <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
-                                    <ComboBox ItemsSource="{Binding Activities}"
-                                              SelectedItem="{Binding Activity}"
-                                              HorizontalAlignment="Stretch" />
-                                </StackPanel>
-                            </Grid>
-                            <WrapPanel>
-                                <Button Content="Launch App" Command="{Binding LaunchAppCommand}" Margin="0,0,8,8" />
-                                <Button Content="Launch Activity" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,8" />
-                                <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,8" />
-                                <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
-                            </WrapPanel>
-                        </StackPanel>
-
-                        <StackPanel Spacing="8" IsVisible="{Binding IsAppMaintenanceMode}">
-                            <TextBlock Text="App Maintenance" FontWeight="SemiBold" />
-                            <TextBlock Text="Manage the package installed on the selected device." Opacity="0.8" />
-                            <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
-                            <WrapPanel>
-                                <Button Content="Force Stop" Command="{Binding ForceStopCommand}" Margin="0,0,8,8" />
-                                <Button Content="Clear Data" Command="{Binding ClearDataCommand}" Margin="0,0,8,8" />
-                                <Button Content="Uninstall" Command="{Binding UninstallCommand}" Margin="0,0,8,8" />
-                                <Button Content="Search Package" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
-                            </WrapPanel>
-                        </StackPanel>
-
-                        <StackPanel Spacing="8" IsVisible="{Binding IsShellPresetsMode}">
-                            <TextBlock Text="Shell / Presets" FontWeight="SemiBold" />
-                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
                                 <TextBox Text="{Binding CommandText}" Watermark="getprop ro.product.model" />
-                                <Button Grid.Column="1" Content="Run Shell" Command="{Binding RunShellCommand}" MinWidth="110" />
-                                <Button Grid.Column="2"
-                                        Content="Run ADB Args"
-                                        ToolTip.Tip="Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model."
-                                        Command="{Binding RunAdbCommand}"
-                                        MinWidth="100" />
-                            </Grid>
-                            <WrapPanel>
-                                <Button Content="Model" Command="{Binding RunModelPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="Android Release" Command="{Binding RunAndroidReleasePresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="SDK" Command="{Binding RunSdkPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="CPU ABI" Command="{Binding RunCpuAbiPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="List Packages" Command="{Binding RunListPackagesPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="Third-Party Packages" Command="{Binding RunThirdPartyPackagesPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="Current Activity" Command="{Binding RunCurrentActivityPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="Reboot" Command="{Binding RunRebootPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="ADB Root" Command="{Binding RunAdbRootPresetCommand}" Margin="0,0,8,8" />
-                                <Button Content="ADB Remount" Command="{Binding RunAdbRemountPresetCommand}" Margin="0,0,8,8" />
-                            </WrapPanel>
-                        </StackPanel>
+                                <WrapPanel>
+                                    <Button Content="Run Shell" Command="{Binding RunShellCommand}" MinWidth="110" Margin="0,0,8,8" />
+                                    <Button Content="Run ADB Args"
+                                            ToolTip.Tip="Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model."
+                                            Command="{Binding RunAdbCommand}"
+                                            MinWidth="100"
+                                            Margin="0,0,8,8" />
+                                </WrapPanel>
+                            </StackPanel>
+                        </Grid>
                     </Grid>
                 </Border>
             </StackPanel>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -17,6 +17,7 @@ public enum DeviceToolMode
 }
 
 public sealed record DeviceToolModeOption(DeviceToolMode Mode, string DisplayName);
+public sealed record ShellPresetOption(string DisplayName, string CommandText);
 
 public partial class DeviceToolsViewModel : ObservableObject
 {
@@ -92,6 +93,9 @@ public partial class DeviceToolsViewModel : ObservableObject
     private DeviceToolModeOption? _selectedDeviceToolMode;
 
     [ObservableProperty]
+    private ShellPresetOption? _selectedShellPreset;
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(InstallApkCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectPackageCommand))]
     [NotifyCanExecuteChangedFor(nameof(LaunchAppCommand))]
@@ -121,9 +125,22 @@ public partial class DeviceToolsViewModel : ObservableObject
     public IReadOnlyList<DeviceToolModeOption> DeviceToolModes { get; } =
     [
         new(DeviceToolMode.InstallApk, "Install APK"),
-        new(DeviceToolMode.LaunchApp, "Launch App"),
-        new(DeviceToolMode.AppMaintenance, "App Maintenance"),
-        new(DeviceToolMode.ShellPresets, "Shell / Presets")
+        new(DeviceToolMode.LaunchApp, "Launch"),
+        new(DeviceToolMode.AppMaintenance, "Manage App"),
+        new(DeviceToolMode.ShellPresets, "Shell")
+    ];
+    public IReadOnlyList<ShellPresetOption> ShellPresets { get; } =
+    [
+        new("Model", "getprop ro.product.model"),
+        new("Android Release", "getprop ro.build.version.release"),
+        new("SDK", "getprop ro.build.version.sdk"),
+        new("CPU ABI", "getprop ro.product.cpu.abi"),
+        new("List Packages", "pm list packages"),
+        new("Third-Party Packages", "pm list packages -3"),
+        new("Current Activity", "dumpsys window | grep -E \"mCurrentFocus|mFocusedApp\""),
+        new("Reboot", "reboot"),
+        new("ADB Root", "root"),
+        new("ADB Remount", "remount")
     ];
 
     public string AdbStatus => IsAdbFound ? "ADB: found" : "ADB: not found";
@@ -138,6 +155,15 @@ public partial class DeviceToolsViewModel : ObservableObject
         _adbService = adbService;
         _filePickerService = filePickerService;
         _selectedDeviceToolMode = DeviceToolModes[0];
+        _selectedShellPreset = ShellPresets[0];
+    }
+
+    partial void OnSelectedShellPresetChanged(ShellPresetOption? value)
+    {
+        if (value is not null)
+        {
+            CommandText = value.CommandText;
+        }
     }
 
     [RelayCommand(AllowConcurrentExecutions = true)]


### PR DESCRIPTION
### Motivation
- Improve usability by showing a single device-tool workflow at a time instead of exposing all controls together. 
- Group controls around common user tasks: installing APKs, launching apps/activities, app maintenance, and running shell/ADB commands. 
- Provide shell presets so users can quickly populate common ADB/shell commands.

### Description
- Reworked `DeviceToolsView.axaml` to replace the top `ComboBox` with a left-side `ListBox` workflow selector and show only the selected workflow panel. 
- Reorganized UI panels so each workflow contains the requested controls: Install APK (path, Browse, Install, Detect), Launch (package, activity textbox/dropdown, Launch App/Activity, Current Activity), Manage App (package textbox/selector, Force Stop, Clear Data, Uninstall), and Shell (preset dropdown, command textbox, Run Shell, Run ADB Args). 
- Added `ShellPresetOption` record, `ShellPresets` list, and `_selectedShellPreset` observable property to `DeviceToolsViewModel`, initialized the selected preset and implemented `OnSelectedShellPresetChanged` to populate `CommandText` when a preset is chosen. 
- Adjusted workflow display names (`Launch`, `Manage App`, `Shell`) and updated view bindings to use the new view-model properties.

### Testing
- Parsed the updated XAML with `python3` using `xml.etree.ElementTree` and it succeeded (`xml ok`).
- Attempted `dotnet build` but it could not be run in this environment because `dotnet` is not installed, so a full build/test was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0a2ed914832298129e6c8e307c92)