### PR TITLE
Separate destructive device app actions

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -3,6 +3,20 @@
              xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.DeviceToolsView"
              x:DataType="vm:DeviceToolsViewModel">
+    <UserControl.Styles>
+        <Style Selector="Button.destructive">
+            <Setter Property="Background" Value="#B3261E" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="Button.destructive:pointerover">
+            <Setter Property="Background" Value="#C93A32" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="Button.destructive:pressed">
+            <Setter Property="Background" Value="#8C1D18" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+    </UserControl.Styles>
     <Grid RowDefinitions="*,220" RowSpacing="16" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="14">
@@ -88,7 +102,7 @@
 
                             <StackPanel Spacing="10" IsVisible="{Binding IsLaunchAppMode}">
                                 <StackPanel Spacing="4">
-                                    <TextBlock Text="Launch" FontWeight="SemiBold" />
+                                    <TextBlock Text="Launch App" FontWeight="SemiBold" />
                                     <TextBlock Text="Enter a package and optionally choose or type a specific activity." Opacity="0.8" />
                                 </StackPanel>
                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
@@ -105,12 +119,18 @@
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
-                                <WrapPanel>
-                                    <Button Content="Launch App" Command="{Binding LaunchAppCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Launch Activity" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
-                                </WrapPanel>
+                                <StackPanel Spacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Launch" FontWeight="SemiBold" />
+                                        <TextBlock Text="Start the app, open a specific activity, or inspect the foreground activity." Opacity="0.75" />
+                                    </StackPanel>
+                                    <WrapPanel>
+                                        <Button Content="Launch App" Command="{Binding LaunchAppCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Launch Activity" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
+                                    </WrapPanel>
+                                </StackPanel>
                             </StackPanel>
 
                             <StackPanel Spacing="10" IsVisible="{Binding IsAppMaintenanceMode}">
@@ -120,14 +140,29 @@
                                 </StackPanel>
                                 <TextBlock Text="Package selector / textbox" Opacity="0.8" />
                                 <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
-                                <WrapPanel>
-                                    <Button Content="Force Stop" Command="{Binding ForceStopCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Clear Data" Command="{Binding ClearDataCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Uninstall" Command="{Binding UninstallCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Search Package" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,8" />
-                                    <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,8" />
-                                    <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
-                                </WrapPanel>
+                                <StackPanel Spacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Destructive Commands" FontWeight="SemiBold" />
+                                        <TextBlock Text="Stop, reset, or remove the selected package. Clear Data and Uninstall require confirmation." Opacity="0.75" />
+                                    </StackPanel>
+                                    <WrapPanel>
+                                        <Button Content="Force Stop" Classes="destructive" Command="{Binding ForceStopCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Clear Data" Classes="destructive" Command="{Binding ClearDataCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Uninstall" Classes="destructive" Command="{Binding UninstallCommand}" Margin="0,0,8,8" />
+                                    </WrapPanel>
+                                </StackPanel>
+
+                                <StackPanel Spacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Package Tools" FontWeight="SemiBold" />
+                                        <TextBlock Text="Search for packages or inspect the installed app path without changing the app." Opacity="0.75" />
+                                    </StackPanel>
+                                    <WrapPanel>
+                                        <Button Content="Search Package" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,8" />
+                                        <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,8" />
+                                        <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,8" />
+                                    </WrapPanel>
+                                </StackPanel>
                             </StackPanel>
 
                             <StackPanel Spacing="10" IsVisible="{Binding IsShellPresetsMode}">

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -40,6 +40,7 @@ public partial class DeviceToolsViewModel : ObservableObject
 {
     private readonly AdbService _adbService;
     private readonly IFilePickerService _filePickerService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AdbStatus))]
@@ -172,10 +173,11 @@ public partial class DeviceToolsViewModel : ObservableObject
     public bool IsShellPresetsMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.ShellPresets;
     public bool HasWorkingDevice => SelectedDevice?.IsUsable == true;
 
-    public DeviceToolsViewModel(AdbService adbService, IFilePickerService filePickerService)
+    public DeviceToolsViewModel(AdbService adbService, IFilePickerService filePickerService, IDialogService dialogService)
     {
         _adbService = adbService;
         _filePickerService = filePickerService;
+        _dialogService = dialogService;
         _selectedDeviceToolMode = DeviceToolModes[0];
         _selectedPreset = Presets[0];
     }
@@ -323,13 +325,35 @@ public partial class DeviceToolsViewModel : ObservableObject
     [RelayCommand(CanExecute = nameof(CanRunPackageAction))]
     private async Task ClearData()
     {
-        await RunPackageActionAsync(["shell", "pm", "clear", PackageName.Trim()]);
+        var package = PackageName.Trim();
+        var confirmed = await _dialogService.ShowQuestionAsync(
+            $"Clear all app data for '{package}'? This removes app storage and cannot be undone.",
+            "Confirm clear app data");
+
+        if (!confirmed)
+        {
+            AppendLog($"Clear data cancelled for '{package}'.");
+            return;
+        }
+
+        await RunPackageActionAsync(["shell", "pm", "clear", package]);
     }
 
     [RelayCommand(CanExecute = nameof(CanRunPackageAction))]
     private async Task Uninstall()
     {
-        await RunPackageActionAsync(["uninstall", PackageName.Trim()]);
+        var package = PackageName.Trim();
+        var confirmed = await _dialogService.ShowQuestionAsync(
+            $"Uninstall '{package}' from the selected device? This removes the app and its data.",
+            "Confirm uninstall app");
+
+        if (!confirmed)
+        {
+            AppendLog($"Uninstall cancelled for '{package}'.");
+            return;
+        }
+
+        await RunPackageActionAsync(["uninstall", package]);
     }
 
     [RelayCommand(CanExecute = nameof(CanRunDeviceAction))]


### PR DESCRIPTION
### Motivation
- Improve UX by separating launch actions from destructive app management actions in the Device Tools UI.
- Make destructive operations more visible and safer by styling destructive buttons and adding confirmation prompts for destructive commands.

### Description
- Added a local `Button.destructive` style in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` with normal/hover/pressed colors and white foreground via `UserControl.Styles`.
- Reorganized the Launch UI so `LaunchAppCommand`, `LaunchActivityCommand`, and `CurrentActivityCommand` remain grouped under a `Launch` section and added clarifying text labels.
- Moved `ForceStopCommand`, `ClearDataCommand`, and `UninstallCommand` into a distinct destructive area under `Manage App` and applied the `destructive` class to those buttons; separated non-destructive package tools (`Search Package`, `App Path`, `Clear`) into a `Package Tools` area.
- Updated `src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs` to accept an `IDialogService` and added confirmation dialogs using `ShowQuestionAsync` before executing `ClearData` and `Uninstall`, with cancellation logging if the user declines.

### Testing
- Ran `git diff --check` with no index errors detected.
- Attempted `dotnet build PulseAPK.sln` but the build could not be executed in this environment because `dotnet` is not installed, so a full compile/test run was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0cf89bdc8322812547dbe803ce43)