### PR TITLE
Improve screen-recording UX and logcat PID guidance in device utilities

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -312,14 +312,16 @@
                                             <StackPanel Spacing="6">
                                                 <TextBlock Text="Utilities" FontWeight="SemiBold" />
                                                 <TextBlock Text="Capture the screen or record a short MP4 without modifying app data." Opacity="0.75" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding ScreenRecordStatus}" Opacity="0.75" TextWrapping="Wrap" />
                                                 <WrapPanel>
                                                     <Button Content="Screenshot" Command="{Binding TakeScreenshotCommand}" Margin="0,0,8,4" />
                                                     <Button Content="Start Screen Record" Command="{Binding StartScreenRecordCommand}" Margin="0,0,8,4" />
                                                     <Button Content="Stop Screen Record" Command="{Binding StopScreenRecordCommand}" Margin="0,0,8,4" />
                                                 </WrapPanel>
-                                                <TextBlock Text="After starting a screen recording, use Stop Screen Record to finish and pull the MP4."
+                                                <TextBlock Text="Recording is active on the selected device until you stop it."
                                                            IsVisible="{Binding IsScreenRecording}"
-                                                           Opacity="0.75"
+                                                           FontWeight="SemiBold"
+                                                           Opacity="0.85"
                                                            TextWrapping="Wrap" />
                                             </StackPanel>
                                         </Border>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -189,6 +189,7 @@ public partial class DeviceToolsViewModel : ObservableObject
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(StartScreenRecordCommand))]
     [NotifyCanExecuteChangedFor(nameof(StopScreenRecordCommand))]
+    [NotifyPropertyChangedFor(nameof(ScreenRecordStatus))]
     private bool _isScreenRecording;
 
     private CancellationTokenSource? _screenRecordCancellation;
@@ -238,6 +239,9 @@ public partial class DeviceToolsViewModel : ObservableObject
     public bool HasWorkingDevice => SelectedDevice?.IsUsable == true;
     public bool CanShowNoDeviceHint => !IsRunning && !HasWorkingDevice;
     public bool CanShowPackageRequiredHint => !IsRunning && string.IsNullOrWhiteSpace(PackageName);
+    public string ScreenRecordStatus => IsScreenRecording
+        ? "Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4."
+        : "Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.";
 
     public DeviceToolsViewModel(AdbService adbService, IFilePickerService filePickerService, IDialogService dialogService)
     {
@@ -512,7 +516,7 @@ public partial class DeviceToolsViewModel : ObservableObject
         var serial = SelectedDevice?.Serial ?? string.Empty;
         _screenRecordCancellation = new CancellationTokenSource();
         IsScreenRecording = true;
-        AppendLog("Screen recording started. Use Stop Screen Record to finish and pull the MP4.");
+        AppendLog($"Screen recording started on the device at {remotePath}. Use Stop Screen Record to end adb shell screenrecord and pull the MP4.");
 
         _screenRecordTask = CompleteScreenRecordAsync(serial, remotePath, localPath, _screenRecordCancellation);
     }
@@ -762,6 +766,7 @@ public partial class DeviceToolsViewModel : ObservableObject
 
         if (!string.IsNullOrWhiteSpace(pid))
         {
+            AppendLog($"Found running PID {pid} for '{package}'. Using logcat --pid filtering where supported by the device.");
             await RunForDeviceAndLogAsync(["logcat", "-d", "--pid", pid]);
             return;
         }


### PR DESCRIPTION
### Motivation
- Surface clearer, non-destructive utility behavior for shell and app workflows by making the screen recording lifecycle explicit and improving log output when using package-scoped logcat filtering.

### Description
- Added a `ScreenRecordStatus` read-only property and hooked it to change notifications so the UI can describe `adb shell screenrecord` behavior (`src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs`).
- Updated `StartScreenRecord` to log the device-side remote path when recording begins and continue to use the existing stop/pull flow (`adb shell screenrecord` + pull) for clarity (`src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs`).
- Added a UI binding to display the new `ScreenRecordStatus` and adjusted the active-recording hint styling in `DeviceToolsView.axaml` (`src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`).
- Improved the `LogcatForPackageAsync` preset to log when a running PID is found and when `logcat --pid` filtering is used before falling back to text filtering (`src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs`).

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it passed.
- Attempted to run `dotnet build` but it could not execute in the current environment because `dotnet` is not available, so a full build was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e443819a883229ae3e84ea7a55d19)