### PR TITLE
Polish Avalonia main view styling

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -55,16 +55,47 @@
 
         <Style Selector="Border.card">
             <Setter Property="Background" Value="{DynamicResource CyberCardBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource CyberCardBorderBrush}" />
-            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="1.25" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="20" />
+        </Style>
+
+        <Style Selector="Border.card.compact">
+            <Setter Property="Padding" Value="16" />
+        </Style>
+
+        <Style Selector="Border.console-card">
+            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="1.25" />
             <Setter Property="CornerRadius" Value="12" />
             <Setter Property="Padding" Value="16" />
+        </Style>
+
+        <Style Selector="Border.console-card.compact">
+            <Setter Property="Padding" Value="14" />
+        </Style>
+
+        <Style Selector="Border.neon-pill">
+            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="12" />
+            <Setter Property="Padding" Value="14,6" />
         </Style>
 
         <Style Selector="TextBlock.page-title">
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
             <Setter Property="FontSize" Value="28" />
             <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+
+        <Style Selector="TextBlock.helper-text">
+            <Setter Property="Foreground" Value="{DynamicResource CyberCardBorderBrush}" />
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Opacity" Value="0.65" />
+            <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
     </Application.Styles>
 

--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml
@@ -4,10 +4,9 @@
              xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.AboutView"
              x:DataType="vm:AboutViewModel">
-    <StackPanel Spacing="12" Margin="20" HorizontalAlignment="Center">
+    <StackPanel Spacing="16" Margin="20" HorizontalAlignment="Center">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
-                   FontSize="36"
-                   FontWeight="Bold"
+                   Classes="page-title"
                    HorizontalAlignment="Center" />
         <TextBlock Text="{Binding AppVersion}"
                    FontSize="16"

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -6,16 +6,11 @@
              x:DataType="vm:AnalyserViewModel">
     <Grid RowDefinitions="Auto,Auto,*,Auto" RowSpacing="16" Margin="20">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AnalyserHeader]}"
-                   FontSize="24"
-                   FontWeight="SemiBold" />
+                   Classes="page-title" />
 
         <Border Grid.Row="1"
-                Background="{DynamicResource CardBackgroundBrush}"
-                BorderBrush="{DynamicResource CardBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                Classes="card">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                 <StackPanel Spacing="6">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
                                FontWeight="SemiBold" />
@@ -25,8 +20,7 @@
                              IsTabStop="False"
                              IsHitTestVisible="False" />
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseProjectFolderTip]}"
-                               FontSize="12"
-                               Opacity="0.7"
+                               Classes="helper-text"
                                IsVisible="{Binding IsHintVisible}" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
@@ -49,11 +43,7 @@
         </Border>
 
         <Border Grid.Row="2"
-                Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
+                Classes="console-card">
             <Grid RowDefinitions="Auto,*" RowSpacing="8">
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
                            FontWeight="SemiBold" />

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -6,16 +6,11 @@
              x:DataType="vm:BuildViewModel">
     <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="16" Margin="20">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BuildHeader]}"
-                   FontSize="24"
-                   FontWeight="SemiBold" />
+                   Classes="page-title" />
 
         <Border Grid.Row="1"
-                Background="{DynamicResource CardBackgroundBrush}"
-                BorderBrush="{DynamicResource CardBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                Classes="card">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                 <StackPanel Spacing="6">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectProjectFolder]}"
                                FontWeight="SemiBold" />
@@ -25,8 +20,7 @@
                              IsTabStop="False"
                              IsHitTestVisible="False" />
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseProjectFolderTip]}"
-                               FontSize="12"
-                               Opacity="0.7"
+                               Classes="helper-text"
                                IsVisible="{Binding IsHintVisible}" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
@@ -73,11 +67,7 @@
         </Grid>
 
         <Border Grid.Row="3"
-                Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
+                Classes="console-card">
             <Grid RowDefinitions="Auto,*" RowSpacing="8">
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
                            FontWeight="SemiBold" />

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -8,16 +8,11 @@
           RowSpacing="16"
           Margin="20">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecompileHeader]}"
-                   FontSize="24"
-                   FontWeight="SemiBold" />
+                   Classes="page-title" />
 
         <Border Grid.Row="1"
-                Background="{DynamicResource CardBackgroundBrush}"
-                BorderBrush="{DynamicResource CardBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                Classes="card">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                 <StackPanel Spacing="6">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
                                FontWeight="SemiBold" />
@@ -27,8 +22,7 @@
                              IsTabStop="False"
                              IsHitTestVisible="False" />
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseApkTip]}"
-                               FontSize="12"
-                               Opacity="0.7"
+                               Classes="helper-text"
                                IsVisible="{Binding IsHintVisible}" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
@@ -79,11 +73,7 @@
         </Grid>
 
         <Border Grid.Row="3"
