### PR TITLE
Refactor Device Tools console panel to collapsible Expander

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -17,7 +17,7 @@
             <Setter Property="Foreground" Value="White" />
         </Style>
     </UserControl.Styles>
-    <Grid RowDefinitions="*,220" RowSpacing="16" Margin="20">
+    <Grid RowDefinitions="*,Auto" RowSpacing="16" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="14">
                 <StackPanel Spacing="4">
@@ -225,23 +225,23 @@
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">
-            <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <Grid ColumnDefinitions="*,Auto">
-                    <TextBlock Text="Console log"
-                               FontWeight="SemiBold" />
-                    <Button Grid.Column="1"
-                            Content="Clear"
+            <Expander Header="Console log"
+                      IsExpanded="False">
+                <Grid RowDefinitions="Auto,*" RowSpacing="8" Margin="0,8,0,0">
+                    <Button Content="Clear"
                             Command="{Binding ClearConsoleCommand}"
-                            MinWidth="80" />
+                            MinWidth="80"
+                            HorizontalAlignment="Right" />
+                    <TextBox Grid.Row="1"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="160"
+                             MaxHeight="260" />
                 </Grid>
-                <TextBox Grid.Row="1"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         VerticalAlignment="Stretch" />
-            </Grid>
+            </Expander>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Remove the fixed 220px console area so the main Device Tools content is not permanently constrained by a large bottom panel.
- Make the console compact by default and collapsible while preserving the existing console behavior and commands.

### Description
- Change the root `Grid` row definitions from `"*,220"` to `"*,Auto"` so the bottom area no longer has a fixed height and can size to content.
- Replace the fixed-height `Border`+`TextBox` console with an `Expander` labeled `"Console log"` and set `IsExpanded="False"` so the console is collapsed by default.
- Preserve the `TextBox` bound to `ConsoleLog` and the `Button` bound to `ClearConsoleCommand`, and add `MinHeight`/`MaxHeight` constraints to the expanded console for a reasonable expansion size.

### Testing
- Parsed the modified AXAML with `xml.etree.ElementTree` using `ET.parse('src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml')` which succeeded and confirmed the file is valid XML.
- Attempted `dotnet build` but it could not be run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e0ee428ec8322aa5e82caa1dc1b47)