### PR TITLE
Refine device tools connection status card

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -16,6 +16,18 @@
             <Setter Property="Background" Value="#8C1D18" />
             <Setter Property="Foreground" Value="White" />
         </Style>
+        <Style Selector="Border.adb-status-pill">
+            <Setter Property="Background" Value="#ECEFF1" />
+            <Setter Property="BorderBrush" Value="#B0BEC5" />
+        </Style>
+        <Style Selector="Border.adb-status-pill.found">
+            <Setter Property="Background" Value="#DDF6E6" />
+            <Setter Property="BorderBrush" Value="#2E7D32" />
+        </Style>
+        <Style Selector="Border.adb-status-pill.missing">
+            <Setter Property="Background" Value="#FDE7D3" />
+            <Setter Property="BorderBrush" Value="#EF6C00" />
+        </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="*,Auto" RowSpacing="16" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
@@ -32,32 +44,43 @@
                         BorderBrush="{DynamicResource CardBorderBrush}"
                         BorderThickness="1"
                         CornerRadius="6"
-                        Padding="10">
-                    <Grid RowDefinitions="Auto,Auto" RowSpacing="10">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
-                            <Border Background="{DynamicResource MainBackgroundBrush}"
-                                    BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                    BorderThickness="1"
-                                    CornerRadius="12"
-                                    Padding="10,4"
-                                    VerticalAlignment="Center"
-                                    ToolTip.Tip="{Binding DetectedAdbPath}">
-                                <TextBlock Text="{Binding AdbStatus}"
+                        Padding="12">
+                    <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="10">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                            <StackPanel Spacing="6">
+                                <TextBlock Text="Connection"
                                            FontWeight="SemiBold" />
-                            </Border>
+                                <WrapPanel>
+                                    <Border Classes="adb-status-pill"
+                                            Classes.found="{Binding IsAdbFound}"
+                                            Classes.missing="{Binding IsAdbMissing}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="10,4"
+                                            Margin="0,0,8,4"
+                                            ToolTip.Tip="{Binding DetectedAdbPath}">
+                                        <TextBlock Text="{Binding AdbStatus}"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="12" />
+                                    </Border>
+                                    <TextBlock Text="Select a connected Android device for APK and shell tools."
+                                               Opacity="0.75"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,0,4" />
+                                </WrapPanel>
+                            </StackPanel>
 
-                            <Expander Grid.Column="1"
-                                      Header="Details"
-                                      HorizontalAlignment="Left"
-                                      VerticalAlignment="Center">
-                                <TextBox Text="{Binding DetectedAdbPath}"
-                                         IsReadOnly="True"
-                                         MinWidth="360"
-                                         Margin="0,6,0,0" />
-                            </Expander>
+                            <Button Grid.Column="1"
+                                    Content="Refresh Devices"
+                                    Command="{Binding RefreshDevicesCommand}"
+                                    MinWidth="120"
+                                    VerticalAlignment="Top" />
                         </Grid>
 
-                        <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+                        <Grid Grid.Row="1"
+                              ColumnDefinitions="*,Auto"
+                              ColumnSpacing="10"
+                              IsVisible="{Binding IsAdbFound}">
                             <ComboBox ItemsSource="{Binding Devices}"
                                       SelectedItem="{Binding SelectedDevice}"
                                       HorizontalAlignment="Stretch">
@@ -72,12 +95,28 @@
                                        Text="{Binding DeviceListStatus}"
                                        VerticalAlignment="Center"
                                        Opacity="0.75" />
-
-                            <Button Grid.Column="2"
-                                    Content="Refresh Devices"
-                                    Command="{Binding RefreshDevicesCommand}"
-                                    MinWidth="120" />
                         </Grid>
+
+                        <Border Grid.Row="2"
+                                Background="{DynamicResource MainBackgroundBrush}"
+                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                Padding="10"
+                                IsVisible="{Binding HasNoConnectedDevices}">
+                            <TextBlock Text="{Binding DeviceListStatus}"
+                                       TextWrapping="Wrap"
+                                       FontWeight="SemiBold" />
+                        </Border>
+
+                        <Expander Grid.Row="3"
+                                  Header="ADB path"
+                                  HorizontalAlignment="Left">
+                            <TextBox Text="{Binding DetectedAdbPath}"
+                                     IsReadOnly="True"
+                                     MinWidth="360"
+                                     Margin="0,6,0,0" />
+                        </Expander>
                     </Grid>
                 </Border>
 

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -49,22 +49,28 @@ public partial class DeviceToolsViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AdbStatus))]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(IsAdbMissing))]
+    [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _isAdbFound;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AdbStatus))]
+    [NotifyPropertyChangedFor(nameof(IsAdbMissing))]
     private bool _hasCheckedAdb;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AdbStatus))]
+    [NotifyPropertyChangedFor(nameof(IsAdbMissing))]
     private bool _isCheckingAdb;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _hasCheckedDevices;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _isRefreshingDevices;
 
     [ObservableProperty]
@@ -191,8 +197,10 @@ public partial class DeviceToolsViewModel : ObservableObject
     public string DeviceListStatus => IsRefreshingDevices
         ? "Checking devices..."
         : HasCheckedDevices && IsAdbFound && Devices.Count == 0
-            ? "No connected devices found"
+            ? "No Android device connected. Connect a device and enable USB debugging."
             : string.Empty;
+    public bool IsAdbMissing => HasCheckedAdb && !IsCheckingAdb && !IsAdbFound;
+    public bool HasNoConnectedDevices => HasCheckedDevices && IsAdbFound && !IsRefreshingDevices && Devices.Count == 0;
     public bool IsInstallApkMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.InstallApk;
     public bool IsLaunchAppMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.LaunchApp;
     public bool IsAppMaintenanceMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.AppMaintenance;
@@ -241,10 +249,12 @@ public partial class DeviceToolsViewModel : ObservableObject
 
             SelectedDevice = Devices.FirstOrDefault(device => device.IsUsable) ?? Devices.FirstOrDefault();
             OnPropertyChanged(nameof(DeviceListStatus));
+            OnPropertyChanged(nameof(HasNoConnectedDevices));
         }
         finally
         {
             IsRefreshingDevices = false;
+            OnPropertyChanged(nameof(HasNoConnectedDevices));
         }
     }
 


### PR DESCRIPTION
### Motivation
- Compact and clarify the top Device Tools area into a focused "Connection" card that surfaces ADB availability and device state more clearly. 
- Present ADB status as a small visual pill and keep `Refresh Devices` as the primary action while hiding device controls when ADB is not available.
- Improve the empty-state messaging when no Android devices are connected and surface the ADB path behind a disclosure.

### Description
- Updated `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to replace the old status area with a `Connection` card, added a small ADB status pill, moved `Refresh Devices` to the card header, and added an `Expander` labeled `ADB path` for the detected ADB path. 
- Added pill styling rules (`Border.adb-status-pill`, `.found`, and `.missing`) and used class bindings to render neutral/green/orange visuals based on ADB state. 
- Hid the device `ComboBox` when ADB is not found by binding `IsVisible` to `IsAdbFound` and added a secondary `Border` that displays the promoted empty-state message when `HasNoConnectedDevices` is true. 
- Extended `src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs` with `IsAdbMissing` and `HasNoConnectedDevices` properties, changed `DeviceListStatus` copy to the clearer empty-state text, and raised `OnPropertyChanged` for `HasNoConnectedDevices` during device refresh flow.

### Testing
- Attempted `dotnet build` in the environment but the `dotnet` SDK is not installed, so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3ea54170832289944207149d3e2d)