### PR TITLE
Make terminal output foldable across screens

### DIFF
--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -50,9 +50,9 @@
             </Grid>
         </Border>
 
-        <Border Grid.Row="2"
-                Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+        <Expander Grid.Row="2"
+                  IsExpanded="False">
+            <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
                             VerticalAlignment="Center" />
@@ -67,18 +67,22 @@
                                    Classes="live-log-pill-text" />
                     </Border>
                 </Grid>
-                <Border Grid.Row="1"
-                        Classes="console-divider" />
-                <TextBox Grid.Row="2"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         Classes="terminal-output"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         VerticalAlignment="Stretch" />
-            </Grid>
-        </Border>
+            </Expander.Header>
+            <Border Classes="console-card compact">
+                <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                    <Border Classes="console-divider" />
+                    <TextBox Grid.Row="1"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Classes="terminal-output"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="180"
+                             MaxHeight="320" />
+                </Grid>
+            </Border>
+        </Expander>
 
         <Button Grid.Row="3"
                 Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SaveReport]}"

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -82,9 +82,9 @@
             </StackPanel>
         </Grid>
 
-        <Border Grid.Row="3"
-                Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+        <Expander Grid.Row="3"
+                  IsExpanded="False">
+            <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
                             VerticalAlignment="Center" />
@@ -99,17 +99,21 @@
                                    Classes="live-log-pill-text" />
                     </Border>
                 </Grid>
-                <Border Grid.Row="1"
-                        Classes="console-divider" />
-                <TextBox Grid.Row="2"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         Classes="terminal-output"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         VerticalAlignment="Stretch" />
-            </Grid>
-        </Border>
+            </Expander.Header>
+            <Border Classes="console-card compact">
+                <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                    <Border Classes="console-divider" />
+                    <TextBox Grid.Row="1"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Classes="terminal-output"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="180"
+                             MaxHeight="320" />
+                </Grid>
+            </Border>
+        </Expander>
     </Grid>
 </UserControl>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -88,9 +88,9 @@
             </StackPanel>
         </Grid>
 
-        <Border Grid.Row="3"
-                Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+        <Expander Grid.Row="3"
+                  IsExpanded="False">
+            <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
                             VerticalAlignment="Center" />
@@ -105,17 +105,21 @@
                                    Classes="live-log-pill-text" />
                     </Border>
                 </Grid>
-                <Border Grid.Row="1"
-                        Classes="console-divider" />
-                <TextBox Grid.Row="2"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         Classes="terminal-output"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         VerticalAlignment="Stretch" />
-            </Grid>
-        </Border>
+            </Expander.Header>
+            <Border Classes="console-card compact">
+                <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                    <Border Classes="console-divider" />
+                    <TextBox Grid.Row="1"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Classes="terminal-output"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="180"
+                             MaxHeight="320" />
+                </Grid>
+            </Border>
+        </Expander>
     </Grid>
 </UserControl>

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -370,15 +370,14 @@
             </StackPanel>
         </ScrollViewer>
 
-        <Border Grid.Row="1"
-                Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="8">
+        <Expander Grid.Row="1"
+                  IsExpanded="False">
+            <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
                             VerticalAlignment="Center" />
                     <TextBlock Grid.Column="1"
-                               Text="TERMINAL OUTPUT"
-                               FontFamily="Consolas, Menlo, monospace"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ConsoleLog]}"
                                Classes="console-title"
                                VerticalAlignment="Center" />
                     <Border Grid.Column="2"
@@ -393,24 +392,26 @@
                             MinWidth="80"
                             HorizontalAlignment="Right" />
                 </Grid>
+            </Expander.Header>
+            <Border Classes="console-card compact">
+                <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+                    <Border Classes="console-divider" />
 
-                <Border Grid.Row="1"
-                        Classes="console-divider" />
+                    <TextBlock Grid.Row="1"
+                               Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutputHelp]}"
+                               Classes="helper-text" />
 