-                Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
+                Classes="console-card">
             <Grid RowDefinitions="Auto,*" RowSpacing="8">
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
                            FontWeight="SemiBold" />

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -36,24 +36,19 @@
             <Setter Property="Foreground" Value="#FFFFFF" />
         </Style>
     </UserControl.Styles>
-    <Grid RowDefinitions="*,Auto" RowSpacing="10" Margin="20">
+    <Grid RowDefinitions="*,Auto" RowSpacing="16" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
-            <StackPanel Spacing="14">
+            <StackPanel Spacing="16">
                 <StackPanel Spacing="4">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsHeader]}"
-                               FontSize="24"
-                               FontWeight="SemiBold" />
+                               Classes="page-title" />
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsSubtitle]}"
-                               Opacity="0.75" />
+                               Classes="helper-text" />
                 </StackPanel>
 
-                <Border Background="{DynamicResource CardBackgroundBrush}"
-                        BorderBrush="{DynamicResource CardBorderBrush}"
-                        BorderThickness="1"
-                        CornerRadius="6"
-                        Padding="12">
-                    <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="10">
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <Border Classes="card">
+                    <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="16">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                             <StackPanel Spacing="6">
                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnection]}"
                                            FontWeight="SemiBold" />
@@ -67,11 +62,10 @@
                                             Margin="0,0,8,4"
                                             ToolTip.Tip="{Binding DetectedAdbPath}">
                                         <TextBlock Text="{Binding AdbStatus}"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="12" />
+                                                   FontWeight="SemiBold" />
                                     </Border>
                                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsSelectDeviceHelp]}"
-                                               Opacity="0.75"
+                                               Classes="helper-text"
                                                VerticalAlignment="Center"
                                                Margin="0,0,0,4" />
                                 </WrapPanel>
@@ -101,15 +95,11 @@
                             <TextBlock Grid.Column="1"
                                        Text="{Binding InlineDeviceListStatus}"
                                        VerticalAlignment="Center"
-                                       Opacity="0.75" />
+                                       Classes="helper-text" />
                         </Grid>
 
                         <Border Grid.Row="2"
-                                Background="{DynamicResource MainBackgroundBrush}"
-                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="6"
-                                Padding="10"
+                                Classes="console-card compact"
                                 IsVisible="{Binding HasNoConnectedDevices}">
                             <TextBlock Text="{Binding DeviceListStatus}"
                                        TextWrapping="Wrap"
@@ -119,11 +109,7 @@
                     </Grid>
                 </Border>
 
-                <Border Background="{DynamicResource CardBackgroundBrush}"
-                        BorderBrush="{DynamicResource CardBorderBrush}"
-                        BorderThickness="1"
-                        CornerRadius="6"
-                        Padding="12">
+                <Border Classes="card">
                     <StackPanel Spacing="10">
                         <StackPanel Spacing="10">
                             <StackPanel Spacing="4">
@@ -140,12 +126,11 @@
                                             Padding="10,4"
                                             VerticalAlignment="Center">
                                         <TextBlock Text="{Binding DeviceConnectionStatus}"
-                                                   FontWeight="SemiBold"
-                                                   FontSize="12" />
+                                                   FontWeight="SemiBold" />
                                     </Border>
                                 </Grid>
                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsWorkflowHelp]}"
-                                           Opacity="0.75" />
+                                           Classes="helper-text" />
                             </StackPanel>
 
                             <ListBox ItemsSource="{Binding DeviceToolModes}"
@@ -159,11 +144,7 @@
                                 </ListBox.ItemsPanel>
                                 <ListBox.ItemTemplate>
                                     <DataTemplate x:DataType="vm:DeviceToolModeOption">
-                                        <Border Background="{DynamicResource MainBackgroundBrush}"
-                                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                                BorderThickness="1"
-                                                CornerRadius="12"
-                                                Padding="14,6"
+                                        <Border Classes="neon-pill"
                                                 Margin="0,0,8,0">
                                             <TextBlock Text="{Binding DisplayName}" />
                                         </Border>
@@ -172,16 +153,12 @@
                             </ListBox>
                         </StackPanel>
 
-                        <Border Background="{DynamicResource MainBackgroundBrush}"
-                                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="6"
-                                Padding="14">
+                        <Border Classes="console-card">
                             <Grid>
                                 <StackPanel Spacing="10" IsVisible="{Binding IsInstallApkMode}">
                                     <StackPanel Spacing="3">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApkPackage]}" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApkHelp]}" Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApkHelp]}" Classes="helper-text" />
                                     </StackPanel>
                                     <StackPanel Spacing="6">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsApkFile]}" Opacity="0.8" />
@@ -194,7 +171,7 @@
                                         </WrapPanel>
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
-                                                   Opacity="0.75"
+                                                   Classes="helper-text"
                                                    TextWrapping="Wrap" />
                                     </StackPanel>
                                 </StackPanel>
