### PR TITLE
Simplify ADB path display

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -52,7 +52,7 @@
                         BorderThickness="1"
                         CornerRadius="6"
                         Padding="12">
-                    <Grid RowDefinitions="Auto,Auto,Auto,Auto" RowSpacing="10">
+                    <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
                         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnection]}"
@@ -116,14 +116,6 @@
                                        FontWeight="SemiBold" />
                         </Border>
 
-                        <Expander Grid.Row="3"
-                                  Header="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsAdbPath]}"
-                                  HorizontalAlignment="Left">
-                            <TextBox Text="{Binding DetectedAdbPath}"
-                                     IsReadOnly="True"
-                                     MinWidth="360"
-                                     Margin="0,6,0,0" />
-                        </Expander>
                     </Grid>
                 </Border>
 

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -65,7 +65,7 @@
         <TextBlock Text="ADB Path"
                    FontWeight="SemiBold" />
         <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-            <TextBox Text="{Binding AdbPath}" Watermark="Auto-detect if empty" />
+            <TextBox Text="{Binding AdbPath}" Watermark="{Binding AdbPathWatermark}" />
             <Button Grid.Column="1"
                     Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
                     Command="{Binding BrowseAdbCommand}"

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -13,6 +13,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private readonly IDialogService _dialogService;
     private readonly IToolRepository _toolRepository;
     private readonly IToolDownloadService _toolDownloadService;
+    private readonly AdbService _adbService;
     private readonly LocalizationService _localizationService;
     private readonly IThemeService _themeService;
     private bool _disposed;
@@ -25,6 +26,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     private string _adbPath;
+
+    [ObservableProperty]
+    private string _adbPathWatermark = "Auto-detect if empty";
 
     [ObservableProperty]
     private bool _isDownloadingTools;
@@ -50,6 +54,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         IDialogService dialogService,
         IToolRepository toolRepository,
         IToolDownloadService toolDownloadService,
+        AdbService adbService,
         LocalizationService localizationService,
         IThemeService themeService)
     {
@@ -58,6 +63,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _dialogService = dialogService;
         _toolRepository = toolRepository;
         _toolDownloadService = toolDownloadService;
+        _adbService = adbService;
         _localizationService = localizationService;
         _themeService = themeService;
 
@@ -70,6 +76,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _localizationService.PropertyChanged += OnLocalizationChanged;
 
         NormalizeManagedToolPathsIfMissing();
+        _ = RefreshAdbPathWatermarkAsync();
     }
 
     partial void OnApktoolPathChanged(string value)
@@ -88,6 +95,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     {
         _settingsService.Settings.AdbPath = value;
         _settingsService.Save();
+        _ = RefreshAdbPathWatermarkAsync();
     }
     
     partial void OnSelectedLanguageChanged(LanguageItem value)
@@ -235,6 +243,25 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         return normalizedConfiguredPath.StartsWith(normalizedToolFolder, StringComparison.OrdinalIgnoreCase);
     }
 
+
+    private async Task RefreshAdbPathWatermarkAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(AdbPath))
+        {
+            AdbPathWatermark = "Auto-detect if empty";
+            return;
+        }
+
+        var detectedPath = await _adbService.ResolveAdbPathAsync();
+        if (!string.IsNullOrWhiteSpace(AdbPath))
+        {
+            return;
+        }
+
+        AdbPathWatermark = string.IsNullOrWhiteSpace(detectedPath)
+            ? "Auto-detect if empty"
+            : detectedPath;
+    }
 
     private void OnLocalizationChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {


### PR DESCRIPTION
### Motivation
- Remove a redundant ADB path control from the Device Tools UI to reduce duplication and visual clutter.
- Surface the auto-detected `adb` executable path in Settings so users can see where ADB was found without extra UI elements.

### Description
- Remove the `Expander` that showed `DetectedAdbPath` from `DeviceToolsView.axaml` and adjust the container grid row definitions accordingly.
- Change the ADB path field in `SettingsView.axaml` to use a view-model watermark by binding the `TextBox` `Watermark` to `AdbPathWatermark` instead of a static string.
- Update `SettingsViewModel` to inject `AdbService`, add the `AdbPathWatermark` observable property, and implement `RefreshAdbPathWatermarkAsync()` which uses `AdbService.ResolveAdbPathAsync()` and is invoked on initialization and when `AdbPath` changes.

### Testing
- Ran `git diff --check` with no reported issues.
- Attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed, so a full build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ef16f18d08322ab32f44b5292d6f2)