### PR TITLE
Localize Device Tools UI strings

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:PulseAPK.Core.ViewModels;assembly=PulseAPK.Core"
+             xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.DeviceToolsView"
              x:DataType="vm:DeviceToolsViewModel">
     <UserControl.Styles>
@@ -33,10 +34,10 @@
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="14">
                 <StackPanel Spacing="4">
-                    <TextBlock Text="Device Tools"
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsHeader]}"
                                FontSize="24"
                                FontWeight="SemiBold" />
-                    <TextBlock Text="Install APKs, launch activities, and run common ADB shell commands."
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsSubtitle]}"
                                Opacity="0.75" />
                 </StackPanel>
 
@@ -48,7 +49,7 @@
                     <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="10">
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                             <StackPanel Spacing="6">
-                                <TextBlock Text="Connection"
+                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnection]}"
                                            FontWeight="SemiBold" />
                                 <WrapPanel>
                                     <Border Classes="adb-status-pill"
@@ -63,7 +64,7 @@
                                                    FontWeight="SemiBold"
                                                    FontSize="12" />
                                     </Border>
-                                    <TextBlock Text="Select a connected Android device for APK and shell tools."
+                                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsSelectDeviceHelp]}"
                                                Opacity="0.75"
                                                VerticalAlignment="Center"
                                                Margin="0,0,0,4" />
@@ -71,7 +72,7 @@
                             </StackPanel>
 
                             <Button Grid.Column="1"
-                                    Content="Refresh Devices"
+                                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRefreshDevices]}"
                                     Command="{Binding RefreshDevicesCommand}"
                                     MinWidth="120"
                                     VerticalAlignment="Top" />
@@ -110,7 +111,7 @@
                         </Border>
 
                         <Expander Grid.Row="3"
-                                  Header="ADB path"
+                                  Header="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsAdbPath]}"
                                   HorizontalAlignment="Left">
                             <TextBox Text="{Binding DetectedAdbPath}"
                                      IsReadOnly="True"
@@ -127,9 +128,9 @@
                         Padding="12">
                     <StackPanel Spacing="10">
                         <StackPanel Spacing="4">
-                            <TextBlock Text="Choose a workflow"
+                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsChooseWorkflow]}"
                                        FontWeight="SemiBold" />
-                            <TextBlock Text="Switch between install, launch, app management, and shell tools."
+                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsWorkflowHelp]}"
                                        Opacity="0.75" />
                         </StackPanel>
 
@@ -163,19 +164,19 @@
                             <Grid>
                                 <StackPanel Spacing="10" IsVisible="{Binding IsInstallApkMode}">
                                     <StackPanel Spacing="3">
-                                        <TextBlock Text="Install APK Package" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="Select an APK file, install it to the active device, or read package metadata from it." Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApkPackage]}" FontSize="18" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApkHelp]}" Opacity="0.75" />
                                     </StackPanel>
                                     <StackPanel Spacing="6">
-                                        <TextBlock Text="APK file" Opacity="0.8" />
-                                        <TextBox Text="{Binding SelectedApkPath}" Watermark="/path/to/app.apk" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsApkFile]}" Opacity="0.8" />
+                                        <TextBox Text="{Binding SelectedApkPath}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsApkPathWatermark]}" />
                                         <WrapPanel>
-                                            <Button Content="Browse" Command="{Binding BrowseApkCommand}" MinWidth="90" Margin="0,0,8,4" />
-                                            <Button Content="Install APK" Command="{Binding InstallApkCommand}" MinWidth="100" Margin="0,0,8,4" />
-                                            <Button Content="Detect Package" Command="{Binding DetectPackageCommand}" MinWidth="120" Margin="0,0,8,4" />
-                                            <Button Content="Clear APK Selection" Command="{Binding ClearApkCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}" Command="{Binding BrowseApkCommand}" MinWidth="90" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApk]}" Command="{Binding InstallApkCommand}" MinWidth="100" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsDetectPackage]}" Command="{Binding DetectPackageCommand}" MinWidth="120" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClearApkSelection]}" Command="{Binding ClearApkCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
-                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
                                                    Opacity="0.75"
                                                    TextWrapping="Wrap" />
@@ -184,21 +185,21 @@
 
                                 <StackPanel Spacing="10" IsVisible="{Binding IsLaunchAppMode}">
                                     <StackPanel Spacing="3">
-                                        <TextBlock Text="Launch an Installed App" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="Enter a package, optionally choose an activity, then launch or inspect the current foreground activity." Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchInstalledApp]}" FontSize="18" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchHelp]}" Opacity="0.75" />
                                     </StackPanel>
                                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
                                         <StackPanel Spacing="6">
