### PR TITLE
Enhance active nav button styling

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -39,7 +39,10 @@
         <Style Selector="Button.nav-button.active">
             <Setter Property="Background" Value="{DynamicResource CyberSelectedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberSelectedBorderBrush}" />
+            <Setter Property="BorderThickness" Value="8,2,2,2" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+            <Setter Property="Opacity" Value="1" />
         </Style>
 
         <Style Selector="TextBlock.nav-glyph">


### PR DESCRIPTION
### Motivation
- Improve the non-functional visual cue for the active navigation button so the selected item is more visually prominent (thicker left accent, stronger text weight and explicit opacity) while preserving the existing active-class bindings.

### Description
- Modified the `Button.nav-button.active` style in `src/PulseAPK.Avalonia/MainWindow.axaml` to add `BorderThickness="8,2,2,2"`, `FontWeight="SemiBold"`, and `Opacity="1"` while keeping the existing `Background` and `BorderBrush` (using `CyberSelectedBrush` / `CyberSelectedBorderBrush`) and leaving all `Classes.active="{Binding ...}"` bindings unchanged.

### Testing
- Parsed the AXAML with `python3 - <<'PY' ...` to confirm it is valid XML, ran `git diff --check` and `rg 'Classes\.active=' src/PulseAPK.Avalonia/MainWindow.axaml` to verify changes and bindings, and attempted `dotnet build` which could not run because the `dotnet` CLI is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f26d277ac8322beb42e0f0845143c)