### PR TITLE
Fix Avalonia ComboBox compilation errors

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -60,7 +60,6 @@
                         <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="10">
                             <ComboBox ItemsSource="{Binding Devices}"
                                       SelectedItem="{Binding SelectedDevice}"
-                                      Watermark="Select device"
                                       HorizontalAlignment="Stretch">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
@@ -128,7 +127,6 @@
                                         <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
                                         <ComboBox ItemsSource="{Binding Activities}"
                                                   SelectedItem="{Binding Activity}"
-                                                  Watermark="Detected activities"
                                                   HorizontalAlignment="Stretch" />
                                     </StackPanel>
                                 </Grid>
@@ -190,7 +188,6 @@
                                     <ComboBox Grid.Column="1"
                                               ItemsSource="{Binding Presets}"
                                               SelectedItem="{Binding SelectedPreset}"
-                                              Watermark="Select preset"
                                               HorizontalAlignment="Stretch">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate x:DataType="vm:DeviceToolPreset">


### PR DESCRIPTION
### Motivation
- Resolve Avalonia XAML compilation failures (AVLN2000) caused by unsupported `Watermark` attributes on `ComboBox` controls in the DeviceTools view.

### Description
- Remove the `Watermark` attributes from the three `ComboBox` controls in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to eliminate the invalid property usage.

### Testing
- Attempted to run `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj -c Release`, but the automated build could not be executed because `dotnet` is not installed in the environment (build did not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e10bbfb308322aa6b413b0f919fa5)