-                                            <TextBlock Text="Package name" Opacity="0.8" />
-                                            <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
+                                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageName]}" Opacity="0.8" />
+                                            <TextBox Text="{Binding PackageName}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageWatermark]}" />
                                         </StackPanel>
                                         <StackPanel Grid.Column="1" Spacing="8">
                                             <StackPanel Spacing="6">
-                                                <TextBlock Text="Activity" Opacity="0.8" />
-                                                <TextBox Text="{Binding Activity}" Watermark=".MainActivity or full class name" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsActivity]}" Opacity="0.8" />
+                                                <TextBox Text="{Binding Activity}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsActivityWatermark]}" />
                                             </StackPanel>
                                             <StackPanel Spacing="6">
-                                                <TextBlock Text="Detected activities" Opacity="0.8" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsDetectedActivities]}" Opacity="0.8" />
                                                 <ComboBox ItemsSource="{Binding Activities}"
                                                           SelectedItem="{Binding Activity}"
                                                           HorizontalAlignment="Stretch" />
@@ -206,17 +207,17 @@
                                         </StackPanel>
                                     </Grid>
                                     <WrapPanel>
-                                        <Button Content="Launch App" Command="{Binding LaunchAppCommand}" Margin="0,0,8,4" />
-                                        <Button Content="Launch Activity" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,4" />
-                                        <Button Content="Current Activity" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,4" />
-                                        <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchApp]}" Command="{Binding LaunchAppCommand}" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchActivity]}" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCurrentActivity]}" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                     </WrapPanel>
                                     <StackPanel Spacing="2">
-                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
                                                    Opacity="0.75"
                                                    TextWrapping="Wrap" />
-                                        <TextBlock Text="Enter a package name to continue."
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageRequiredHint]}"
                                                    IsVisible="{Binding CanShowPackageRequiredHint}"
                                                    Opacity="0.75"
                                                    TextWrapping="Wrap" />
@@ -225,19 +226,19 @@
 
                                 <StackPanel Spacing="10" IsVisible="{Binding IsAppMaintenanceMode}">
                                     <StackPanel Spacing="3">
-                                        <TextBlock Text="Manage Installed App" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="Target a package, then stop it, reset data, remove it, or inspect package details." Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsManageInstalledApp]}" FontSize="18" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsManageHelp]}" Opacity="0.75" />
                                     </StackPanel>
                                     <StackPanel Spacing="6">
-                                        <TextBlock Text="Package name" Opacity="0.8" />
-                                        <TextBox Text="{Binding PackageName}" Watermark="com.example.app" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageName]}" Opacity="0.8" />
+                                        <TextBox Text="{Binding PackageName}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageWatermark]}" />
                                         <WrapPanel>
-                                            <Button Content="Force Stop" Classes="destructive" Command="{Binding ForceStopCommand}" Margin="0,0,8,4" />
-                                            <Button Content="Clear Data" Classes="destructive" Command="{Binding ClearDataCommand}" Margin="0,0,8,4" />
-                                            <Button Content="Uninstall" Classes="destructive" Command="{Binding UninstallCommand}" Margin="0,0,8,4" />
-                                            <Button Content="Search Package" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,4" />
-                                            <Button Content="App Path" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,4" />
-                                            <Button Content="Clear" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsForceStop]}" Classes="destructive" Command="{Binding ForceStopCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClearData]}" Classes="destructive" Command="{Binding ClearDataCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsUninstall]}" Classes="destructive" Command="{Binding UninstallCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsSearchPackage]}" Command="{Binding RunSearchPackagePresetCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsAppPath]}" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
                                         <Border Background="{DynamicResource CardBackgroundBrush}"
                                                 BorderBrush="{DynamicResource CardBorderBrush}"
@@ -246,21 +247,21 @@
                                                 Padding="10"
                                                 Margin="0,4,0,0">
                                             <StackPanel Spacing="6">
