### PR TITLE
Add device tools action hints

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -175,6 +175,10 @@
                                             <Button Content="Detect Package" Command="{Binding DetectPackageCommand}" MinWidth="120" Margin="0,0,8,4" />
                                             <Button Content="Clear APK Selection" Command="{Binding ClearApkCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
+                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                                   IsVisible="{Binding CanShowNoDeviceHint}"
+                                                   Opacity="0.75"
+                                                   TextWrapping="Wrap" />
                                     </StackPanel>
                                 </StackPanel>
 
@@ -202,6 +206,16 @@
                                         <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,4" />
                                         <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                     </WrapPanel>
+                                    <StackPanel Spacing="2">
+                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                                   IsVisible="{Binding CanShowNoDeviceHint}"
+                                                   Opacity="0.75"
+                                                   TextWrapping="Wrap" />
+                                        <TextBlock Text="Enter a package name to continue."
+                                                   IsVisible="{Binding CanShowPackageRequiredHint}"
+                                                   Opacity="0.75"
+                                                   TextWrapping="Wrap" />
+                                    </StackPanel>
                                 </StackPanel>
 
                                 <StackPanel Spacing="10" IsVisible="{Binding IsAppMaintenanceMode}">
@@ -220,6 +234,16 @@
                                             <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,4" />
                                             <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
+                                        <StackPanel Spacing="2">
+                                            <TextBlock Text="Connect a usable Android device to enable these actions."
+                                                       IsVisible="{Binding CanShowNoDeviceHint}"
+                                                       Opacity="0.75"
+                                                       TextWrapping="Wrap" />
+                                            <TextBlock Text="Enter a package name to continue."
+                                                       IsVisible="{Binding CanShowPackageRequiredHint}"
+                                                       Opacity="0.75"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
                                     </StackPanel>
                                 </StackPanel>
 
@@ -258,6 +282,10 @@
                                                     MinWidth="100"
                                                     Margin="0,0,8,4" />
                                         </WrapPanel>
+                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                                   IsVisible="{Binding CanShowNoDeviceHint}"
+                                                   Opacity="0.75"
+                                                   TextWrapping="Wrap" />
                                     </StackPanel>
                                 </StackPanel>
                             </Grid>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -75,6 +75,8 @@ public partial class DeviceToolsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasWorkingDevice))]
+    [NotifyPropertyChangedFor(nameof(CanShowNoDeviceHint))]
+    [NotifyPropertyChangedFor(nameof(CanShowPackageRequiredHint))]
     [NotifyCanExecuteChangedFor(nameof(InstallApkCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectPackageCommand))]
     [NotifyCanExecuteChangedFor(nameof(LaunchAppCommand))]
@@ -106,6 +108,7 @@ public partial class DeviceToolsViewModel : ObservableObject
     private string _selectedApkPath = string.Empty;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanShowPackageRequiredHint))]
     [NotifyCanExecuteChangedFor(nameof(LaunchAppCommand))]
     [NotifyCanExecuteChangedFor(nameof(LaunchActivityCommand))]
     [NotifyCanExecuteChangedFor(nameof(ForceStopCommand))]
@@ -140,6 +143,8 @@ public partial class DeviceToolsViewModel : ObservableObject
     private DeviceToolPreset? _selectedPreset;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanShowNoDeviceHint))]
+    [NotifyPropertyChangedFor(nameof(CanShowPackageRequiredHint))]
     [NotifyCanExecuteChangedFor(nameof(InstallApkCommand))]
     [NotifyCanExecuteChangedFor(nameof(DetectPackageCommand))]
     [NotifyCanExecuteChangedFor(nameof(LaunchAppCommand))]
@@ -206,6 +211,8 @@ public partial class DeviceToolsViewModel : ObservableObject
     public bool IsAppMaintenanceMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.AppMaintenance;
     public bool IsShellPresetsMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.ShellPresets;
     public bool HasWorkingDevice => SelectedDevice?.IsUsable == true;
+    public bool CanShowNoDeviceHint => !IsRunning && !HasWorkingDevice;
+    public bool CanShowPackageRequiredHint => !IsRunning && string.IsNullOrWhiteSpace(PackageName);
 
     public DeviceToolsViewModel(AdbService adbService, IFilePickerService filePickerService, IDialogService dialogService)
     {


### PR DESCRIPTION
### Motivation
- Improve UX by showing contextual helper messages when device-dependent actions are unavailable.
- Provide specific guidance when no usable Android device is selected and when package-dependent actions require a package name.
- Expose simple boolean properties for Avalonia bindings so the view updates when device, package, or running state changes.

### Description
- Updated `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to add visible helper `TextBlock`s near the Install, Launch, App Maintenance, and Shell action groups, bound to `CanShowNoDeviceHint` and `CanShowPackageRequiredHint`.
- Added computed properties `CanShowNoDeviceHint` and `CanShowPackageRequiredHint` to `src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs` that return `!IsRunning && !HasWorkingDevice` and `!IsRunning && string.IsNullOrWhiteSpace(PackageName)`, respectively.
- Added `NotifyPropertyChangedFor` attributes so changes to `SelectedDevice`, `PackageName`, `SelectedPreset`, and `IsRunning` will raise updates for the new hint properties and existing command can-execute notifications.
- Kept existing command and validation logic unchanged; hints are purely view/VM helpers for guidance.

### Testing
- Ran `git diff --check` to verify whitespace/format issues and it passed.
- Attempted `dotnet test` but it could not be run in this environment because `dotnet` is not installed (test run unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4020ab5c832284c4101ac105840b)