### PR TITLE
Add shared connection-status pill and show online/offline in workflow chooser

### DIFF
--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -17,22 +17,22 @@
             <Setter Property="Background" Value="#8C1D18" />
             <Setter Property="Foreground" Value="White" />
         </Style>
-        <Style Selector="Border.adb-status-pill">
+        <Style Selector="Border.connection-status-pill">
             <Setter Property="Background" Value="#ECEFF1" />
             <Setter Property="BorderBrush" Value="#B0BEC5" />
         </Style>
-        <Style Selector="Border.adb-status-pill.found">
-            <Setter Property="Background" Value="#0284C7" />
-            <Setter Property="BorderBrush" Value="#7DD3FC" />
+        <Style Selector="Border.connection-status-pill.online">
+            <Setter Property="Background" Value="#15803D" />
+            <Setter Property="BorderBrush" Value="#86EFAC" />
         </Style>
-        <Style Selector="Border.adb-status-pill.found TextBlock">
-            <Setter Property="Foreground" Value="#E0F7FF" />
+        <Style Selector="Border.connection-status-pill.online TextBlock">
+            <Setter Property="Foreground" Value="#ECFDF5" />
         </Style>
-        <Style Selector="Border.adb-status-pill.missing">
+        <Style Selector="Border.connection-status-pill.offline">
             <Setter Property="Background" Value="#B91C1C" />
             <Setter Property="BorderBrush" Value="#FCA5A5" />
         </Style>
-        <Style Selector="Border.adb-status-pill.missing TextBlock">
+        <Style Selector="Border.connection-status-pill.offline TextBlock">
             <Setter Property="Foreground" Value="#FFFFFF" />
         </Style>
     </UserControl.Styles>
@@ -58,9 +58,9 @@
                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnection]}"
                                            FontWeight="SemiBold" />
                                 <WrapPanel>
-                                    <Border Classes="adb-status-pill"
-                                            Classes.found="{Binding IsAdbFound}"
-                                            Classes.missing="{Binding IsAdbMissing}"
+                                    <Border Classes="connection-status-pill"
+                                            Classes.online="{Binding IsAdbFound}"
+                                            Classes.offline="{Binding IsAdbMissing}"
                                             BorderThickness="1"
                                             CornerRadius="12"
                                             Padding="10,4"
@@ -125,17 +125,32 @@
                         CornerRadius="6"
                         Padding="12">
                     <StackPanel Spacing="10">
-                        <StackPanel Spacing="10"
-                                    IsEnabled="{Binding HasWorkingDevice}">
+                        <StackPanel Spacing="10">
                             <StackPanel Spacing="4">
-                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsChooseWorkflow]}"
-                                           FontWeight="SemiBold" />
+                                <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="8">
+                                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsChooseWorkflow]}"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center" />
+                                    <Border Grid.Column="1"
+                                            Classes="connection-status-pill"
+                                            Classes.online="{Binding IsDeviceOnline}"
+                                            Classes.offline="{Binding IsDeviceOffline}"
+                                            BorderThickness="1"
+                                            CornerRadius="12"
+                                            Padding="10,4"
+                                            VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding DeviceConnectionStatus}"
+                                                   FontWeight="SemiBold"
+                                                   FontSize="12" />
+                                    </Border>
+                                </Grid>
                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsWorkflowHelp]}"
                                            Opacity="0.75" />
                             </StackPanel>
 
                             <ListBox ItemsSource="{Binding DeviceToolModes}"
                                      SelectedItem="{Binding SelectedDeviceToolMode}"
+                                     IsEnabled="{Binding HasWorkingDevice}"
                                      HorizontalAlignment="Left">
                                 <ListBox.ItemsPanel>
                                     <ItemsPanelTemplate>

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -485,6 +485,12 @@ Output: {0}</value>
   <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
     <value>Switch between install, launch, app management, and shell tools.</value>
   </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Device: online</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Device: offline</value>
+  </data>
   <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
     <value>Install APK Package</value>
   </data>

--- a/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DeviceToolsViewModel.cs
@@ -80,6 +80,9 @@ public partial class DeviceToolsViewModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasWorkingDevice))]
+    [NotifyPropertyChangedFor(nameof(IsDeviceOnline))]
+    [NotifyPropertyChangedFor(nameof(IsDeviceOffline))]
+    [NotifyPropertyChangedFor(nameof(DeviceConnectionStatus))]
     [NotifyPropertyChangedFor(nameof(CanShowNoDeviceHint))]
     [NotifyPropertyChangedFor(nameof(CanShowPackageRequiredHint))]
     [NotifyCanExecuteChangedFor(nameof(InstallApkCommand))]
@@ -242,6 +245,11 @@ public partial class DeviceToolsViewModel : ObservableObject
     public bool IsAppMaintenanceMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.AppMaintenance;
     public bool IsShellPresetsMode => SelectedDeviceToolMode?.Mode == DeviceToolMode.ShellPresets;
     public bool HasWorkingDevice => SelectedDevice?.IsUsable == true;
+    public bool IsDeviceOnline => HasWorkingDevice;
+    public bool IsDeviceOffline => !HasWorkingDevice;
+    public string DeviceConnectionStatus => HasWorkingDevice
+        ? T("DeviceToolsDeviceOnline")
+        : T("DeviceToolsDeviceOffline");
     public bool CanShowNoDeviceHint => !IsRunning && !HasWorkingDevice;
     public bool CanShowPackageRequiredHint => !IsRunning && string.IsNullOrWhiteSpace(PackageName);
     public string ScreenRecordStatus => IsScreenRecording


### PR DESCRIPTION
### Motivation

- Provide a visible online/offline indicator for the device in the "Choose a workflow" area similar to the existing Connection section. 
- Unify the status pill styling so the positive/online state uses green (instead of the previous blue) across the view.

### Description

- Replaced the ADB-specific pill with a shared `connection-status-pill` style and added `online` and `offline` variants, with the online color changed to green (`#15803D`) and adjusted foreground/brush values. 
- Updated the ADB connection UI to use `Classes.online`/`Classes.offline` bindings (`IsAdbFound`/`IsAdbMissing`) against the new `connection-status-pill`. 
- Added a device connection pill to the `Choose a workflow` header bound to new view-model properties `IsDeviceOnline`, `IsDeviceOffline`, and `DeviceConnectionStatus`, and enabled the workflow list only when `HasWorkingDevice` is true. 
- Added view-model properties and change notifications in `DeviceToolsViewModel` and new resource keys `DeviceToolsDeviceOnline` / `DeviceToolsDeviceOffline` in `Resources.resx` for the status text.

### Testing

- Parsed modified files with `xml.etree.ElementTree` to validate XML/XAML and resource syntax for `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` and `src/PulseAPK.Core/Properties/Resources.resx`, which succeeded. 
- Attempted `dotnet build` but it could not be run in the environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efca3efd08322a1cfe89f35b2f71e)