-                                                <TextBlock Text="Utilities" FontWeight="SemiBold" />
-                                                <TextBlock Text="Non-destructive shortcuts for the selected device and package." Opacity="0.75" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsUtilities]}" FontWeight="SemiBold" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageUtilitiesHelp]}" Opacity="0.75" TextWrapping="Wrap" />
                                                 <WrapPanel>
-                                                    <Button Content="Open App Settings" Command="{Binding OpenAppSettingsCommand}" Margin="0,0,8,4" />
-                                                    <Button Content="Copy APK from Device" Command="{Binding CopyApkFromDeviceCommand}" Margin="0,0,8,4" />
-                                                    <Button Content="Logcat for Package" Command="{Binding RunLogcatForPackagePresetCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsOpenAppSettings]}" Command="{Binding OpenAppSettingsCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCopyApkFromDevice]}" Command="{Binding CopyApkFromDeviceCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLogcatForPackage]}" Command="{Binding RunLogcatForPackagePresetCommand}" Margin="0,0,8,4" />
                                                 </WrapPanel>
                                             </StackPanel>
                                         </Border>
                                         <StackPanel Spacing="2">
-                                            <TextBlock Text="Connect a usable Android device to enable these actions."
+                                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                        IsVisible="{Binding CanShowNoDeviceHint}"
                                                        Opacity="0.75"
                                                        TextWrapping="Wrap" />
-                                            <TextBlock Text="Enter a package name to continue."
+                                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageRequiredHint]}"
                                                        IsVisible="{Binding CanShowPackageRequiredHint}"
                                                        Opacity="0.75"
                                                        TextWrapping="Wrap" />
@@ -270,11 +271,11 @@
 
                                 <StackPanel Spacing="10" IsVisible="{Binding IsShellPresetsMode}">
                                     <StackPanel Spacing="3">
-                                        <TextBlock Text="Run ADB Shell Commands" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="Run a preset command, or type shell/raw ADB arguments for the selected device." Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbShellCommands]}" FontSize="18" FontWeight="SemiBold" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsShellHelp]}" Opacity="0.75" />
                                     </StackPanel>
                                     <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
-                                        <TextBlock Text="Preset"
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPreset]}"
                                                    Opacity="0.8"
                                                    VerticalAlignment="Center" />
                                         <ComboBox Grid.Column="1"
@@ -288,17 +289,17 @@
                                             </ComboBox.ItemTemplate>
                                         </ComboBox>
                                         <Button Grid.Column="2"
-                                                Content="Run Preset"
+                                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunPreset]}"
                                                 Command="{Binding RunSelectedPresetCommand}"
                                                 MinWidth="110" />
                                     </Grid>
                                     <StackPanel Spacing="6">
-                                        <TextBlock Text="Command" Opacity="0.8" />
-                                        <TextBox Text="{Binding CommandText}" Watermark="getprop ro.product.model" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommand]}" Opacity="0.8" />
+                                        <TextBox Text="{Binding CommandText}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandWatermark]}" />
                                         <WrapPanel>
-                                            <Button Content="Run Shell" Command="{Binding RunShellCommand}" MinWidth="110" Margin="0,0,8,4" />
-                                            <Button Content="Run ADB Args"
-                                                    ToolTip.Tip="Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model."
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunShell]}" Command="{Binding RunShellCommand}" MinWidth="110" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbArgs]}"
+                                                    ToolTip.Tip="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbArgsTip]}"
                                                     Command="{Binding RunAdbCommand}"
                                                     MinWidth="100"
                                                     Margin="0,0,8,4" />
@@ -310,22 +311,22 @@
                                                 Padding="10"
                                                 Margin="0,4,0,0">
                                             <StackPanel Spacing="6">
-                                                <TextBlock Text="Utilities" FontWeight="SemiBold" />
-                                                <TextBlock Text="Capture the screen or record a short MP4 without modifying app data." Opacity="0.75" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsUtilities]}" FontWeight="SemiBold" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsScreenUtilitiesHelp]}" Opacity="0.75" TextWrapping="Wrap" />
                                                 <TextBlock Text="{Binding ScreenRecordStatus}" Opacity="0.75" TextWrapping="Wrap" />
                                                 <WrapPanel>
