### PR TITLE
Restyle Avalonia sidebar navigation

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -12,6 +12,45 @@
         Icon="/Assets/CyberUnpack.ico"
         Height="700">
 
+    <Window.Styles>
+        <Style Selector="Button.nav-button">
+            <Setter Property="Background" Value="#33141B2E" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="4,1,1,1" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+            <Setter Property="Padding" Value="12,10" />
+        </Style>
+
+        <Style Selector="Button.nav-button:pointerover">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+        </Style>
+
+        <Style Selector="Button.nav-button:pressed">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
+        <Style Selector="Button.nav-button.active">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+        </Style>
+
+        <Style Selector="TextBlock.nav-glyph">
+            <Setter Property="FontSize" Value="16" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Width" Value="24" />
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+    </Window.Styles>
+
     <Window.DataTemplates>
         <DataTemplate DataType="{x:Type vm:DecompileViewModel}">
             <views:DecompileView/>
@@ -36,45 +75,86 @@
         </DataTemplate>
     </Window.DataTemplates>
 
-    <Grid ColumnDefinitions="220, *">
+    <Grid ColumnDefinitions="240, *">
         <!-- Sidebar -->
-        <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}" Padding="16">
+        <Border Grid.Column="0" Background="{DynamicResource CyberSidebarBrush}" Padding="16">
             <StackPanel Spacing="10">
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
-                           FontSize="20"
-                           FontWeight="Bold"
-                           Foreground="{DynamicResource SystemAccentColor}"
-                           HorizontalAlignment="Center"
-                           Margin="0,0,0,20"/>
-                
-                <Button Command="{Binding NavigateToDecompileCommand}"
-                        IsVisible="{Binding IsDecompileEnabled}"
-                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuDecompile]}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToBuildCommand}"
-                        IsVisible="{Binding IsBuildEnabled}"
-                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToPatchCommand}"
-                        IsVisible="{Binding IsPatchEnabled}"
-                        Content="{Binding MenuPatchLabel}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToAnalyserCommand}"
-                        IsVisible="{Binding IsAnalyserEnabled}"
-                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToDeviceToolsCommand}"
-                        IsVisible="{Binding IsDeviceToolsEnabled}"
-                        Content="{Binding MenuDeviceToolsLabel}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToSettingsCommand}"
-                        IsVisible="{Binding IsSettingsEnabled}"
-                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuSettings]}"
-                        HorizontalAlignment="Stretch"/>
-                <Button Command="{Binding NavigateToAboutCommand}"
-                        IsVisible="{Binding IsAboutEnabled}"
-                        Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAbout]}"
-                        HorizontalAlignment="Stretch"/>
+                <StackPanel Margin="0,0,0,8">
+                    <TextBlock Text="PulseAPK"
+                               FontSize="30"
+                               FontWeight="Black"
+                               Foreground="{DynamicResource CyberAccentBrush}"
+                               HorizontalAlignment="Center"
+                               LetterSpacing="1.5"/>
+                    <TextBlock Text="APK REVERSE LAB"
+                               FontSize="11"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource CyberAccentSecondaryBrush}"
+                               HorizontalAlignment="Center"
+                               LetterSpacing="2"
+                               Margin="0,2,0,14"/>
+                    <Border Height="1"
+                            Background="{DynamicResource CyberAccentBrush}"
+                            Opacity="0.65"
+                            Margin="12,0,12,10"/>
+                </StackPanel>
+
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToDecompileCommand}"
+                        IsVisible="{Binding IsDecompileEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="⌬"/>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuDecompile]}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToBuildCommand}"
+                        IsVisible="{Binding IsBuildEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="⬡"/>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToPatchCommand}"
+                        IsVisible="{Binding IsPatchEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="⚡"/>
+                        <TextBlock Text="{Binding MenuPatchLabel}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToAnalyserCommand}"
+                        IsVisible="{Binding IsAnalyserEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="◎"/>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToDeviceToolsCommand}"
+                        IsVisible="{Binding IsDeviceToolsEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="▣"/>
+                        <TextBlock Text="{Binding MenuDeviceToolsLabel}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToSettingsCommand}"
+                        IsVisible="{Binding IsSettingsEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="⚙"/>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuSettings]}"/>
+                    </StackPanel>
+                </Button>
+                <Button Classes="nav-button"
+                        Command="{Binding NavigateToAboutCommand}"
+                        IsVisible="{Binding IsAboutEnabled}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Classes="nav-glyph" Text="?"/>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAbout]}"/>
+                    </StackPanel>
+                </Button>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
### Motivation
- Improve the app chrome by widening the sidebar and applying the cyberpunk visual theme from `App.axaml` so the sidebar matches the rest of the UI.
- Give the navigation a more modern, neon look and provide a reusable styling surface for nav buttons to make future refinements easier.
- Emphasize branding by enlarging the app title area and adding a short subtitle/divider for clearer app identity.
- Add compact glyphs next to menu labels to improve discoverability and visual scanning of sidebar items.

### Description
- Increased the left column width from `220` to `240` in the `Grid` `ColumnDefinitions` and switched the sidebar `Background` to `{DynamicResource CyberSidebarBrush}`.
- Added `Window.Styles` with reusable `Button.nav-button` and `TextBlock.nav-glyph` selectors and states for `:pointerover`, `:pressed` and an `.active` style hook to support active-item highlighting later.
- Replaced the plain title `TextBlock` with a branded header containing a larger `PulseAPK` title, a small `APK REVERSE LAB` subtitle, and a bottom divider line using the cyan/magenta accent brushes from the theme.
- Replaced plain `Button` label usages with nav buttons that use `Classes="nav-button"` and a `StackPanel` containing a glyph `TextBlock` (e.g. `⌬`, `⬡`, `⚡`, `◎`, `▣`, `⚙`, `?`) followed by the existing localized menu label bindings.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors and it completed successfully.
- Parsed the updated XAML with `python3` and `xml.etree.ElementTree` via `ET.parse('src/PulseAPK.Avalonia/MainWindow.axaml')` which succeeded.
- Attempted to run `dotnet build` but the `dotnet` SDK is not available in this environment so a full build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f031547208322a8c145ba6fc47e9a)