### PR TITLE
Improve console/log expander layout and main window sizing

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -10,7 +10,10 @@
         x:DataType="vm:MainViewModel"
         Title="{Binding WindowTitle}"
         Icon="/Assets/CyberUnpack.ico"
-        Height="700">
+        Width="1280"
+        Height="800"
+        MinWidth="1100"
+        MinHeight="760">
 
     <Window.Styles>
         <Style Selector="Button.nav-button">
@@ -209,7 +212,9 @@
 
         <!-- Content -->
         <Border Grid.Column="1" Background="{DynamicResource MainBackgroundBrush}" Padding="20">
-            <ContentControl Content="{Binding CurrentView}"/>
+            <ContentControl Content="{Binding CurrentView}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"/>
         </Border>
     </Grid>
 </Window>

--- a/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AnalyserView.axaml
@@ -51,6 +51,8 @@
         </Border>
 
         <Expander Grid.Row="2"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
                   IsExpanded="False">
             <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -68,7 +70,9 @@
                     </Border>
                 </Grid>
             </Expander.Header>
-            <Border Classes="console-card compact">
+            <Border Classes="console-card compact"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
                 <Grid RowDefinitions="Auto,*" RowSpacing="8">
                     <Border Classes="console-divider" />
                     <TextBox Grid.Row="1"
@@ -76,10 +80,12 @@
                              IsReadOnly="True"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch"
                              Classes="terminal-output"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="180"
-                             MaxHeight="320" />
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             MinHeight="260" />
                 </Grid>
             </Border>
         </Expander>

--- a/src/PulseAPK.Avalonia/Views/BuildView.axaml
+++ b/src/PulseAPK.Avalonia/Views/BuildView.axaml
@@ -83,6 +83,8 @@
         </Grid>
 
         <Expander Grid.Row="3"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
                   IsExpanded="False">
             <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -100,7 +102,9 @@
                     </Border>
                 </Grid>
             </Expander.Header>
-            <Border Classes="console-card compact">
+            <Border Classes="console-card compact"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
                 <Grid RowDefinitions="Auto,*" RowSpacing="8">
                     <Border Classes="console-divider" />
                     <TextBox Grid.Row="1"
@@ -108,10 +112,12 @@
                              IsReadOnly="True"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch"
                              Classes="terminal-output"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="180"
-                             MaxHeight="320" />
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             MinHeight="260" />
                 </Grid>
             </Border>
         </Expander>

--- a/src/PulseAPK.Avalonia/Views/DecompileView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DecompileView.axaml
@@ -89,6 +89,8 @@
         </Grid>
 
         <Expander Grid.Row="3"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
                   IsExpanded="False">
             <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -106,7 +108,9 @@
                     </Border>
                 </Grid>
             </Expander.Header>
-            <Border Classes="console-card compact">
+            <Border Classes="console-card compact"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
                 <Grid RowDefinitions="Auto,*" RowSpacing="8">
                     <Border Classes="console-divider" />
                     <TextBox Grid.Row="1"
@@ -114,10 +118,12 @@
                              IsReadOnly="True"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch"
                              Classes="terminal-output"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="180"
-                             MaxHeight="320" />
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             MinHeight="260" />
                 </Grid>
             </Border>
         </Expander>

--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -133,6 +133,8 @@
         </Grid>
 
         <Expander Grid.Row="3"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch"
                   IsExpanded="False">
             <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
@@ -150,7 +152,9 @@
                     </Border>
                 </Grid>
             </Expander.Header>
-            <Border Classes="console-card compact">
+            <Border Classes="console-card compact"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch">
                 <Grid RowDefinitions="Auto,*" RowSpacing="8">
                     <Border Classes="console-divider" />
                     <TextBox Grid.Row="1"
@@ -158,10 +162,12 @@
                              IsReadOnly="True"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
+                             HorizontalAlignment="Stretch"
+                             VerticalAlignment="Stretch"
                              Classes="terminal-output"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="180"
-                             MaxHeight="320" />
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                             MinHeight="260" />
                 </Grid>
             </Border>
         </Expander>


### PR DESCRIPTION
### Motivation
- Console/terminal output areas were constrained by fixed sizes and container alignment, causing expanded logs to appear cramped or clipped instead of using available space.
- The main content area did not fully stretch to the available window, preventing the console from occupying the horizontal space when expanded.

### Description
- Increased default and minimum window dimensions by updating `src/PulseAPK.Avalonia/MainWindow.axaml` to set `Width`, `Height`, `MinWidth`, and `MinHeight` and made the main `ContentControl` stretch with `HorizontalAlignment`/`VerticalAlignment` set to `Stretch`.
- Updated console `Expander` and surrounding `Border` in `src/PulseAPK.Avalonia/Views/PatchView.axaml`, `BuildView.axaml`, `DecompileView.axaml`, and `AnalyserView.axaml` to use `HorizontalAlignment="Stretch"` and `VerticalAlignment="Stretch"` so the card fills available space.
- Adjusted terminal `TextBox` in those views to add `HorizontalAlignment="Stretch"`, `VerticalAlignment="Stretch"`, `ScrollViewer.HorizontalScrollBarVisibility="Auto"`, and increased `MinHeight` from `180` to `260`, removing the previous `MaxHeight` cap so expanded logs can grow vertically and scroll horizontally.

### Testing
- Ran `git diff --check` which reported no whitespace errors and passed.
- Attempted to run `dotnet test` but it could not be executed in this environment because the `dotnet` SDK is not installed, so unit tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f38eb95988322b9f9bedc3f072b91)