### PR TITLE
Organize settings view into styled cards

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -5,71 +5,100 @@
              x:Class="PulseAPK.Avalonia.Views.SettingsView"
              x:DataType="vm:SettingsViewModel">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-    <StackPanel Spacing="16" Margin="20">
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SettingsHeader]}"
-                   Classes="page-title" />
+        <StackPanel Spacing="16" Margin="20">
+            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SettingsHeader]}"
+                       Classes="page-title" />
 
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[LanguageLabel]}"
-                   FontWeight="SemiBold" />
-        <ComboBox ItemsSource="{Binding AvailableLanguages}"
-                  SelectedItem="{Binding SelectedLanguage}"
-                  Width="260">
-            <ComboBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Name}" />
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
+            <Border Classes="card">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Appearance"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource CyberAccentBrush}" />
 
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ThemeLabel]}"
-                   FontWeight="SemiBold" />
-        <ComboBox ItemsSource="{Binding AvailableThemeModes}"
-                  SelectedItem="{Binding SelectedThemeMode}"
-                  Width="260">
-            <ComboBox.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Name}" />
-                </DataTemplate>
-            </ComboBox.ItemTemplate>
-        </ComboBox>
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[LanguageLabel]}"
+                               FontWeight="SemiBold" />
+                    <ComboBox ItemsSource="{Binding AvailableLanguages}"
+                              SelectedItem="{Binding SelectedLanguage}"
+                              Width="260"
+                              HorizontalAlignment="Left">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Name}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
 
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
-                   FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
-            <TextBox Text="{Binding ApktoolPath}" />
-            <Button Grid.Column="1"
-                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
-                    Command="{Binding BrowseApktoolCommand}"
-                    Width="110" />
-            <Button Grid.Column="2"
-                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadApktoolButton]}"
-                    Command="{Binding DownloadApktoolCommand}"
-                    Width="150" />
-        </Grid>
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ThemeLabel]}"
+                               FontWeight="SemiBold" />
+                    <ComboBox ItemsSource="{Binding AvailableThemeModes}"
+                              SelectedItem="{Binding SelectedThemeMode}"
+                              Width="260"
+                              HorizontalAlignment="Left">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Name}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </StackPanel>
+            </Border>
 
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UbersignPath]}"
-                   FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
-            <TextBox Text="{Binding UbersignPath}" />
-            <Button Grid.Column="1"
-                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
-                    Command="{Binding BrowseUbersignCommand}"
-                    Width="110" />
-            <Button Grid.Column="2"
-                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadUbersignerButton]}"
-                    Command="{Binding DownloadUbersignerCommand}"
-                    Width="150" />
-        </Grid>
+            <Border Classes="card">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Toolchain"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource CyberAccentBrush}" />
 
-        <TextBlock Text="ADB Path"
-                   FontWeight="SemiBold" />
-        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-            <TextBox Text="{Binding AdbPath}" Watermark="{Binding AdbPathWatermark}" />
-            <Button Grid.Column="1"
-                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
-                    Command="{Binding BrowseAdbCommand}"
-                    Width="110" />
-        </Grid>
-    </StackPanel>
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
+                               FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+                        <TextBox Text="{Binding ApktoolPath}" />
+                        <Button Grid.Column="1"
+                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                                Command="{Binding BrowseApktoolCommand}"
+                                Width="110" />
+                        <Button Grid.Column="2"
+                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadApktoolButton]}"
+                                Command="{Binding DownloadApktoolCommand}"
+                                Width="150" />
+                    </Grid>
+
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UbersignPath]}"
+                               FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+                        <TextBox Text="{Binding UbersignPath}" />
+                        <Button Grid.Column="1"
+                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                                Command="{Binding BrowseUbersignCommand}"
+                                Width="110" />
+                        <Button Grid.Column="2"
+                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DownloadUbersignerButton]}"
+                                Command="{Binding DownloadUbersignerCommand}"
+                                Width="150" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+
+            <Border Classes="card">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Android Debug Bridge"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource CyberAccentBrush}" />
+
+                    <TextBlock Text="ADB Path"
+                               FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                        <TextBox Text="{Binding AdbPath}" Watermark="{Binding AdbPathWatermark}" />
+                        <Button Grid.Column="1"
+                                Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                                Command="{Binding BrowseAdbCommand}"
+                                Width="110" />
+                    </Grid>
+                </StackPanel>
+            </Border>
+        </StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Improve Settings UI clarity by visually grouping related controls into titled cards and reusing the shared `card` styling defined in `App.axaml`.
- Add small accent-colored section headers for better scannability while keeping existing view logic intact.

### Description
- Wrapped language and theme controls in an `Appearance` card implemented as `<Border Classes="card">` with a small accent-colored section header.
- Wrapped `Apktool` and `Ubersigner` controls in a `Toolchain` card using the shared `card` style and preserved the existing layout for browse/download buttons.
- Wrapped the ADB controls in an `Android Debug Bridge` card using the shared `card` style and preserved the `AdbPath` and watermark layout.
- Preserved all existing bindings and commands referenced by the view such as `AvailableLanguages`, `SelectedLanguage`, `AvailableThemeModes`, `SelectedThemeMode`, `ApktoolPath`, `UbersignPath`, `AdbPath`, and browse/download commands, and avoided changing code-behind logic.

### Testing
- Verified the XAML change by reviewing the resulting diff and committing the updated file successfully.
- Attempted to run `dotnet build` but the `dotnet` CLI is not available in this environment, so no build or automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f088808788322885a1a69603a0132)