### PR TITLE
Avoid duplicate no-device status

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -93,7 +93,7 @@
                             </ComboBox>
 
                             <TextBlock Grid.Column="1"
-                                       Text="{Binding DeviceListStatus}"
+                                       Text="{Binding InlineDeviceListStatus}"
                                        VerticalAlignment="Center"
                                        Opacity="0.75" />
                         </Grid>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -51,6 +51,7 @@ public partial class DeviceToolsViewModel : ObservableObject
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AdbStatus))]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(InlineDeviceListStatus))]
     [NotifyPropertyChangedFor(nameof(IsAdbMissing))]
     [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _isAdbFound;
@@ -67,11 +68,13 @@ public partial class DeviceToolsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(InlineDeviceListStatus))]
     [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _hasCheckedDevices;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(DeviceListStatus))]
+    [NotifyPropertyChangedFor(nameof(InlineDeviceListStatus))]
     [NotifyPropertyChangedFor(nameof(HasNoConnectedDevices))]
     private bool _isRefreshingDevices;
 
@@ -231,6 +234,7 @@ public partial class DeviceToolsViewModel : ObservableObject
         : HasCheckedDevices && IsAdbFound && Devices.Count == 0
             ? T("DeviceToolsNoConnectedDevices")
             : string.Empty;
+    public string InlineDeviceListStatus => HasNoConnectedDevices ? string.Empty : DeviceListStatus;
     public bool IsAdbMissing => HasCheckedAdb && !IsCheckingAdb && !IsAdbFound;
     public bool HasNoConnectedDevices => HasCheckedDevices && IsAdbFound && !IsRefreshingDevices && Devices.Count == 0;
     public bool IsInstallApkMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.InstallApk;
@@ -287,6 +291,7 @@ public partial class DeviceToolsViewModel : ObservableObject
             SelectedDevice = Devices.FirstOrDefault(device => device.IsUsable) ?? Devices.FirstOrDefault();
             OnPropertyChanged(nameof(DeviceListStatus));
             OnPropertyChanged(nameof(HasNoConnectedDevices));
+            OnPropertyChanged(nameof(InlineDeviceListStatus));
         }
         finally
         {


### PR DESCRIPTION
### Motivation
- Prevent the "No Android device connected" message from appearing twice by keeping the bottom warning panel and hiding the inline selector message when no devices are present.

### Description
- Add `InlineDeviceListStatus` property to `DeviceToolsViewModel` that returns an empty string when the bottom no-device panel is visible and otherwise mirrors `DeviceListStatus`.
- Add `NotifyPropertyChangedFor(nameof(InlineDeviceListStatus))` to the relevant observable fields so the inline status updates when ADB/devices state changes.
- Update `RefreshDevicesAsync` to raise `OnPropertyChanged(nameof(InlineDeviceListStatus))` after the device list is refreshed.
- Switch the ComboBox-area `TextBlock` binding in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` from `DeviceListStatus` to `InlineDeviceListStatus` to suppress the duplicate message.

### Testing
- `git diff --check` was run and passed.
- `dotnet build PulseAPK.sln` was attempted but could not be executed in the environment because `dotnet` is not installed (build not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eed70fd0c8322a5988d7a33ba04c8)