### PR TITLE
Clarify launch activity inputs

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -192,12 +192,17 @@
                                             <TextBlock Text="Package name" Opacity="0.8" />
                                             <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
                                         </StackPanel>
-                                        <StackPanel Grid.Column="1" Spacing="6">
-                                            <TextBlock Text="Activity" Opacity="0.8" />
-                                            <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
-                                            <ComboBox ItemsSource="{Binding Activities}"
-                                                      SelectedItem="{Binding Activity}"
-                                                      HorizontalAlignment="Stretch" />
+                                        <StackPanel Grid.Column="1" Spacing="8">
+                                            <StackPanel Spacing="6">
+                                                <TextBlock Text="Activity" Opacity="0.8" />
+                                                <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
+                                            </StackPanel>
+                                            <StackPanel Spacing="6">
+                                                <TextBlock Text="Detected activities" Opacity="0.8" />
+                                                <ComboBox ItemsSource="{Binding Activities}"
+                                                          SelectedItem="{Binding Activity}"
+                                                          HorizontalAlignment="Stretch" />
+                                            </StackPanel>
                                         </StackPanel>
                                     </Grid>
                                     <WrapPanel>


### PR DESCRIPTION
### Motivation
- Improve the Launch App UI by making the manual activity input the primary control and separating detected activity choices for clarity.
- Avoid surprising users by clearly labeling automatically detected activities and provide a cleaner layout for picking an activity.

### Description
- Updated `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to replace the inline `TextBox`+`ComboBox` with a two-row layout that keeps the manual `TextBox` as the primary input and places the detected activity selector under a `Detected activities` label.
- Adjusted spacing in the `IsLaunchAppMode` section to `Spacing="8"` and introduced nested `StackPanel`s to separate the controls while preserving existing bindings (`Activity` and `Activities`).
- No changes were made to view models or runtime logic; bindings and commands remain unchanged.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Attempted `dotnet build`, but the environment does not have the `dotnet` SDK installed so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e40f7a8188322b0958504008be3c4)