### PR TITLE
Suppress Linux launcher GTK warnings

### DIFF
--- a/src/PulseAPK.Core/Services/SystemService.cs
+++ b/src/PulseAPK.Core/Services/SystemService.cs
@@ -25,20 +25,52 @@ public class SystemService : ISystemService
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Process.Start("explorer.exe", path);
+                StartDetached("explorer.exe", path);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                Process.Start("xdg-open", path);
+                StartDetached("xdg-open", path, suppressStandardError: true);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                Process.Start("open", path);
+                StartDetached("open", path);
             }
         }
         catch (Exception ex)
         {
             Debug.WriteLine($"Failed to open path '{path}': {ex.Message}");
         }
+    }
+
+    private static void StartDetached(string fileName, string argument, bool suppressStandardError = false)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        startInfo.ArgumentList.Add(argument);
+
+        if (suppressStandardError)
+        {
+            startInfo.RedirectStandardError = true;
+        }
+
+        var process = Process.Start(startInfo);
+        if (process is null)
+            return;
+
+        if (!suppressStandardError)
+        {
+            process.Dispose();
+            return;
+        }
+
+        process.EnableRaisingEvents = true;
+        process.ErrorDataReceived += static (_, _) => { };
+        process.Exited += static (sender, _) => ((Process)sender!).Dispose();
+        process.BeginErrorReadLine();
     }
 }


### PR DESCRIPTION
### Motivation
- Launching folders/URLs on Linux via `xdg-open` can spawn helpers (e.g. `exo-open`, `xfce4-mime-helper`, browsers) that inherit the AppImage stderr and print GTK theme parsing warnings like `-gtk-icon-size` into the terminal, which is noisy and not actionable for the app.

### Description
- Route platform opener calls through a shared helper `StartDetached` instead of calling `Process.Start` directly from `OpenPath` in `src/PulseAPK.Core/Services/SystemService.cs`.
- Use `ProcessStartInfo` with `ArgumentList`, `UseShellExecute = false`, and `CreateNoWindow = true` so arguments are passed safely without shell parsing.
- For Linux `xdg-open` launches set `RedirectStandardError = true` and drain `StandardError` with `BeginErrorReadLine()` and no-op handlers to suppress GTK theme parser warnings from propagated child processes.
- Ensure processes are disposed correctly when not draining stderr and dispose asynchronously when draining finishes to avoid leaking handles.

### Testing
- Ran `git diff --check` to validate the workspace and it succeeded.
- Attempted `dotnet test PulseAPK.sln` but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f355c1cc08322a8fbf753dac6d8b2)