### PR TITLE
Disable device workflow chooser until a device is connected

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -125,34 +125,37 @@
                         CornerRadius="6"
                         Padding="12">
                     <StackPanel Spacing="10">
-                        <StackPanel Spacing="4">
-                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsChooseWorkflow]}"
-                                       FontWeight="SemiBold" />
-                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsWorkflowHelp]}"
-                                       Opacity="0.75" />
-                        </StackPanel>
+                        <StackPanel Spacing="10"
+                                    IsEnabled="{Binding HasWorkingDevice}">
+                            <StackPanel Spacing="4">
+                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsChooseWorkflow]}"
+                                           FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsWorkflowHelp]}"
+                                           Opacity="0.75" />
+                            </StackPanel>
 
-                        <ListBox ItemsSource="{Binding DeviceToolModes}"
-                                 SelectedItem="{Binding SelectedDeviceToolMode}"
-                                 HorizontalAlignment="Left">
-                            <ListBox.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <StackPanel Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                            </ListBox.ItemsPanel>
-                            <ListBox.ItemTemplate>
-                                <DataTemplate x:DataType="vm:DeviceToolModeOption">
-                                    <Border Background="{DynamicResource MainBackgroundBrush}"
-                                            BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                            BorderThickness="1"
-                                            CornerRadius="12"
-                                            Padding="14,6"
-                                            Margin="0,0,8,0">
-                                        <TextBlock Text="{Binding DisplayName}" />
-                                    </Border>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                            <ListBox ItemsSource="{Binding DeviceToolModes}"
+                                     SelectedItem="{Binding SelectedDeviceToolMode}"
+                                     HorizontalAlignment="Left">
+                                <ListBox.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal" />
+                                    </ItemsPanelTemplate>
+                                </ListBox.ItemsPanel>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:DeviceToolModeOption">
+                                        <Border Background="{DynamicResource MainBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="12"
+                                                Padding="14,6"
+                                                Margin="0,0,8,0">
+                                            <TextBlock Text="{Binding DisplayName}" />
+                                        </Border>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
 
                         <Border Background="{DynamicResource MainBackgroundBrush}"
                                 BorderBrush="{DynamicResource ConsoleBorderBrush}"


### PR DESCRIPTION
### Motivation

- Prevent users from selecting a device workflow when no usable Android device is connected by greying out the workflow chooser until a device is available.

### Description

- Updated `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` to wrap the workflow selector area in a `StackPanel` with `IsEnabled="{Binding HasWorkingDevice}"`, disabling the chooser UI when there is no usable selected device and leaving all existing workflow options and viewmodel logic unchanged.

### Testing

- Ran `git diff --check` which passed, and attempted `dotnet build` but the build could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ef34d619c8322a8731154a2cc064a)