### PR TITLE
Improve ADB status pill contrast

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -22,12 +22,18 @@
             <Setter Property="BorderBrush" Value="#B0BEC5" />
         </Style>
         <Style Selector="Border.adb-status-pill.found">
-            <Setter Property="Background" Value="#DDF6E6" />
-            <Setter Property="BorderBrush" Value="#2E7D32" />
+            <Setter Property="Background" Value="#0284C7" />
+            <Setter Property="BorderBrush" Value="#7DD3FC" />
+        </Style>
+        <Style Selector="Border.adb-status-pill.found TextBlock">
+            <Setter Property="Foreground" Value="#E0F7FF" />
         </Style>
         <Style Selector="Border.adb-status-pill.missing">
-            <Setter Property="Background" Value="#FDE7D3" />
-            <Setter Property="BorderBrush" Value="#EF6C00" />
+            <Setter Property="Background" Value="#B91C1C" />
+            <Setter Property="BorderBrush" Value="#FCA5A5" />
+        </Style>
+        <Style Selector="Border.adb-status-pill.missing TextBlock">
+            <Setter Property="Foreground" Value="#FFFFFF" />
         </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="*,Auto" RowSpacing="10" Margin="20">


### PR DESCRIPTION
### Motivation
- Improve visibility of the ADB presence indicator so the "ADB: found" state is clearly visible (blue) and the "ADB: not found" state is clearly indicated (red).

### Description
- Update `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to use a bright blue background (`#0284C7`) with a light foreground for the `.adb-status-pill.found` style and a red background (`#B91C1C`) with white foreground for the `.adb-status-pill.missing` style, and adjust border colors accordingly.

### Testing
- Ran `git diff --check` which passed, and attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eef9f6aa08322a947cf11d02404ce)