-                                                    <Button Content="Screenshot" Command="{Binding TakeScreenshotCommand}" Margin="0,0,8,4" />
-                                                    <Button Content="Start Screen Record" Command="{Binding StartScreenRecordCommand}" Margin="0,0,8,4" />
-                                                    <Button Content="Stop Screen Record" Command="{Binding StopScreenRecordCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsScreenshot]}" Command="{Binding TakeScreenshotCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsStartScreenRecord]}" Command="{Binding StartScreenRecordCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsStopScreenRecord]}" Command="{Binding StopScreenRecordCommand}" Margin="0,0,8,4" />
                                                 </WrapPanel>
-                                                <TextBlock Text="Recording is active on the selected device until you stop it."
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRecordingActiveHint]}"
                                                            IsVisible="{Binding IsScreenRecording}"
                                                            FontWeight="SemiBold"
                                                            Opacity="0.85"
                                                            TextWrapping="Wrap" />
                                             </StackPanel>
                                         </Border>
-                                        <TextBlock Text="Connect a usable Android device to enable these actions."
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
                                                    Opacity="0.75"
                                                    TextWrapping="Wrap" />
@@ -346,18 +347,18 @@
                 Padding="12">
             <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
-                    <TextBlock Text="Command output"
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutput]}"
                                FontWeight="SemiBold"
                                VerticalAlignment="Center" />
                     <Button Grid.Column="1"
-                            Content="Clear"
+                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}"
                             Command="{Binding ClearConsoleCommand}"
                             MinWidth="80"
                             HorizontalAlignment="Right" />
                 </Grid>
 
                 <TextBlock Grid.Row="1"
-                           Text="Latest command output appears below."
+                           Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutputHelp]}"
                            FontSize="12"
                            Opacity="0.65" />
 

--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -461,4 +461,250 @@ Output: {0}</value>
   <data name="ThemeModeLight" xml:space="preserve">
     <value>Light mode</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -449,4 +449,250 @@
   <data name="PatchPreviewAddCustomScript" xml:space="preserve">
     <value>- Добавить пользовательский скрипт: {0}</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -364,4 +364,250 @@
   <data name="PatchScriptInjectFridaGadget" xml:space="preserve">
     <value>Inject gadget and custom script</value>
   </data>
