### PR TITLE
Add reusable console header styling

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -117,6 +117,38 @@
             <Setter Property="Padding" Value="14" />
         </Style>
 
+        <Style Selector="Border.console-header-dot">
+            <Setter Property="Width" Value="8" />
+            <Setter Property="Height" Value="8" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Background" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+        </Style>
+
+        <Style Selector="Border.console-divider">
+            <Setter Property="Height" Value="1" />
+            <Setter Property="Background" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="Opacity" Value="0.65" />
+        </Style>
+
+        <Style Selector="Border.live-log-pill">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Padding" Value="8,3" />
+        </Style>
+
+        <Style Selector="TextBlock.console-title">
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+
+        <Style Selector="TextBlock.live-log-pill-text">
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+            <Setter Property="FontSize" Value="10" />
+            <Setter Property="FontWeight" Value="SemiBold" />
+        </Style>
+
         <Style Selector="Border.neon-pill">
             <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -52,10 +52,24 @@
 
         <Border Grid.Row="2"
                 Classes="console-card">
-            <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
-                           FontWeight="SemiBold" />
-                <TextBox Grid.Row="1"
+            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <Border Classes="console-header-dot"
+                            VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                               Classes="console-title"
+                               VerticalAlignment="Center" />
+                    <Border Grid.Column="2"
+                            Classes="live-log-pill"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="LIVE LOG"
+                                   Classes="live-log-pill-text" />
+                    </Border>
+                </Grid>
+                <Border Grid.Row="1"
+                        Classes="console-divider" />
+                <TextBox Grid.Row="2"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"
                          AcceptsReturn="True"

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -84,10 +84,24 @@
 
         <Border Grid.Row="3"
                 Classes="console-card">
-            <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
-                           FontWeight="SemiBold" />
-                <TextBox Grid.Row="1"
+            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <Border Classes="console-header-dot"
+                            VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                               Classes="console-title"
+                               VerticalAlignment="Center" />
+                    <Border Grid.Column="2"
+                            Classes="live-log-pill"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="LIVE LOG"
+                                   Classes="live-log-pill-text" />
+                    </Border>
+                </Grid>
+                <Border Grid.Row="1"
+                        Classes="console-divider" />
+                <TextBox Grid.Row="2"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"
                          AcceptsReturn="True"

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -90,10 +90,24 @@
 
         <Border Grid.Row="3"
                 Classes="console-card">
-            <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
-                           FontWeight="SemiBold" />
-                <TextBox Grid.Row="1"
+            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <Border Classes="console-header-dot"
+                            VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                               Classes="console-title"
+                               VerticalAlignment="Center" />
+                    <Border Grid.Column="2"
+                            Classes="live-log-pill"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="LIVE LOG"
+                                   Classes="live-log-pill-text" />
+                    </Border>
+                </Grid>
+                <Border Grid.Row="1"
+                        Classes="console-divider" />
+                <TextBox Grid.Row="2"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"
                          AcceptsReturn="True"

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -372,25 +372,36 @@
 
         <Border Grid.Row="1"
                 Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
-                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
-                    <TextBlock Text="TERMINAL OUTPUT"
+            <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="8">
+                    <Border Classes="console-header-dot"
+                            VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1"
+                               Text="TERMINAL OUTPUT"
                                FontFamily="Consolas, Menlo, monospace"
-                               FontWeight="SemiBold"
-                               Foreground="{DynamicResource CyberAccentBrush}"
+                               Classes="console-title"
                                VerticalAlignment="Center" />
-                    <Button Grid.Column="1"
+                    <Border Grid.Column="2"
+                            Classes="live-log-pill"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="LIVE LOG"
+                                   Classes="live-log-pill-text" />
+                    </Border>
+                    <Button Grid.Column="3"
                             Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsClear]}"
                             Command="{Binding ClearConsoleCommand}"
                             MinWidth="80"
                             HorizontalAlignment="Right" />
                 </Grid>
 
-                <TextBlock Grid.Row="1"
+                <Border Grid.Row="1"
+                        Classes="console-divider" />
+
+                <TextBlock Grid.Row="2"
                            Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutputHelp]}"
                            Classes="helper-text" />
 
-                <TextBox Grid.Row="2"
+                <TextBox Grid.Row="3"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"
                          AcceptsReturn="True"

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -134,10 +134,24 @@
 
         <Border Grid.Row="3"
                 Classes="console-card">
-            <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
-                           FontWeight="SemiBold" />
-                <TextBox Grid.Row="1"
+            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <Border Classes="console-header-dot"
+                            VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
+                               Classes="console-title"
+                               VerticalAlignment="Center" />
+                    <Border Grid.Column="2"
+                            Classes="live-log-pill"
+                            VerticalAlignment="Center">
+                        <TextBlock Text="LIVE LOG"
+                                   Classes="live-log-pill-text" />
+                    </Border>
+                </Grid>
+                <Border Grid.Row="1"
+                        Classes="console-divider" />
+                <TextBox Grid.Row="2"
                          Text="{Binding ConsoleLog}"
                          IsReadOnly="True"
                          AcceptsReturn="True"


### PR DESCRIPTION
### Motivation
- Introduce a reusable visual pattern for console headers across multiple views to improve UI consistency and surface live logging state. 
- Keep existing console `TextBox` bindings and behavior (read-only, wrapping, scrolling) unchanged while adding an accented header treatment.

### Description
- Added shared styles in `src/PulseAPK.Avalonia/App.axaml` for the console header: `Border.console-header-dot`, `Border.console-divider`, `Border.live-log-pill`, `TextBlock.console-title`, and `TextBlock.live-log-pill-text`.
- Updated console sections in `src/PulseAPK.Avalonia/Views/DecompileView.axaml`, `BuildView.axaml`, `PatchView.axaml`, `AnalyserView.axaml`, and `DeviceToolsView.axaml` to use a three-column header layout (status dot, title, live-log pill) followed by a thin accent divider and the existing console `TextBox` content area.
- Preserved all `TextBox Text="{Binding ConsoleLog}"`, `IsReadOnly`, `AcceptsReturn`, `TextWrapping`, and scrolling/min/max height settings in each modified view; the Device Tools view retains its clear button alongside the new header pattern.

### Testing
- Ran an XML parse check against modified XAML files using `python3` with `xml.etree.ElementTree.parse`, and parsing succeeded for all updated files. 
- Ran `git diff --check` to verify no whitespace or merge issues, and it returned clean. 
- Attempted `dotnet build PulseAPK.sln` but the `dotnet` SDK was not available in the environment so a full build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f2ac73afc832295762df6c56effc3)