### PR TITLE
Add dismissible "Support Work" section to left sidebar

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -81,7 +81,8 @@
     <Grid ColumnDefinitions="240, *">
         <!-- Sidebar -->
         <Border Grid.Column="0" Background="{DynamicResource CyberSidebarBrush}" Padding="16">
-            <StackPanel Spacing="10">
+            <Grid RowDefinitions="Auto,*,Auto">
+            <StackPanel Grid.Row="0" Spacing="10">
                 <StackPanel Margin="0,0,0,8">
                     <TextBlock Text="PulseAPK"
                                FontSize="30"
@@ -166,6 +167,44 @@
                     </StackPanel>
                 </Button>
             </StackPanel>
+
+            <Border Grid.Row="2"
+                    IsVisible="{Binding IsSupportWorkVisible}"
+                    Background="#33141B2E"
+                    BorderBrush="{DynamicResource CyberAccentBrush}"
+                    BorderThickness="1"
+                    CornerRadius="10"
+                    Padding="10"
+                    Margin="0,16,0,0">
+                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto">
+                    <Button Grid.Row="0"
+                            Grid.Column="1"
+                            Command="{Binding DismissSupportWorkCommand}"
+                            Content="X"
+                            ToolTip.Tip="Close"
+                            Width="28"
+                            Height="28"
+                            Padding="0"
+                            HorizontalContentAlignment="Center"
+                            VerticalContentAlignment="Center"
+                            Background="Transparent"
+                            BorderBrush="{DynamicResource CyberAccentBrush}"
+                            Foreground="{DynamicResource CyberAccentBrush}"/>
+                    <Button Grid.Row="1"
+                            Grid.ColumnSpan="2"
+                            Command="{Binding OpenSupportWorkCommand}"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Center"
+                            Margin="0,8,0,0"
+                            Padding="10,8"
+                            Background="{DynamicResource CyberAccentMutedBrush}"
+                            BorderBrush="{DynamicResource CyberAccentSecondaryBrush}"
+                            Foreground="{DynamicResource CyberAccentSecondaryBrush}">
+                        <TextBlock Text="Support Work" FontWeight="SemiBold"/>
+                    </Button>
+                </Grid>
+            </Border>
+            </Grid>
         </Border>
 
         <!-- Content -->

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -11,6 +11,7 @@ namespace PulseAPK.Core.Services
         public string AdbPath { get; set; } = string.Empty;
         public string SelectedLanguage { get; set; } = "en-US";
         public string ThemeMode { get; set; } = "dark_mode";
+        public bool IsSupportWorkDismissed { get; set; }
     }
 
     public interface ISettingsService

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -11,7 +11,11 @@ namespace PulseAPK.Core.ViewModels;
 public partial class MainViewModel : ObservableObject
 {
     private readonly IServiceProvider _serviceProvider;
+    private const string SupportWorkUrl = "https://yarygintech.com/support-work/";
+
     private readonly LocalizationService _localizationService;
+    private readonly ISettingsService _settingsService;
+    private readonly ISystemService _systemService;
 
     [ObservableProperty]
     private object _currentView = null!;
@@ -30,6 +34,9 @@ public partial class MainViewModel : ObservableObject
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
 
+    [ObservableProperty]
+    private bool _isSupportWorkVisible;
+
     public bool IsDecompileSelected => SelectedMenu == "Decompile";
     public bool IsBuildSelected => SelectedMenu == "Build";
     public bool IsPatchSelected => SelectedMenu == "Patch";
@@ -46,10 +53,17 @@ public partial class MainViewModel : ObservableObject
     public bool IsSettingsEnabled => FeatureFlags.Settings;
     public bool IsAboutEnabled => FeatureFlags.About;
 
-    public MainViewModel(IServiceProvider serviceProvider, LocalizationService localizationService)
+    public MainViewModel(
+        IServiceProvider serviceProvider,
+        LocalizationService localizationService,
+        ISettingsService settingsService,
+        ISystemService systemService)
     {
         _serviceProvider = serviceProvider;
         _localizationService = localizationService;
+        _settingsService = settingsService;
+        _systemService = systemService;
+        IsSupportWorkVisible = !_settingsService.Settings.IsSupportWorkDismissed;
         WindowTitle = _localizationService["AppTitle"];
         _localizationService.PropertyChanged += HandleLocalizationChanged;
         SetInitialView();
@@ -111,6 +125,20 @@ public partial class MainViewModel : ObservableObject
         if (!CanNavigateToAbout()) return;
         SetCurrentView(Resolve<AboutViewModel>());
         SelectedMenu = "About";
+    }
+
+    [RelayCommand]
+    private void OpenSupportWork()
+    {
+        _systemService.OpenUrl(SupportWorkUrl);
+    }
+
+    [RelayCommand]
+    private void DismissSupportWork()
+    {
+        IsSupportWorkVisible = false;
+        _settingsService.Settings.IsSupportWorkDismissed = true;
+        _settingsService.Save();
     }
 
     partial void OnSelectedMenuChanged(string value)


### PR DESCRIPTION
### Motivation
- Provide an always-visible, low-profile way for users to support development from the left sidebar until they choose to dismiss it.
- Persist the dismissal so the UI does not re-show the prompt after a user closes it.

### Description
- Add a bottom sidebar block in `src/PulseAPK.Avalonia/MainWindow.axaml` that displays a close (`X`) button and a `Support Work` link button. 
- Wire the `Support Work` button to open `https://yarygintech.com/support-work/` via the `ISystemService.OpenUrl` call implemented in `MainViewModel` (`OpenSupportWork` command). 
- Add a dismiss action (`DismissSupportWork` command) that hides the block immediately and sets `AppSettings.IsSupportWorkDismissed` to true, persisting via `ISettingsService.Save()`; new setting added in `src/PulseAPK.Core/Services/SettingsService.cs`.
- Inject `ISettingsService` and `ISystemService` into `MainViewModel` and expose `IsSupportWorkVisible` to control the UI visibility based on the persisted flag.

### Testing
- Ran `git diff --check`, which completed without issues.
- Attempted `dotnet build --no-restore` in this environment but it was not run/failed because the .NET SDK is not available here (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f33e0891c83229c61ef1c38a60592)