### PR TITLE
Improve helper text contrast

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -105,9 +105,8 @@
         </Style>
 
         <Style Selector="TextBlock.helper-text">
-            <Setter Property="Foreground" Value="{DynamicResource CyberCardBorderBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberHelperTextBrush}" />
             <Setter Property="FontSize" Value="11" />
-            <Setter Property="Opacity" Value="0.65" />
             <Setter Property="TextWrapping" Value="Wrap" />
         </Style>
     </Application.Styles>
@@ -127,6 +126,7 @@
                     <SolidColorBrush x:Key="CyberConsoleForegroundBrush" Color="#39FF88" />
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#102B3C" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#2B1234" />
+                    <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#8EA4C8" />
 
                     <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#0D1024" />
                     <SolidColorBrush x:Key="MainBackgroundBrush" Color="#090A18" />
@@ -146,6 +146,7 @@
                     <SolidColorBrush x:Key="CyberConsoleForegroundBrush" Color="#006E3A" />
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#DDF8FF" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#FCE0F6" />
+                    <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#52677A" />
 
                     <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#EEF4FF" />
                     <SolidColorBrush x:Key="MainBackgroundBrush" Color="#F7FAFF" />


### PR DESCRIPTION
### Motivation
- The subtitle/helper text appeared very low-contrast and hard to read, so theme-aware colors were added to improve readability across light and dark modes.

### Description
- Change `TextBlock.helper-text` to use a dedicated `CyberHelperTextBrush` instead of `CyberCardBorderBrush` and remove the opacity reduction so helper text is fully legible.
- Add `CyberHelperTextBrush` color definitions for the `Dark` theme (`#8EA4C8`) and the `Light` theme (`#52677A`) in `src/PulseAPK.Avalonia/App.axaml`.
- The change is localized to `App.axaml` and affects global helper/subtitle styling used across views.

### Testing
- Parsed `src/PulseAPK.Avalonia/App.axaml` with `python3` and `xml.etree.ElementTree` which succeeded (`App.axaml XML parsed successfully`).
- `dotnet build` was not executed in this environment because the `dotnet` CLI is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f0a915648832298cc0e505dc8defe)