### PR TITLE
Improve device tools command output panel

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -29,7 +29,7 @@
             <Setter Property="BorderBrush" Value="#EF6C00" />
         </Style>
     </UserControl.Styles>
-    <Grid RowDefinitions="*,Auto" RowSpacing="16" Margin="20">
+    <Grid RowDefinitions="*,Auto" RowSpacing="10" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="14">
                 <StackPanel Spacing="4">
@@ -306,23 +306,32 @@
                 BorderThickness="1"
                 CornerRadius="6"
                 Padding="12">
-            <Expander Header="Console log"
-                      IsExpanded="False">
-                <Grid RowDefinitions="Auto,*" RowSpacing="8" Margin="0,8,0,0">
-                    <Button Content="Clear"
+            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                    <TextBlock Text="Command output"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                    <Button Grid.Column="1"
+                            Content="Clear"
                             Command="{Binding ClearConsoleCommand}"
                             MinWidth="80"
                             HorizontalAlignment="Right" />
-                    <TextBox Grid.Row="1"
-                             Text="{Binding ConsoleLog}"
-                             IsReadOnly="True"
-                             AcceptsReturn="True"
-                             TextWrapping="Wrap"
-                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="160"
-                             MaxHeight="260" />
                 </Grid>
-            </Expander>
+
+                <TextBlock Grid.Row="1"
+                           Text="Latest command output appears below."
+                           FontSize="12"
+                           Opacity="0.65" />
+
+                <TextBox Grid.Row="2"
+                         Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         MinHeight="180"
+                         MaxHeight="280" />
+            </Grid>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Make the bottom device tools console always visible and reduce the large blank gap so command results are immediately accessible below the active workflow card.
- Surface a clearer header and a small status line so users can tell this area contains the latest command output and act on it quickly.
- Keep the `Clear` action aligned with the panel header to improve ergonomics compared to the previous collapsed expander placement.

### Description
- Reduced main layout spacing by changing `RowSpacing` from `16` to `10` in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` so the output panel sits closer to the workflow area. 
- Replaced the `Expander Header="Console log"` block with a persistent panel implemented as a `Grid` and updated the header text to `Command output` in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`.
- Moved the `Clear` button into the panel header and added a helper `TextBlock` reading `Latest command output appears below.` above the log body in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`.
- Increased the visible output area by adjusting the `TextBox` `MinHeight`/`MaxHeight` values so results are more readily readable without extra expansion.

### Testing
- Ran `git diff --check` which completed without issues.
- Attempted `dotnet build` in this environment but it could not be executed because the `dotnet` CLI is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4219b3948322a719c1a192695796)