@@ -202,7 +179,7 @@
                                 <StackPanel Spacing="10" IsVisible="{Binding IsLaunchAppMode}">
                                     <StackPanel Spacing="3">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchInstalledApp]}" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchHelp]}" Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchHelp]}" Classes="helper-text" />
                                     </StackPanel>
                                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
                                         <StackPanel Spacing="6">
@@ -231,11 +208,11 @@
                                     <StackPanel Spacing="2">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
-                                                   Opacity="0.75"
+                                                   Classes="helper-text"
                                                    TextWrapping="Wrap" />
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageRequiredHint]}"
                                                    IsVisible="{Binding CanShowPackageRequiredHint}"
-                                                   Opacity="0.75"
+                                                   Classes="helper-text"
                                                    TextWrapping="Wrap" />
                                     </StackPanel>
                                 </StackPanel>
@@ -243,7 +220,7 @@
                                 <StackPanel Spacing="10" IsVisible="{Binding IsAppMaintenanceMode}">
                                     <StackPanel Spacing="3">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsManageInstalledApp]}" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsManageHelp]}" Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsManageHelp]}" Classes="helper-text" />
                                     </StackPanel>
                                     <StackPanel Spacing="6">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageName]}" Opacity="0.8" />
@@ -256,15 +233,11 @@
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsAppPath]}" Command="{Binding RunAppPathPresetCommand}" Margin="0,0,8,4" />
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
-                                        <Border Background="{DynamicResource CardBackgroundBrush}"
-                                                BorderBrush="{DynamicResource CardBorderBrush}"
-                                                BorderThickness="1"
-                                                CornerRadius="6"
-                                                Padding="10"
+                                        <Border Classes="card compact"
                                                 Margin="0,4,0,0">
                                             <StackPanel Spacing="6">
                                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsUtilities]}" FontWeight="SemiBold" />
-                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageUtilitiesHelp]}" Opacity="0.75" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageUtilitiesHelp]}" Classes="helper-text" TextWrapping="Wrap" />
                                                 <WrapPanel>
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsOpenAppSettings]}" Command="{Binding OpenAppSettingsCommand}" Margin="0,0,8,4" />
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCopyApkFromDevice]}" Command="{Binding CopyApkFromDeviceCommand}" Margin="0,0,8,4" />
@@ -275,11 +248,11 @@
                                         <StackPanel Spacing="2">
                                             <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                        IsVisible="{Binding CanShowNoDeviceHint}"
-                                                       Opacity="0.75"
+                                                       Classes="helper-text"
                                                        TextWrapping="Wrap" />
                                             <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageRequiredHint]}"
                                                        IsVisible="{Binding CanShowPackageRequiredHint}"
-                                                       Opacity="0.75"
+                                                       Classes="helper-text"
                                                        TextWrapping="Wrap" />
                                         </StackPanel>
                                     </StackPanel>
@@ -288,7 +261,7 @@
                                 <StackPanel Spacing="10" IsVisible="{Binding IsShellPresetsMode}">
                                     <StackPanel Spacing="3">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbShellCommands]}" FontSize="18" FontWeight="SemiBold" />
-                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsShellHelp]}" Opacity="0.75" />
+                                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsShellHelp]}" Classes="helper-text" />
                                     </StackPanel>
                                     <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPreset]}"
@@ -320,16 +293,12 @@
                                                     MinWidth="100"
                                                     Margin="0,0,8,4" />
                                         </WrapPanel>
-                                        <Border Background="{DynamicResource CardBackgroundBrush}"
-                                                BorderBrush="{DynamicResource CardBorderBrush}"
-                                                BorderThickness="1"
-                                                CornerRadius="6"
-                                                Padding="10"
+                                        <Border Classes="card compact"
                                                 Margin="0,4,0,0">
                                             <StackPanel Spacing="6">
                                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsUtilities]}" FontWeight="SemiBold" />
-                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsScreenUtilitiesHelp]}" Opacity="0.75" TextWrapping="Wrap" />
-                                                <TextBlock Text="{Binding ScreenRecordStatus}" Opacity="0.75" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsScreenUtilitiesHelp]}" Classes="helper-text" TextWrapping="Wrap" />
+                                                <TextBlock Text="{Binding ScreenRecordStatus}" Classes="helper-text" TextWrapping="Wrap" />
                                                 <WrapPanel>
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsScreenshot]}" Command="{Binding TakeScreenshotCommand}" Margin="0,0,8,4" />
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsStartScreenRecord]}" Command="{Binding StartScreenRecordCommand}" Margin="0,0,8,4" />
@@ -344,7 +313,7 @@
                                         </Border>
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsConnectDeviceHint]}"
                                                    IsVisible="{Binding CanShowNoDeviceHint}"
