### PR TITLE
Refine dark cyberpunk theme brushes

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -187,36 +187,36 @@
         <ResourceDictionary>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="CyberBackgroundBrush" Color="#090A18" />
-                    <SolidColorBrush x:Key="CyberSidebarBrush" Color="#0D1024" />
-                    <SolidColorBrush x:Key="CyberCardBrush" Color="#141B2E" />
-                    <SolidColorBrush x:Key="CyberCardBorderBrush" Color="#263B5E" />
-                    <SolidColorBrush x:Key="CyberAccentBrush" Color="#00E5FF" />
-                    <SolidColorBrush x:Key="CyberAccentSecondaryBrush" Color="#FF2BD6" />
-                    <SolidColorBrush x:Key="CyberWarningBrush" Color="#FF5A36" />
-                    <SolidColorBrush x:Key="CyberConsoleBackgroundBrush" Color="#050A12" />
+                    <SolidColorBrush x:Key="CyberBackgroundBrush" Color="#05070D" />
+                    <SolidColorBrush x:Key="CyberSidebarBrush" Color="#080B12" />
+                    <SolidColorBrush x:Key="CyberCardBrush" Color="#0C101A" />
+                    <SolidColorBrush x:Key="CyberCardBorderBrush" Color="#1C2A40" />
+                    <SolidColorBrush x:Key="CyberAccentBrush" Color="#00D9FF" />
+                    <SolidColorBrush x:Key="CyberAccentSecondaryBrush" Color="#7A2CFF" />
+                    <SolidColorBrush x:Key="CyberWarningBrush" Color="#FFB000" />
+                    <SolidColorBrush x:Key="CyberConsoleBackgroundBrush" Color="#03060B" />
                     <SolidColorBrush x:Key="CyberConsoleForegroundBrush" Color="#39FF88" />
-                    <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#102B3C" />
-                    <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#2B1234" />
-                    <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#3A0B4D" />
-                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#3A0B4D" />
-                    <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#FF2BD6" />
+                    <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#0A2636" />
+                    <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#122B3D" />
+                    <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#20104A" />
+                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#20104A" />
+                    <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#7A2CFF" />
                     <SolidColorBrush x:Key="CyberPrimaryButtonForegroundBrush" Color="#03111A" />
                     <SolidColorBrush x:Key="CyberPressedButtonForegroundBrush" Color="#FFFFFF" />
-                    <SolidColorBrush x:Key="CyberFocusBorderBrush" Color="#FFF27A" />
-                    <SolidColorBrush x:Key="CyberDisabledButtonBrush" Color="#071B2A" />
-                    <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#0E6A82" />
-                    <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#4FD8EA" />
-                    <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#8EA4C8" />
-                    <BoxShadows x:Key="CyberCardBoxShadow">0 10 28 0 #6600E5FF</BoxShadows>
-                    <BoxShadows x:Key="CyberConsoleCardBoxShadow">0 12 32 0 #8000E5FF</BoxShadows>
-                    <BoxShadows x:Key="CyberNeonPillBoxShadow">0 0 18 0 #66FF2BD6</BoxShadows>
+                    <SolidColorBrush x:Key="CyberFocusBorderBrush" Color="#FFB000" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBrush" Color="#0A111C" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#17485C" />
+                    <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#6FE7FF" />
+                    <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#91A3C2" />
+                    <BoxShadows x:Key="CyberCardBoxShadow">0 10 28 0 #5500D9FF</BoxShadows>
+                    <BoxShadows x:Key="CyberConsoleCardBoxShadow">0 12 32 0 #6600D9FF</BoxShadows>
+                    <BoxShadows x:Key="CyberNeonPillBoxShadow">0 0 18 0 #557A2CFF</BoxShadows>
 
-                    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#0D1024" />
-                    <SolidColorBrush x:Key="MainBackgroundBrush" Color="#090A18" />
-                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#141B2E" />
-                    <SolidColorBrush x:Key="CardBorderBrush" Color="#263B5E" />
-                    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#00E5FF" />
+                    <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#080B12" />
+                    <SolidColorBrush x:Key="MainBackgroundBrush" Color="#05070D" />
+                    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#0C101A" />
+                    <SolidColorBrush x:Key="CardBorderBrush" Color="#1C2A40" />
+                    <SolidColorBrush x:Key="ConsoleBorderBrush" Color="#00D9FF" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <SolidColorBrush x:Key="CyberBackgroundBrush" Color="#F7FAFF" />


### PR DESCRIPTION
### Motivation
- Refresh the dark theme palette to a near-black cyberpunk aesthetic with stronger contrast and colder cyan accents. 
- Replace broad pink/magenta surfaces with deep violet/electric purple accents and keep magenta/pink for very small highlights only. 
- Reserve amber/orange for warning and attention states. 
- Keep the light theme resources valid but prioritize dark-theme visual updates.

### Description
- Updated the dark `ResourceDictionary` in `src/PulseAPK.Avalonia/App.axaml` to use near-black backgrounds for `CyberBackgroundBrush`, `CyberSidebarBrush`, `CyberCardBrush`, and `CyberCardBorderBrush`. 
- Shifted the main accent to a slightly colder cyan by changing `CyberAccentBrush` to `#00D9FF` and replaced the bright pink secondary accent `CyberAccentSecondaryBrush` with electric purple `#7A2CFF`. 
- Reduced pink usage across hover/selected/pressed states by updating `CyberAccentMutedBrush`, `CyberAccentPressedBrush`, `CyberButtonPressedBrush`, `CyberSelectedBrush`, and `CyberSelectedBorderBrush` to darker/cooler purple and blue tones. 
- Aligned warning/focus and supporting brushes by setting `CyberWarningBrush` and `CyberFocusBorderBrush` to amber `#FFB000`, adjusted disabled/foreground/helper brushes, and updated box-shadow hexes to match the new cyan/purple glow palette.

### Testing
- Parsed the modified XAML with `python3 - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('src/PulseAPK.Avalonia/App.axaml')\nprint('App.axaml XML parsed successfully')\nPY` and the parse succeeded. 
- Attempted `dotnet build PulseAPK.sln` but the build was not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f88f5e95483228eb83622d53d6a56)