### PR TITLE
Restyle About view as cyberpunk card

### DIFF
--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml
@@ -4,31 +4,76 @@
              xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.AboutView"
              x:DataType="vm:AboutViewModel">
-    <StackPanel Spacing="16" Margin="20" HorizontalAlignment="Center">
-        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[AppTitle]}"
-                   Classes="page-title"
-                   HorizontalAlignment="Center" />
-        <TextBlock Text="{Binding AppVersion}"
-                   FontSize="16"
-                   HorizontalAlignment="Center" />
+    <Grid Margin="20"
+          HorizontalAlignment="Stretch"
+          VerticalAlignment="Stretch">
+        <Border Classes="card"
+                Width="420"
+                MaxWidth="520"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="0 0 28 0 #4000E5FF">
+            <StackPanel Spacing="18" HorizontalAlignment="Center">
+                <Border Width="104"
+                        Height="104"
+                        Padding="10"
+                        Background="{DynamicResource CyberConsoleBackgroundBrush}"
+                        BorderBrush="{DynamicResource CyberAccentSecondaryBrush}"
+                        BorderThickness="1.5"
+                        CornerRadius="24"
+                        HorizontalAlignment="Center"
+                        BoxShadow="0 0 22 0 #66FF2BD6">
+                    <Image Source="/Assets/CyberUnpack.png"
+                           Stretch="Uniform" />
+                </Border>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
-            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DevelopedBy]}"
-                       FontSize="14" />
-            <TextBlock Text="{Binding DeveloperName}"
-                       FontSize="14"
-                       FontWeight="SemiBold" />
-        </StackPanel>
+                <StackPanel Spacing="6" HorizontalAlignment="Center">
+                    <TextBlock Text="PulseAPK"
+                               FontSize="42"
+                               FontWeight="Bold"
+                               Foreground="{DynamicResource CyberAccentBrush}"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center" />
+                    <TextBlock Text="Android APK reverse engineering toolkit"
+                               FontSize="15"
+                               Foreground="{DynamicResource CyberAccentSecondaryBrush}"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center" />
+                </StackPanel>
 
-        <TextBlock Text="{Binding Year}"
-                   FontSize="14"
-                   HorizontalAlignment="Center" />
+                <Border Classes="neon-pill" HorizontalAlignment="Center">
+                    <TextBlock Text="{Binding AppVersion}"
+                               FontSize="16"
+                               HorizontalAlignment="Center" />
+                </Border>
 
-        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_ProjectPage]}"
-                Command="{Binding OpenProjectPageCommand}"
-                Width="200" />
-        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DeveloperPage]}"
-                Command="{Binding OpenDeveloperPageCommand}"
-                Width="200" />
-    </StackPanel>
+                <StackPanel Spacing="8" HorizontalAlignment="Center">
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DevelopedBy]}"
+                                   FontSize="14" />
+                        <TextBlock Text="{Binding DeveloperName}"
+                                   FontSize="14"
+                                   FontWeight="SemiBold"
+                                   Foreground="{DynamicResource CyberAccentBrush}" />
+                    </StackPanel>
+
+                    <TextBlock Text="{Binding Year}"
+                               FontSize="14"
+                               HorizontalAlignment="Center"
+                               Opacity="0.75" />
+                </StackPanel>
+
+                <StackPanel Spacing="10" HorizontalAlignment="Center">
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_ProjectPage]}"
+                            Command="{Binding OpenProjectPageCommand}"
+                            Width="240"
+                            HorizontalContentAlignment="Center" />
+                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DeveloperPage]}"
+                            Command="{Binding OpenDeveloperPageCommand}"
+                            Width="240"
+                            HorizontalContentAlignment="Center" />
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Grid>
 </UserControl>


### PR DESCRIPTION
### Motivation
- Improve and modernize the About view with a centered, cyberpunk-styled card that matches the app theme. 
- Surface the app branding more prominently with a large neon heading and the existing app icon. 
- Keep all existing data/command bindings intact while using the shared cyberpunk button style for consistency.

### Description
- Replaced the root `StackPanel` with a centered `Border` using the shared `card` class and neon `BoxShadow` to form a styled card (`src/PulseAPK.Avalonia/Views/AboutView.axaml`).
- Added the existing icon with `<Image Source="/Assets/CyberUnpack.png" />` inside a rounded, highlighted border and a large static neon `PulseAPK` heading with a short tagline (`Android APK reverse engineering toolkit`).
- Kept and reused the existing bindings `AppVersion`, `DeveloperName`, `Year`, `OpenProjectPageCommand`, and `OpenDeveloperPageCommand` while widening and centering the project/developer buttons so they pick up the app-wide cyberpunk `Button` styling.
- Used existing dynamic resources (`CyberAccentBrush`, `CyberAccentSecondaryBrush`, `CyberConsoleBackgroundBrush`) and `neon-pill` / `card` style classes; no new resource files were added and the tagline was added as static text rather than a new localized resource.

### Testing
- Ran an XML parse check with `python3` to validate the XAML: succeeded (`xml ok`).
- Attempted `dotnet build PulseAPK.sln` but it could not be run in this environment because `dotnet` is not installed, so a full build/test was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f09078b7c832297a1e609da8acc90)