### PR TITLE
DeviceToolsView: Add compact ADB badge, Details expander, and Refresh Devices button

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -33,34 +33,47 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="10">
-                    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
-                        <Border Background="{DynamicResource MainBackgroundBrush}"
-                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="12"
-                                Padding="10,4"
-                                VerticalAlignment="Center"
-                                ToolTip.Tip="{Binding DetectedAdbPath}">
-                            <TextBlock Text="{Binding AdbStatus}"
-                                       FontWeight="SemiBold" />
-                        </Border>
+                    <Grid RowDefinitions="Auto,Auto" RowSpacing="10">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                            <Border Background="{DynamicResource MainBackgroundBrush}"
+                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="12"
+                                    Padding="10,4"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="{Binding DetectedAdbPath}">
+                                <TextBlock Text="{Binding AdbStatus}"
+                                           FontWeight="SemiBold" />
+                            </Border>
 
-                        <ComboBox Grid.Column="1"
-                                  ItemsSource="{Binding Devices}"
-                                  SelectedItem="{Binding SelectedDevice}"
-                                  Watermark="Select device"
-                                  HorizontalAlignment="Stretch">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding DisplayName}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                            <Expander Grid.Column="1"
+                                      Header="Details"
+                                      HorizontalAlignment="Left"
+                                      VerticalAlignment="Center">
+                                <TextBox Text="{Binding DetectedAdbPath}"
+                                         IsReadOnly="True"
+                                         MinWidth="360"
+                                         Margin="0,6,0,0" />
+                            </Expander>
+                        </Grid>
 
-                        <Button Grid.Column="2"
-                                Content="Refresh"
-                                Command="{Binding RefreshDevicesCommand}"
-                                MinWidth="100" />
+                        <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <ComboBox ItemsSource="{Binding Devices}"
+                                      SelectedItem="{Binding SelectedDevice}"
+                                      Watermark="Select device"
+                                      HorizontalAlignment="Stretch">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding DisplayName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                            <Button Grid.Column="1"
+                                    Content="Refresh Devices"
+                                    Command="{Binding RefreshDevicesCommand}"
+                                    MinWidth="120" />
+                        </Grid>
                     </Grid>
                 </Border>
 


### PR DESCRIPTION
### Motivation
- Surface ADB availability at the top of the Device Tools area while keeping the detected ADB path available but not part of the main workflow. 
- Make device selection and refreshing immediately accessible so users can pick a device first and then choose tasks.

### Description
- Reworked the top card layout in `DeviceToolsView.axaml` to use a two-row grid so the `AdbStatus` appears as a compact badge while an adjacent `Expander` shows `DetectedAdbPath` in a read-only `TextBox` labeled `Details`.
- Moved the device `ComboBox` into the primary row below the badge and added a `Refresh Devices` button bound to `RefreshDevicesCommand` with updated content and spacing.
- Ensured `DetectedAdbPath` remains bound read-only (`IsReadOnly="True"`) and separated from the main workflow so device selection and task choice are foregrounded.

### Testing
- Parsed the modified AXAML with `python3` using `xml.etree.ElementTree` and the file was reported as well-formed XML (success).
- Attempted `dotnet build --no-restore` but the `dotnet` CLI is unavailable in the environment so the solution build was not performed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0e28923c832288f7767ed3c23893)