### PR TITLE
Refine active nav button styling

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -41,10 +41,11 @@
         </Style>
 
         <Style Selector="Button.nav-button.active">
-            <Setter Property="Background" Value="{DynamicResource CyberSelectedBrush}" />
+            <Setter Property="Background" Value="#11131D" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberSelectedBorderBrush}" />
-            <Setter Property="BorderThickness" Value="8,2,2,2" />
-            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="6,1,1,1" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Foreground" Value="#F4F7FF" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Opacity" Value="1" />
         </Style>
@@ -55,6 +56,10 @@
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
             <Setter Property="Width" Value="24" />
             <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+
+        <Style Selector="Button.nav-button.active TextBlock.nav-glyph">
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
         </Style>
     </Window.Styles>
 


### PR DESCRIPTION
### Motivation
- Reduce the pill-like appearance of the active sidebar button, keep a strong left border, and improve visual hierarchy between glyph and label for selected nav items.

### Description
- Updated `src/PulseAPK.Avalonia/MainWindow.axaml` `Button.nav-button.active` to use a dark background `#11131D`, reduced `CornerRadius` to `4`, and adjusted `BorderThickness` to `6,1,1,1` while keeping `FontWeight="SemiBold"` and setting the label `Foreground` to `#F4F7FF`.
- Kept the left border brush as the existing `{DynamicResource CyberSelectedBorderBrush}` to preserve a cyan/violet accent in-theme.
- Added a style `Button.nav-button.active TextBlock.nav-glyph` that sets the glyph `Foreground` to `{DynamicResource CyberAccentBrush}` so the glyph appears cyan while text is near-white.

### Testing
- Parsed the modified `MainWindow.axaml` with `python3` and `xml.etree.ElementTree` which succeeded and reported the file as valid XML.
- Attempted `dotnet build` but it was not run successfully because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8abe6b5483229f719a7f5e8a7695)