### PR TITLE
Add section labels to APK workflow views

### DIFF
--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -52,12 +52,20 @@
 
         <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
             <StackPanel Spacing="8">
+                <TextBlock Text="OPTIONS"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
                           IsChecked="{Binding UseAapt2}" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SignApk]}"
                           IsChecked="{Binding SignApk}" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="OUTPUT"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApkName]}"
                            FontWeight="SemiBold" />
                 <TextBox Text="{Binding OutputApkName}"

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -54,6 +54,10 @@
 
         <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
             <StackPanel Spacing="8">
+                <TextBlock Text="OPTIONS"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
                           IsChecked="{Binding DecodeResources}" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
@@ -64,6 +68,10 @@
                           IsChecked="{Binding ExtractToApkFolder}" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="OUTPUT"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[OutputFolder]}"
                            FontWeight="SemiBold" />
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -56,8 +56,17 @@
 
         <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
             <StackPanel Spacing="8">
+                <TextBlock Text="SIGNING"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
                           IsChecked="{Binding SignApk}" />
+                <TextBlock Text="INJECTION"
+                           Foreground="{DynamicResource CyberHelperTextBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold"
+                           Margin="0,8,0,0" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
                           IsChecked="{Binding InjectLibForAllArchitectures}" />
                 <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
@@ -101,6 +110,10 @@
                            IsVisible="{Binding IsSampleInjectionProfileSelected}" />
             </StackPanel>
             <StackPanel Grid.Column="1" Spacing="8">
+                <TextBlock Text="OUTPUT"
+                           Foreground="{DynamicResource CyberAccentBrush}"
+                           FontSize="11"
+                           FontWeight="SemiBold" />
                 <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputLabel]}"
                            FontWeight="SemiBold" />
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">


### PR DESCRIPTION
### Motivation
- Improve visual grouping in the Decompile, Build, and Patch workflow UIs by adding small uppercase/semi-bold labels above existing option and output groups while reusing existing theme resources.

### Description
- Added presentational `TextBlock` labels ("OPTIONS", "OUTPUT", "SIGNING", "INJECTION") to `src/PulseAPK.Avalonia/Views/DecompileView.axaml`, `src/PulseAPK.Avalonia/Views/BuildView.axaml`, and `src/PulseAPK.Avalonia/Views/PatchView.axaml` and styled them with the existing `CyberAccentBrush` and `CyberHelperTextBrush` resources without modifying localized strings or existing bindings.

### Testing
- Ran `git diff --check` and it reported no issues; attempted `dotnet build` but it was not executed because the `dotnet` CLI is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f29d284a48322ab9a8e07a6e8c7e7)