### PR TITLE
Style primary action buttons

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -22,12 +22,31 @@
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 
+
         <Style Selector="Button:pressed">
             <Setter Property="Background" Value="{DynamicResource CyberButtonPressedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
             <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
         </Style>
 
+        <Style Selector="Button.primary-action">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+
+        <Style Selector="Button.primary-action:pointerover">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
+        <Style Selector="Button.primary-action:pressed">
+            <Setter Property="Background" Value="{DynamicResource CyberButtonPressedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
 
         <Style Selector="Button:disabled">
             <Setter Property="Background" Value="{DynamicResource CyberDisabledButtonBrush}" />

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -33,6 +33,7 @@
                             Padding="16,0" />
                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[RunAnalysis]}"
                             Command="{Binding RunAnalysisCommand}"
+                            Classes="primary-action"
                             MinWidth="120"
                             Height="38"
                             FontSize="14"

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -33,6 +33,7 @@
                             Padding="16,0" />
                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[RunBuild]}"
                             Command="{Binding RunBuildCommand}"
+                            Classes="primary-action"
                             MinWidth="120"
                             Height="38"
                             FontSize="14"

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -35,6 +35,7 @@
                             Padding="16,0" />
                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
                             Command="{Binding RunDecompileCommand}"
+                            Classes="primary-action"
                             MinWidth="120"
                             Height="38"
                             FontSize="14"

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -209,7 +209,7 @@
                                         <TextBox Text="{Binding SelectedApkPath}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsApkPathWatermark]}" />
                                         <WrapPanel>
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}" Command="{Binding BrowseApkCommand}" MinWidth="90" Margin="0,0,8,4" />
-                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApk]}" Command="{Binding InstallApkCommand}" MinWidth="100" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsInstallApk]}" Command="{Binding InstallApkCommand}" Classes="primary-action" MinWidth="100" Margin="0,0,8,4" />
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsDetectPackage]}" Command="{Binding DetectPackageCommand}" MinWidth="120" Margin="0,0,8,4" />
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClearApkSelection]}" Command="{Binding ClearApkCommand}" Margin="0,0,8,4" />
                                         </WrapPanel>
@@ -244,8 +244,8 @@
                                         </StackPanel>
                                     </Grid>
                                     <WrapPanel>
-                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchApp]}" Command="{Binding LaunchAppCommand}" Margin="0,0,8,4" />
-                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchActivity]}" Command="{Binding LaunchActivityCommand}" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchApp]}" Command="{Binding LaunchAppCommand}" Classes="primary-action" Margin="0,0,8,4" />
+                                        <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLaunchActivity]}" Command="{Binding LaunchActivityCommand}" Classes="primary-action" Margin="0,0,8,4" />
                                         <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCurrentActivity]}" Command="{Binding CurrentActivityCommand}" Margin="0,0,8,4" />
                                         <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}" Command="{Binding ClearPackageCommand}" Margin="0,0,8,4" />
                                     </WrapPanel>
@@ -284,7 +284,7 @@
                                                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsPackageUtilitiesHelp]}" Classes="helper-text" TextWrapping="Wrap" />
                                                 <WrapPanel>
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsOpenAppSettings]}" Command="{Binding OpenAppSettingsCommand}" Margin="0,0,8,4" />
-                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCopyApkFromDevice]}" Command="{Binding CopyApkFromDeviceCommand}" Margin="0,0,8,4" />
+                                                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCopyApkFromDevice]}" Command="{Binding CopyApkFromDeviceCommand}" Classes="primary-action" Margin="0,0,8,4" />
                                                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsLogcatForPackage]}" Command="{Binding RunLogcatForPackagePresetCommand}" Margin="0,0,8,4" />
                                                 </WrapPanel>
                                             </StackPanel>
@@ -324,16 +324,18 @@
                                         <Button Grid.Column="2"
                                                 Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunPreset]}"
                                                 Command="{Binding RunSelectedPresetCommand}"
+                                                Classes="primary-action"
                                                 MinWidth="110" />
                                     </Grid>
                                     <StackPanel Spacing="6">
                                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommand]}" Opacity="0.8" />
                                         <TextBox Text="{Binding CommandText}" Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandWatermark]}" />
                                         <WrapPanel>
-                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunShell]}" Command="{Binding RunShellCommand}" MinWidth="110" Margin="0,0,8,4" />
+                                            <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunShell]}" Command="{Binding RunShellCommand}" Classes="primary-action" MinWidth="110" Margin="0,0,8,4" />
                                             <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbArgs]}"
                                                     ToolTip.Tip="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsRunAdbArgsTip]}"
                                                     Command="{Binding RunAdbCommand}"
+                                                    Classes="primary-action"
                                                     MinWidth="100"
                                                     Margin="0,0,8,4" />
                                         </WrapPanel>

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -39,6 +39,7 @@
                             Padding="16,0" />
                     <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
                             Command="{Binding RunPatchCommand}"
+                            Classes="primary-action"
                             MinWidth="120"
                             Height="38"
                             FontSize="14"


### PR DESCRIPTION
### Motivation
- Introduce a consistent primary action appearance for the UI by reusing the existing cyber theme resources to make main run/execute buttons visually distinct.
- Apply the new style only to primary actions so non-primary and destructive buttons retain their current look and behavior.

### Description
- Add a global `Button.primary-action` style (normal, `:pointerover`, and `:pressed` states) to `App.axaml` that uses `CyberAccentBrush`, `CyberAccentSecondaryBrush`, `CyberConsoleForegroundBrush`, and `CyberButtonPressedBrush`.
- Apply `Classes="primary-action"` to the main run buttons bound to `RunDecompileCommand`, `RunBuildCommand`, `RunPatchCommand`, and `RunAnalysisCommand` in their respective view files.
- Apply `Classes="primary-action"` to key Device Tools execute buttons such as `InstallApkCommand`, `LaunchAppCommand`, `LaunchActivityCommand`, `CopyApkFromDeviceCommand`, `RunSelectedPresetCommand`, `RunShellCommand`, and `RunAdbCommand` in `DeviceToolsView.axaml`.
- Preserve all existing `Command` bindings, enabled states, margins, sizes, and other properties unchanged.

### Testing
- Parsed updated AXAML files with `python3` + `xml.etree.ElementTree` and all modified files parsed successfully.
- Ran `git diff --check` which reported no whitespace or diff issues.
- Attempted `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` but `dotnet` is not installed in the environment so the build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2858ca1c832288e2bf5d0c3c7170)