### PR TITLE
Add global terminal-output style and apply to console TextBoxes

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -37,6 +37,19 @@
             <Setter Property="Padding" Value="10,7" />
         </Style>
 
+
+        <Style Selector="TextBox.terminal-output">
+            <Setter Property="Background" Value="#02060D" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="1.5" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="FontFamily" Value="Consolas, Menlo, Monaco, 'Courier New', monospace" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+            <Setter Property="Padding" Value="14,10" />
+            <Setter Property="SelectionBrush" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="SelectionForegroundBrush" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
         <Style Selector="ComboBox">
             <Setter Property="Background" Value="{DynamicResource CyberCardBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberCardBorderBrush}" />

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -52,6 +52,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
+                         Classes="terminal-output"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          VerticalAlignment="Stretch" />
             </Grid>

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -76,6 +76,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
+                         Classes="terminal-output"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          VerticalAlignment="Stretch" />
             </Grid>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -82,6 +82,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
+                         Classes="terminal-output"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          VerticalAlignment="Stretch" />
             </Grid>

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -70,13 +70,6 @@
             <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
-        <Style Selector="TextBox.terminal-output">
-            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource CyberConsoleBorderBrush}" />
-            <Setter Property="BorderThickness" Value="1.25" />
-            <Setter Property="FontFamily" Value="Consolas, Menlo, monospace" />
-            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
-        </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="*,Auto" RowSpacing="16" Margin="20">
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -123,6 +123,7 @@
                          IsReadOnly="True"
                          AcceptsReturn="True"
                          TextWrapping="Wrap"
+                         Classes="terminal-output"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          VerticalAlignment="Stretch" />
             </Grid>


### PR DESCRIPTION
### Motivation
- Provide a consistent terminal/console appearance across views using a monospace font, very dark background, neon accent border, and readable selection colors. 
- Replace per-view styling with a single global style so console TextBoxes share padding, border, foreground and selection behavior while preserving existing bindings and scrolling behavior.

### Description
- Added a global `TextBox.terminal-output` style in `src/PulseAPK.Avalonia/App.axaml` with a monospace `FontFamily`, very dark `Background`, neon `BorderBrush`, larger `Padding`, and explicit `SelectionBrush`/`SelectionForegroundBrush` for readable disabled selection. 
- Removed the local `TextBox.terminal-output` style from `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` so the global style is used. 
- Applied `Classes="terminal-output"` to the console/log `TextBox` in `AnalyserView.axaml`, `BuildView.axaml`, `DecompileView.axaml`, and `PatchView.axaml`, and retained the same `Text` binding, `AcceptsReturn`, `TextWrapping`, and `ScrollViewer.VerticalScrollBarVisibility` settings. 

### Testing
- Parsed all modified AXAML files with `xml.etree.ElementTree.parse` to validate well-formed XML, and the parse succeeded for each file. 
- Attempted to run `dotnet build` but it could not be executed in the environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f07ab7b808322a83a7ce0874aa09b)