+  <data name="DeviceToolsHeader" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsSubtitle" xml:space="preserve">
+    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+  </data>
+  <data name="DeviceToolsConnection" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
+    <value>Select a connected Android device for APK and shell tools.</value>
+  </data>
+  <data name="DeviceToolsRefreshDevices" xml:space="preserve">
+    <value>Refresh Devices</value>
+  </data>
+  <data name="DeviceToolsAdbPath" xml:space="preserve">
+    <value>ADB path</value>
+  </data>
+  <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
+    <value>Choose a workflow</value>
+  </data>
+  <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
+    <value>Switch between install, launch, app management, and shell tools.</value>
+  </data>
+  <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
+    <value>Install APK Package</value>
+  </data>
+  <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
+    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+  </data>
+  <data name="DeviceToolsApkFile" xml:space="preserve">
+    <value>APK file</value>
+  </data>
+  <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
+    <value>/path/to/app.apk</value>
+  </data>
+  <data name="DeviceToolsInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsDetectPackage" xml:space="preserve">
+    <value>Detect Package</value>
+  </data>
+  <data name="DeviceToolsClearApkSelection" xml:space="preserve">
+    <value>Clear APK Selection</value>
+  </data>
+  <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
+    <value>Connect a usable Android device to enable these actions.</value>
+  </data>
+  <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
+    <value>Launch an Installed App</value>
+  </data>
+  <data name="DeviceToolsLaunchHelp" xml:space="preserve">
+    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+  </data>
+  <data name="DeviceToolsPackageName" xml:space="preserve">
+    <value>Package name</value>
+  </data>
+  <data name="DeviceToolsPackageWatermark" xml:space="preserve">
+    <value>com.example.app</value>
+  </data>
+  <data name="DeviceToolsActivity" xml:space="preserve">
+    <value>Activity</value>
+  </data>
+  <data name="DeviceToolsActivityWatermark" xml:space="preserve">
+    <value>.MainActivity or full class name</value>
+  </data>
+  <data name="DeviceToolsDetectedActivities" xml:space="preserve">
+    <value>Detected activities</value>
+  </data>
+  <data name="DeviceToolsLaunchApp" xml:space="preserve">
+    <value>Launch App</value>
+  </data>
+  <data name="DeviceToolsLaunchActivity" xml:space="preserve">
+    <value>Launch Activity</value>
+  </data>
+  <data name="DeviceToolsCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsClear" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
+    <value>Enter a package name to continue.</value>
+  </data>
+  <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
+    <value>Manage Installed App</value>
+  </data>
+  <data name="DeviceToolsManageHelp" xml:space="preserve">
+    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+  </data>
+  <data name="DeviceToolsForceStop" xml:space="preserve">
+    <value>Force Stop</value>
+  </data>
+  <data name="DeviceToolsClearData" xml:space="preserve">
+    <value>Clear Data</value>
+  </data>
+  <data name="DeviceToolsUninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="DeviceToolsSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsUtilities" xml:space="preserve">
+    <value>Utilities</value>
+  </data>
+  <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
+    <value>Non-destructive shortcuts for the selected device and package.</value>
+  </data>
+  <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
+    <value>Open App Settings</value>
+  </data>
+  <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
+    <value>Copy APK from Device</value>
+  </data>
+  <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
+    <value>Run ADB Shell Commands</value>
+  </data>
+  <data name="DeviceToolsShellHelp" xml:space="preserve">
+    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+  </data>
+  <data name="DeviceToolsPreset" xml:space="preserve">
+    <value>Preset</value>
+  </data>
+  <data name="DeviceToolsRunPreset" xml:space="preserve">
+    <value>Run Preset</value>
+  </data>
+  <data name="DeviceToolsCommand" xml:space="preserve">
+    <value>Command</value>
+  </data>
+  <data name="DeviceToolsCommandWatermark" xml:space="preserve">
+    <value>getprop ro.product.model</value>
+  </data>
+  <data name="DeviceToolsRunShell" xml:space="preserve">
+    <value>Run Shell</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
+    <value>Run ADB Args</value>
+  </data>
+  <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
+    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+  </data>
+  <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
+    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+  </data>
+  <data name="DeviceToolsScreenshot" xml:space="preserve">
+    <value>Screenshot</value>
+  </data>
+  <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
+    <value>Start Screen Record</value>
+  </data>
+  <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
+    <value>Stop Screen Record</value>
+  </data>
+  <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
+    <value>Recording is active on the selected device until you stop it.</value>
+  </data>
+  <data name="DeviceToolsCommandOutput" xml:space="preserve">
+    <value>Command output</value>
+  </data>
+  <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
+    <value>Latest command output appears below.</value>
+  </data>
+  <data name="MenuDeviceTools" xml:space="preserve">
+    <value>Device Tools</value>
+  </data>
+  <data name="DeviceToolsPresetModel" xml:space="preserve">
+    <value>Model</value>
+  </data>
+  <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
+    <value>Android Release</value>
+  </data>
+  <data name="DeviceToolsPresetSdk" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="DeviceToolsPresetCpuAbi" xml:space="preserve">
+    <value>CPU ABI</value>
+  </data>
+  <data name="DeviceToolsPresetListPackages" xml:space="preserve">
+    <value>List Packages</value>
+  </data>
+  <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
+    <value>Third-Party Packages</value>
+  </data>
+  <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
+    <value>Search Package</value>
+  </data>
+  <data name="DeviceToolsPresetAppPath" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
+    <value>Current Activity</value>
+  </data>
+  <data name="DeviceToolsPresetReboot" xml:space="preserve">
+    <value>Reboot</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
+    <value>ADB Root</value>
+  </data>
+  <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
+    <value>ADB Remount</value>
+  </data>
+  <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
+    <value>Logcat for Package</value>
+  </data>
+  <data name="DeviceToolsModeInstallApk" xml:space="preserve">
+    <value>Install APK</value>
+  </data>
+  <data name="DeviceToolsModeLaunch" xml:space="preserve">
+    <value>Launch</value>
+  </data>
+  <data name="DeviceToolsModeManageApp" xml:space="preserve">
+    <value>Manage App</value>
+  </data>
+  <data name="DeviceToolsModeShell" xml:space="preserve">
+    <value>Shell</value>
+  </data>
+  <data name="DeviceToolsAdbChecking" xml:space="preserve">
+    <value>ADB: checking...</value>
+  </data>
+  <data name="DeviceToolsAdbFound" xml:space="preserve">
+    <value>ADB: found</value>
+  </data>
+  <data name="DeviceToolsAdbNotFound" xml:space="preserve">
+    <value>ADB: not found</value>
+  </data>
+  <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
+    <value>ADB: not checked</value>
+  </data>
+  <data name="DeviceToolsCheckingDevices" xml:space="preserve">
+    <value>Checking devices...</value>
+  </data>
+  <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
+    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
+    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+  </data>
+  <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
+    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -39,6 +39,7 @@ public sealed record DeviceToolPreset(string DisplayName, DeviceToolPresetKind K
 
 public partial class DeviceToolsViewModel : ObservableObject
 {
+    private static string T(string key) => LocalizationService.Instance[key];
     private readonly AdbService _adbService;
     private readonly IFilePickerService _filePickerService;
     private readonly IDialogService _dialogService;
@@ -199,36 +200,36 @@ public partial class DeviceToolsViewModel : ObservableObject
     public ObservableCollection<string> Activities { get; } = [];
     public ObservableCollection<DeviceToolPreset> Presets { get; } =
     [
-        new("Model", DeviceToolPresetKind.Model),
-        new("Android Release", DeviceToolPresetKind.AndroidRelease),
-        new("SDK", DeviceToolPresetKind.Sdk),
-        new("CPU ABI", DeviceToolPresetKind.CpuAbi),
-        new("List Packages", DeviceToolPresetKind.ListPackages),
-        new("Third-Party Packages", DeviceToolPresetKind.ThirdPartyPackages),
-        new("Search Package", DeviceToolPresetKind.SearchPackage),
-        new("App Path", DeviceToolPresetKind.AppPath),
-        new("Current Activity", DeviceToolPresetKind.CurrentActivity),
-        new("Reboot", DeviceToolPresetKind.Reboot),
-        new("ADB Root", DeviceToolPresetKind.AdbRoot),
-        new("ADB Remount", DeviceToolPresetKind.AdbRemount),
-        new("Logcat for Package", DeviceToolPresetKind.LogcatForPackage)
+        new(T("DeviceToolsPresetModel"), DeviceToolPresetKind.Model),
+        new(T("DeviceToolsPresetAndroidRelease"), DeviceToolPresetKind.AndroidRelease),
+        new(T("DeviceToolsPresetSdk"), DeviceToolPresetKind.Sdk),
+        new(T("DeviceToolsPresetCpuAbi"), DeviceToolPresetKind.CpuAbi),
+        new(T("DeviceToolsPresetListPackages"), DeviceToolPresetKind.ListPackages),
+        new(T("DeviceToolsPresetThirdPartyPackages"), DeviceToolPresetKind.ThirdPartyPackages),
+        new(T("DeviceToolsPresetSearchPackage"), DeviceToolPresetKind.SearchPackage),
+        new(T("DeviceToolsPresetAppPath"), DeviceToolPresetKind.AppPath),
+        new(T("DeviceToolsPresetCurrentActivity"), DeviceToolPresetKind.CurrentActivity),
+        new(T("DeviceToolsPresetReboot"), DeviceToolPresetKind.Reboot),
+        new(T("DeviceToolsPresetAdbRoot"), DeviceToolPresetKind.AdbRoot),
+        new(T("DeviceToolsPresetAdbRemount"), DeviceToolPresetKind.AdbRemount),
+        new(T("DeviceToolsPresetLogcatForPackage"), DeviceToolPresetKind.LogcatForPackage)
     ];
     public IReadOnlyList<DeviceToolModeOption> DeviceToolModes { get; } =
     [
-        new(DeviceToolMode.InstallApk, "Install APK"),
-        new(DeviceToolMode.LaunchApp, "Launch"),
-        new(DeviceToolMode.AppMaintenance, "Manage App"),
-        new(DeviceToolMode.ShellPresets, "Shell")
+        new(DeviceToolMode.InstallApk, T("DeviceToolsModeInstallApk")),
+        new(DeviceToolMode.LaunchApp, T("DeviceToolsModeLaunch")),
+        new(DeviceToolMode.AppMaintenance, T("DeviceToolsModeManageApp")),
+        new(DeviceToolMode.ShellPresets, T("DeviceToolsModeShell"))
     ];
     public string AdbStatus => IsCheckingAdb
-        ? "ADB: checking..."
+        ? T("DeviceToolsAdbChecking")
         : HasCheckedAdb
-            ? (IsAdbFound ? "ADB: found" : "ADB: not found")
-            : "ADB: not checked";
+            ? (IsAdbFound ? T("DeviceToolsAdbFound") : T("DeviceToolsAdbNotFound"))
+            : T("DeviceToolsAdbNotChecked");
     public string DeviceListStatus => IsRefreshingDevices
-        ? "Checking devices..."
+        ? T("DeviceToolsCheckingDevices")
         : HasCheckedDevices && IsAdbFound && Devices.Count == 0
-            ? "No Android device connected. Connect a device and enable USB debugging."
+            ? T("DeviceToolsNoConnectedDevices")
             : string.Empty;
     public bool IsAdbMissing => HasCheckedAdb && !IsCheckingAdb && !IsAdbFound;
     public bool HasNoConnectedDevices => HasCheckedDevices && IsAdbFound && !IsRefreshingDevices && Devices.Count == 0;
@@ -240,8 +241,8 @@ public partial class DeviceToolsViewModel : ObservableObject
     public bool CanShowNoDeviceHint => !IsRunning && !HasWorkingDevice;
     public bool CanShowPackageRequiredHint => !IsRunning && string.IsNullOrWhiteSpace(PackageName);
     public string ScreenRecordStatus => IsScreenRecording
-        ? "Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4."
-        : "Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.";
+        ? T("DeviceToolsScreenRecordInProgress")
+        : T("DeviceToolsScreenRecordReady");
 
     public DeviceToolsViewModel(AdbService adbService, IFilePickerService filePickerService, IDialogService dialogService)
     {

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -26,7 +26,7 @@ public partial class MainViewModel : ObservableObject
     public string MenuBuildLabel => _localizationService["MenuBuild"];
     public string MenuPatchLabel => _localizationService["MenuPatch"];
     public string MenuAnalyserLabel => _localizationService["MenuAnalyser"];
-    public string MenuDeviceToolsLabel => "Device Tools";
+    public string MenuDeviceToolsLabel => _localizationService["MenuDeviceTools"];
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
 


### PR DESCRIPTION
### Motivation
- Replace hard-coded Device Tools UI text with resource-backed lookups to support localization parity with other views such as `DecompileView.axaml` and `BuildView.axaml`.
- Centralize labels, helper text, button content, watermarks, tooltips, and empty-state strings so translations from the existing `.resx` pipeline can be used across languages.
- Ensure view-model strings (preset/mode names, ADB/device statuses, screen-record messages) use the same localization source as the UI.

### Description
- Updated `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to bind all hard-coded `Text`, `Content`, `Header`, `Watermark`, and `ToolTip.Tip` values to `LocalizationService.Instance` resource keys instead of inline literals.
- Added a set of `DeviceTools*` resource keys to the neutral `src/PulseAPK.Core/Properties/Resources.resx` and mirrored those keys into all present localized `.resx` files (`ar-SA`, `de-DE`, `es-ES`, `fr-FR`, `pt-BR`, `ru-RU`, `uk-UA`, `zh-CN`).
- Updated `src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs` to resolve display/preset/mode/status strings through a small `T(string key)` helper that calls `LocalizationService.Instance`, and replaced inline strings (presets, modes, ADB/device status text, screen-record messages, etc.) with resource keys.
- Replaced the hard-coded Device Tools menu label in `src/PulseAPK.Core/ViewModels/MainViewModel.cs` with a localized lookup (`_localizationService["MenuDeviceTools"]`).

### Testing
- Parsed every `Resources*.resx` with Python `xml.etree.ElementTree` to validate well-formed XML, and the check passed successfully.
- Ran a regex-based scan to assert `DeviceToolsView.axaml` no longer contains remaining hard-coded `Text/Content/Header/Watermark/ToolTip` strings, and verification returned no matches.
- Ran `git diff --check` for whitespace/format issues (no problems found) and attempted `dotnet build` which could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e44e4a8248322a7211f6b1f5a38d1)