### PR TITLE
Update Avalonia hover styling

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -17,8 +17,9 @@
         </Style>
 
         <Style Selector="Button:pointerover">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="Background" Value="#111827" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="2" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 
@@ -37,9 +38,10 @@
         </Style>
 
         <Style Selector="Button.primary-action:pointerover">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentSecondaryBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
-            <Setter Property="Foreground" Value="{DynamicResource CyberPrimaryButtonForegroundBrush}" />
+            <Setter Property="Background" Value="#10131F" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 
         <Style Selector="Button.primary-action:pressed">

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -28,8 +28,9 @@
         </Style>
 
         <Style Selector="Button.nav-button:pointerover">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="Background" Value="#10131F" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="6,1.5,1.5,1.5" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -15,8 +15,9 @@
             <Setter Property="Foreground" Value="#FFB3C1" />
         </Style>
         <Style Selector="Button.destructive:pointerover">
-            <Setter Property="Background" Value="#6E0B1D" />
+            <Setter Property="Background" Value="#10131F" />
             <Setter Property="BorderBrush" Value="#FF5A36" />
+            <Setter Property="BorderThickness" Value="2" />
             <Setter Property="Foreground" Value="#FFFFFF" />
         </Style>
         <Style Selector="Button.destructive:pressed">
@@ -63,8 +64,10 @@
             <Setter Property="Padding" Value="16,8" />
         </Style>
         <Style Selector="ListBox.workflow-tabs ListBoxItem:pointerover">
-            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="Background" Value="#111827" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
         <Style Selector="ListBox.workflow-tabs ListBoxItem:selected">
             <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />


### PR DESCRIPTION
### Motivation

- Replace washed-out/gray hover backgrounds with darker, high-contrast hover treatments to avoid UI elements looking disabled or muted.
- Emphasize hover state using `BorderBrush`, `Foreground`, and slightly thicker left borders for navigation elements to improve discoverability.
- Keep navigation hover backgrounds dark and use cyan/violet accents for border/foreground to match the app theme.

### Description

- Updated global `Button:pointerover` to use a dark background `#111827`, set `BorderThickness` to `2`, and use `CyberAccentSecondaryBrush` for the foreground in `src/PulseAPK.Avalonia/App.axaml`.
- Updated `Button.primary-action:pointerover` to use `#10131F`, added `BorderThickness="2"`, and switch foreground to `CyberAccentSecondaryBrush` in `src/PulseAPK.Avalonia/App.axaml`.
- Updated navigation hover style `Button.nav-button:pointerover` to use `#10131F`, increase left border emphasis with `BorderThickness="6,1.5,1.5,1.5"`, and keep foreground as `CyberAccentSecondaryBrush` in `src/PulseAPK.Avalonia/MainWindow.axaml`.
- Updated view-local hover styles in `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml` by setting `Button.destructive:pointerover` to `#10131F` with `BorderThickness="2"`, and `ListBox.workflow-tabs ListBoxItem:pointerover` to `#111827` with `BorderThickness="2"` and `CyberAccentSecondaryBrush` for foreground.

### Testing

- Parsed updated AXAML files with Python XML parser using `xml.etree.ElementTree` which succeeded for `src/PulseAPK.Avalonia/App.axaml`, `src/PulseAPK.Avalonia/MainWindow.axaml`, and `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`.
- Ran `dotnet build --no-restore` but it could not be executed in this environment because `dotnet` is not installed (build not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f897b6f34832281f2bdf7f72aa5cc)