-                                                   Opacity="0.75"
+                                                   Classes="helper-text"
                                                    TextWrapping="Wrap" />
                                     </StackPanel>
                                 </StackPanel>
@@ -356,13 +325,9 @@
         </ScrollViewer>
 
         <Border Grid.Row="1"
-                Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
+                Classes="console-card">
             <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
-                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutput]}"
                                FontWeight="SemiBold"
                                VerticalAlignment="Center" />
@@ -375,8 +340,7 @@
 
                 <TextBlock Grid.Row="1"
                            Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutputHelp]}"
-                           FontSize="12"
-                           Opacity="0.65" />
+                           Classes="helper-text" />
 
                 <TextBox Grid.Row="2"
                          Text="{Binding ConsoleLog}"

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -9,20 +9,14 @@
           Margin="20">
         <StackPanel Spacing="4">
             <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchHeader]}"
-                       FontSize="24"
-                       FontWeight="SemiBold" />
+                       Classes="page-title" />
             <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchBetaWarning]}"
-                       FontSize="13"
-                       Opacity="0.7" />
+                       Classes="helper-text" />
         </StackPanel>
 
         <Border Grid.Row="1"
-                Background="{DynamicResource CardBackgroundBrush}"
-                BorderBrush="{DynamicResource CardBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                Classes="card">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
                 <StackPanel Spacing="6">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
                                FontWeight="SemiBold" />
@@ -32,8 +26,7 @@
                              IsTabStop="False"
                              IsHitTestVisible="False" />
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseApkTip]}"
-                               FontSize="12"
-                               Opacity="0.7"
+                               Classes="helper-text"
                                IsVisible="{Binding IsHintVisible}" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
@@ -70,7 +63,7 @@
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
                           IsChecked="{Binding UseAapt2ForBuild}" />
                 <Grid ColumnDefinitions="*,*"
-                      ColumnSpacing="12"
+                      ColumnSpacing="16"
                       Margin="0,8,0,0">
                     <StackPanel Spacing="4">
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptProfile]}"
@@ -98,8 +91,7 @@
                     </StackPanel>
                 </Grid>
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptSampleInjectionInfo]}"
-                           FontSize="12"
-                           Opacity="0.7"
+                           Classes="helper-text"
                            IsVisible="{Binding IsSampleInjectionProfileSelected}" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
@@ -122,11 +114,7 @@
         </Grid>
 
         <Border Grid.Row="3"
-                Background="{DynamicResource MainBackgroundBrush}"
-                BorderBrush="{DynamicResource ConsoleBorderBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Padding="12">
+                Classes="console-card">
             <Grid RowDefinitions="Auto,*" RowSpacing="8">
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
                            FontWeight="SemiBold" />

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -5,10 +5,9 @@
              x:Class="PulseAPK.Avalonia.Views.SettingsView"
              x:DataType="vm:SettingsViewModel">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-    <StackPanel Spacing="12" Margin="20">
+    <StackPanel Spacing="16" Margin="20">
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SettingsHeader]}"
-                   FontSize="24"
-                   FontWeight="SemiBold" />
+                   Classes="page-title" />
 
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[LanguageLabel]}"
                    FontWeight="SemiBold" />


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize visual tokens for cards, consoles and helper text so themes and accents are consistent across screens.
- Improve visual hierarchy by making page titles consistent, dimming helper text, and increasing card padding and corner radii.
- Introduce subtle neon/cyber accent borders to reinforce the app accent color without scattering raw brushes in views.
- Standardize spacing and row/column gaps so layouts have a consistent rhythm across main views.

### Description
- Added shared styles in `App.axaml` including updated `Border.card` (padding `20`, `CornerRadius` `12`, `BorderBrush` -> `CyberAccentBrush`, `BorderThickness` `1.25`), `Border.card.compact`, `Border.console-card` and `Border.console-card.compact`, `Border.neon-pill`, `TextBlock.page-title`, and `TextBlock.helper-text`.
- Replaced repeated inline card/console border attributes in views with class usage such as `Classes="card"`, `Classes="console-card"`, `Classes="neon-pill"`, and applied `Classes="page-title"` to screen titles.
- Increased spacing and grid/column gaps (standardized to `16` in many places) and introduced `card compact` where smaller padding was previously used.
- Converted small helper text instances from inline `FontSize`/`Opacity` to the shared `helper-text` class to create a clearer typographic hierarchy.

### Testing
- Parsed `App.axaml` and all modified view files using `xml.etree.ElementTree` which succeeded without XML parse errors.
- Ran `git diff --check` to validate whitespace/conflict markers which returned clean results.
- Attempted `dotnet build PulseAPK.sln` but it could not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f04cb001c8322bb9ea1a008139eba)