-                <TextBlock Grid.Row="2"
-                           Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DeviceToolsCommandOutputHelp]}"
-                           Classes="helper-text" />
-
-                <TextBox Grid.Row="3"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         Classes="terminal-output"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         MinHeight="180"
-                         MaxHeight="280" />
-            </Grid>
-        </Border>
+                    <TextBox Grid.Row="2"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Classes="terminal-output"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="180"
+                             MaxHeight="280" />
+                </Grid>
+            </Border>
+        </Expander>
     </Grid>
 </UserControl>

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -132,9 +132,9 @@
             </StackPanel>
         </Grid>
 
-        <Border Grid.Row="3"
-                Classes="console-card">
-            <Grid RowDefinitions="Auto,Auto,*" RowSpacing="8">
+        <Expander Grid.Row="3"
+                  IsExpanded="False">
+            <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
                             VerticalAlignment="Center" />
@@ -149,17 +149,21 @@
                                    Classes="live-log-pill-text" />
                     </Border>
                 </Grid>
-                <Border Grid.Row="1"
-                        Classes="console-divider" />
-                <TextBox Grid.Row="2"
-                         Text="{Binding ConsoleLog}"
-                         IsReadOnly="True"
-                         AcceptsReturn="True"
-                         TextWrapping="Wrap"
-                         Classes="terminal-output"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         VerticalAlignment="Stretch" />
-            </Grid>
-        </Border>
+            </Expander.Header>
+            <Border Classes="console-card compact">
+                <Grid RowDefinitions="Auto,*" RowSpacing="8">
+                    <Border Classes="console-divider" />
+                    <TextBox Grid.Row="1"
+                             Text="{Binding ConsoleLog}"
+                             IsReadOnly="True"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             Classes="terminal-output"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                             MinHeight="180"
+                             MaxHeight="320" />
+                </Grid>
+            </Border>
+        </Expander>
     </Grid>
 </UserControl>

--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -302,7 +302,7 @@
     <value>اسم APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>سجل وحدة التحكم</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>سيتم عرض المسار بعد اختيار ملف APK.</value>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -302,7 +302,7 @@
     <value>APK-Name</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Konsolenprotokoll</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>Der Pfad wird angezeigt, nachdem eine APK-Datei ausgewählt wurde.</value>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -302,7 +302,7 @@
     <value>Nombre del APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Registro de consola</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>La ruta se mostrará después de seleccionar un archivo APK.</value>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -302,7 +302,7 @@
     <value>Nom de l'APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Journal de console</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>Le chemin s'affichera après avoir choisi un fichier APK.</value>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -302,7 +302,7 @@
     <value>Nome do APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Registro do console</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>O caminho será exibido após escolher um arquivo APK.</value>

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -302,7 +302,7 @@
     <value>APK Name</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Console log</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>The path will be displayed after picking an APK file.</value>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -302,7 +302,7 @@
     <value>Имя APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Консольный журнал</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>Путь будет отображен после выбора APK-файла.</value>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -302,7 +302,7 @@
     <value>Назва APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Журнал консолі</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>Шлях буде відображено після вибору APK-файлу.</value>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -302,7 +302,7 @@
     <value>APK 名称</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>控制台日志</value>
+    <value>Terminal</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>选择 APK 文件后将显示路径。</value>


### PR DESCRIPTION
### Motivation
- The console panel consumed too much vertical space in non-maximized windows and needed to be collapsible to improve layout density.
- The label `Console log` was considered dated and should be unified to a clearer name like `Terminal` across UIs.
- The foldable terminal behavior should be applied consistently across screens without changing existing log bindings or behavior.

### Description
- Replaced fixed `Border`-based console panels with collapsed-by-default `Expander` sections on Patch, Decompile, Build, Analyser, and Device Tools views so terminal output only expands when needed.
- Preserved existing `ConsoleLog` bindings and live-log UI elements (including the `LIVE LOG` pill) so runtime behavior remains unchanged when expanded.
- Kept Device Tools clear action and help text intact inside the foldable terminal header/content so existing commands continue to work as before.
- Updated localized resource files so the `ConsoleLog` resource value now reads `Terminal` in the main and several localized `Resources*.resx` files for consistent terminology.

### Testing
- Ran `git diff --check` to validate formatting and basic diffs which passed.
- Attempted to run `dotnet test PulseAPK.sln` but `dotnet` is not available in this environment so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f36edfd6483229fdbb8e1b19d0e81)