### PR TITLE
Fix About screen layout and include app PNG resource

### DIFF
--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <AvaloniaResource Include="..\..\Resources\CyberUnpack.ico" Link="Assets\CyberUnpack.ico" />
+    <AvaloniaResource Include="..\..\Resources\CyberUnpack.png" Link="Assets\CyberUnpack.png" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml
@@ -4,76 +4,88 @@
              xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.AboutView"
              x:DataType="vm:AboutViewModel">
-    <Grid Margin="20"
-          HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch">
-        <Border Classes="card"
-                Width="420"
-                MaxWidth="520"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                BoxShadow="0 0 28 0 #4000E5FF">
-            <StackPanel Spacing="18" HorizontalAlignment="Center">
-                <Border Width="104"
-                        Height="104"
-                        Padding="10"
-                        Background="{DynamicResource CyberConsoleBackgroundBrush}"
-                        BorderBrush="{DynamicResource CyberAccentSecondaryBrush}"
-                        BorderThickness="1.5"
-                        CornerRadius="24"
-                        HorizontalAlignment="Center"
-                        BoxShadow="0 0 22 0 #66FF2BD6">
-                    <Image Source="/Assets/CyberUnpack.png"
-                           Stretch="Uniform" />
-                </Border>
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                  VerticalScrollBarVisibility="Auto">
+        <Grid Margin="20"
+              MinHeight="560"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch">
+            <Border Classes="card"
+                    Width="460"
+                    MaxWidth="560"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+                <StackPanel Spacing="18"
+                            HorizontalAlignment="Stretch">
+                    <Border Width="112"
+                            Height="112"
+                            Padding="12"
+                            Background="{DynamicResource CyberConsoleBackgroundBrush}"
+                            BorderBrush="{DynamicResource CyberAccentSecondaryBrush}"
+                            BorderThickness="1.5"
+                            CornerRadius="24"
+                            HorizontalAlignment="Center">
+                        <Image Source="avares://PulseAPK/Assets/CyberUnpack.png"
+                               Stretch="Uniform" />
+                    </Border>
 
-                <StackPanel Spacing="6" HorizontalAlignment="Center">
-                    <TextBlock Text="PulseAPK"
-                               FontSize="42"
-                               FontWeight="Bold"
-                               Foreground="{DynamicResource CyberAccentBrush}"
-                               HorizontalAlignment="Center"
-                               TextAlignment="Center" />
-                    <TextBlock Text="Android APK reverse engineering toolkit"
-                               FontSize="15"
-                               Foreground="{DynamicResource CyberAccentSecondaryBrush}"
-                               HorizontalAlignment="Center"
-                               TextAlignment="Center" />
-                </StackPanel>
-
-                <Border Classes="neon-pill" HorizontalAlignment="Center">
-                    <TextBlock Text="{Binding AppVersion}"
-                               FontSize="16"
-                               HorizontalAlignment="Center" />
-                </Border>
-
-                <StackPanel Spacing="8" HorizontalAlignment="Center">
-                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="6">
-                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DevelopedBy]}"
-                                   FontSize="14" />
-                        <TextBlock Text="{Binding DeveloperName}"
-                                   FontSize="14"
-                                   FontWeight="SemiBold"
-                                   Foreground="{DynamicResource CyberAccentBrush}" />
+                    <StackPanel Spacing="6"
+                                HorizontalAlignment="Stretch">
+                        <TextBlock Text="PulseAPK"
+                                   FontSize="42"
+                                   FontWeight="Bold"
+                                   Foreground="{DynamicResource CyberAccentBrush}"
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center" />
+                        <TextBlock Text="Android APK reverse engineering toolkit"
+                                   FontSize="15"
+                                   Foreground="{DynamicResource CyberAccentSecondaryBrush}"
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center"
+                                   TextWrapping="Wrap" />
                     </StackPanel>
 
-                    <TextBlock Text="{Binding Year}"
-                               FontSize="14"
-                               HorizontalAlignment="Center"
-                               Opacity="0.75" />
-                </StackPanel>
+                    <Border Classes="neon-pill"
+                            HorizontalAlignment="Center">
+                        <TextBlock Text="{Binding AppVersion}"
+                                   FontSize="16"
+                                   HorizontalAlignment="Center" />
+                    </Border>
 
-                <StackPanel Spacing="10" HorizontalAlignment="Center">
-                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_ProjectPage]}"
-                            Command="{Binding OpenProjectPageCommand}"
-                            Width="240"
-                            HorizontalContentAlignment="Center" />
-                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DeveloperPage]}"
-                            Command="{Binding OpenDeveloperPageCommand}"
-                            Width="240"
-                            HorizontalContentAlignment="Center" />
+                    <StackPanel Spacing="8"
+                                HorizontalAlignment="Center">
+                        <StackPanel Orientation="Horizontal"
+                                    HorizontalAlignment="Center"
+                                    Spacing="6">
+                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DevelopedBy]}"
+                                       FontSize="14" />
+                            <TextBlock Text="{Binding DeveloperName}"
+                                       FontSize="14"
+                                       FontWeight="SemiBold"
+                                       Foreground="{DynamicResource CyberAccentBrush}" />
+                        </StackPanel>
+
+                        <TextBlock Text="{Binding Year}"
+                                   FontSize="14"
+                                   HorizontalAlignment="Center"
+                                   Opacity="0.75" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="10"
+                                HorizontalAlignment="Stretch">
+                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_ProjectPage]}"
+                                Command="{Binding OpenProjectPageCommand}"
+                                Width="240"
+                                HorizontalAlignment="Center"
+                                HorizontalContentAlignment="Center" />
+                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_DeveloperPage]}"
+                                Command="{Binding OpenDeveloperPageCommand}"
+                                Width="240"
+                                HorizontalAlignment="Center"
+                                HorizontalContentAlignment="Center" />
+                    </StackPanel>
                 </StackPanel>
-            </StackPanel>
-        </Border>
-    </Grid>
+            </Border>
+        </Grid>
+    </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
### Motivation
- The About screen could render incorrectly or not scale on some window sizes and lacked a reliable resource URI for the artwork. 
- The app PNG was not registered as an Avalonia resource so the image resolution could fail at runtime.

### Description
- Wrap the About content in a `ScrollViewer` and center a fixed-width card with `MinHeight` to ensure proper layout and scrolling in `src/PulseAPK.Avalonia/Views/AboutView.axaml`. 
- Adjust inner layout to use stretching alignment and increase the artwork container size for more predictable rendering. 
- Use an explicit Avalonia URI for the image (`avares://PulseAPK/Assets/CyberUnpack.png`) in `AboutView.axaml`. 
- Register the PNG in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` by adding an `AvaloniaResource` entry for `Resources/CyberUnpack.png` so the asset is bundled and addressable.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues which passed. 
- Parsed the updated AXAML and project file with `python3` using `xml.etree.ElementTree` which succeeded. 
- Attempted `dotnet build PulseAPK-Core.sln` but the environment does not have `dotnet` installed so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f0f7a0168832293d5ff37a090837f)