### PR TITLE
Restore sidebar selected highlight with cyberpunk magenta

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -23,9 +23,17 @@
         </Style>
 
         <Style Selector="Button:pressed">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
+            <Setter Property="Background" Value="{DynamicResource CyberButtonPressedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
+
+        <Style Selector="Button:disabled">
+            <Setter Property="Background" Value="{DynamicResource CyberDisabledButtonBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberDisabledButtonBorderBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberDisabledButtonForegroundBrush}" />
+            <Setter Property="Opacity" Value="0.78" />
         </Style>
 
         <Style Selector="TextBox">
@@ -126,6 +134,12 @@
                     <SolidColorBrush x:Key="CyberConsoleForegroundBrush" Color="#39FF88" />
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#102B3C" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#2B1234" />
+                    <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#3A0B4D" />
+                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#3A0B4D" />
+                    <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#FF2BD6" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBrush" Color="#1B2142" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#284B6F" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#7387A8" />
                     <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#8EA4C8" />
 
                     <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#0D1024" />
@@ -146,6 +160,12 @@
                     <SolidColorBrush x:Key="CyberConsoleForegroundBrush" Color="#006E3A" />
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#DDF8FF" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#FCE0F6" />
+                    <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#FFD7F7" />
+                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#FFD7F7" />
+                    <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#B0007C" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBrush" Color="#E5F6FF" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#86CCE5" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#4E7A8C" />
                     <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#52677A" />
 
                     <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#EEF4FF" />

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -37,8 +37,8 @@
         </Style>
 
         <Style Selector="Button.nav-button.active">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Background" Value="{DynamicResource CyberSelectedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberSelectedBorderBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 
@@ -101,6 +101,7 @@
 
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToDecompileCommand}"
+                        Classes.active="{Binding IsDecompileSelected}"
                         IsVisible="{Binding IsDecompileEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="⌬"/>
@@ -109,6 +110,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToBuildCommand}"
+                        Classes.active="{Binding IsBuildSelected}"
                         IsVisible="{Binding IsBuildEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="⬡"/>
@@ -117,6 +119,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToPatchCommand}"
+                        Classes.active="{Binding IsPatchSelected}"
                         IsVisible="{Binding IsPatchEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="⚡"/>
@@ -125,6 +128,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToAnalyserCommand}"
+                        Classes.active="{Binding IsAnalyserSelected}"
                         IsVisible="{Binding IsAnalyserEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="◎"/>
@@ -133,6 +137,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToDeviceToolsCommand}"
+                        Classes.active="{Binding IsDeviceToolsSelected}"
                         IsVisible="{Binding IsDeviceToolsEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="▣"/>
@@ -141,6 +146,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToSettingsCommand}"
+                        Classes.active="{Binding IsSettingsSelected}"
                         IsVisible="{Binding IsSettingsEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="⚙"/>
@@ -149,6 +155,7 @@
                 </Button>
                 <Button Classes="nav-button"
                         Command="{Binding NavigateToAboutCommand}"
+                        Classes.active="{Binding IsAboutSelected}"
                         IsVisible="{Binding IsAboutEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <TextBlock Classes="nav-glyph" Text="?"/>

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -30,6 +30,14 @@ public partial class MainViewModel : ObservableObject
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
 
+    public bool IsDecompileSelected => SelectedMenu == "Decompile";
+    public bool IsBuildSelected => SelectedMenu == "Build";
+    public bool IsPatchSelected => SelectedMenu == "Patch";
+    public bool IsAnalyserSelected => SelectedMenu == "Analyser";
+    public bool IsDeviceToolsSelected => SelectedMenu == "DeviceTools";
+    public bool IsSettingsSelected => SelectedMenu == "Settings";
+    public bool IsAboutSelected => SelectedMenu == "About";
+
     public bool IsDecompileEnabled => FeatureFlags.Decompile;
     public bool IsBuildEnabled => FeatureFlags.BuildApk;
     public bool IsPatchEnabled => FeatureFlags.PatchApk;
@@ -103,6 +111,17 @@ public partial class MainViewModel : ObservableObject
         if (!CanNavigateToAbout()) return;
         SetCurrentView(Resolve<AboutViewModel>());
         SelectedMenu = "About";
+    }
+
+    partial void OnSelectedMenuChanged(string value)
+    {
+        OnPropertyChanged(nameof(IsDecompileSelected));
+        OnPropertyChanged(nameof(IsBuildSelected));
+        OnPropertyChanged(nameof(IsPatchSelected));
+        OnPropertyChanged(nameof(IsAnalyserSelected));
+        OnPropertyChanged(nameof(IsDeviceToolsSelected));
+        OnPropertyChanged(nameof(IsSettingsSelected));
+        OnPropertyChanged(nameof(IsAboutSelected));
     }
 
     private static bool CanNavigateToDecompile() => FeatureFlags.Decompile;


### PR DESCRIPTION
### Motivation
- The sidebar lost its visible selected state when a section was active, making it hard to see which page is selected.
- The existing gray/neutral highlights were not aligned with the cyberpunk theme and disabled buttons used a bland gray look.

### Description
- Add boolean selected properties to `MainViewModel` (`IsDecompileSelected`, `IsBuildSelected`, `IsPatchSelected`, `IsAnalyserSelected`, `IsDeviceToolsSelected`, `IsSettingsSelected`, `IsAboutSelected`) and notify them from the `OnSelectedMenuChanged` partial method so the view can react to `SelectedMenu` changes.
- Bind each sidebar `Button` in `MainWindow.axaml` to the new selected properties via `Classes.active` so the active section gets an `active` class.
- Replace the `nav-button.active` styling to use new cyberpunk selected brushes (`CyberSelectedBrush` + `CyberSelectedBorderBrush`) instead of the previous gray-toned pressed brush.
- Add theme-specific brushes and small button style changes in `App.axaml`: new `CyberSelectedBrush`/`CyberSelectedBorderBrush` values (dark: `#3A0B4D` with border `#FF2BD6`, light: `#FFD7F7` with border `#B0007C`), replace pressed button resource with `CyberButtonPressedBrush`, and add a `Button:disabled` style with themed disabled brushes.

### Testing
- Ran `git diff --check` to validate changes and found no whitespace/formatting errors (success).
- Attempted to run `dotnet build PulseAPK.sln` but the `dotnet` SDK is not installed in this environment so a full build could not be executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1e09048c8322ba6caaee74a43e8d)