### PR TITLE
Make Support Work CTA compact and non-dismissible with startup pulse

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -62,6 +62,50 @@
         <Style Selector="Button.nav-button.active TextBlock.nav-glyph">
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
         </Style>
+
+        <Style Selector="Button.support-work-button">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="Padding" Value="8,5" />
+            <Style.Animations>
+                <Animation Duration="0:0:0.45"
+                           IterationCount="4">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+                        <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+                    </KeyFrame>
+                    <KeyFrame Cue="50%">
+                        <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
+                        <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+                        <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
+
+        <Style Selector="Button.support-work-button:pointerover">
+            <Setter Property="Background" Value="#10131F" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
+        </Style>
+
+        <Style Selector="Button.support-work-button:pressed">
+            <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
     </Window.Styles>
 
     <Window.DataTemplates>
@@ -183,36 +227,15 @@
                     Background="#33141B2E"
                     BorderBrush="{DynamicResource CyberAccentBrush}"
                     BorderThickness="1"
-                    CornerRadius="10"
-                    Padding="10"
-                    Margin="0,16,0,0">
-                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto">
-                    <Button Grid.Row="0"
-                            Grid.Column="1"
-                            Command="{Binding DismissSupportWorkCommand}"
-                            Content="X"
-                            ToolTip.Tip="Close"
-                            Width="28"
-                            Height="28"
-                            Padding="0"
-                            HorizontalContentAlignment="Center"
-                            VerticalContentAlignment="Center"
-                            Background="Transparent"
-                            BorderBrush="{DynamicResource CyberAccentBrush}"
-                            Foreground="{DynamicResource CyberAccentBrush}"/>
-                    <Button Grid.Row="1"
-                            Grid.ColumnSpan="2"
-                            Command="{Binding OpenSupportWorkCommand}"
-                            HorizontalAlignment="Stretch"
-                            HorizontalContentAlignment="Center"
-                            Margin="0,8,0,0"
-                            Padding="10,8"
-                            Background="{DynamicResource CyberAccentMutedBrush}"
-                            BorderBrush="{DynamicResource CyberAccentSecondaryBrush}"
-                            Foreground="{DynamicResource CyberAccentSecondaryBrush}">
-                        <TextBlock Text="Support Work" FontWeight="SemiBold"/>
-                    </Button>
-                </Grid>
+                    CornerRadius="8"
+                    Padding="4"
+                    Margin="0,10,0,0">
+                <Button Classes="support-work-button"
+                        Command="{Binding OpenSupportWorkCommand}">
+                    <TextBlock Text="Support Work"
+                               FontSize="12"
+                               FontWeight="SemiBold"/>
+                </Button>
             </Border>
             </Grid>
         </Border>

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -11,7 +11,6 @@ namespace PulseAPK.Core.Services
         public string AdbPath { get; set; } = string.Empty;
         public string SelectedLanguage { get; set; } = "en-US";
         public string ThemeMode { get; set; } = "dark_mode";
-        public bool IsSupportWorkDismissed { get; set; }
     }
 
     public interface ISettingsService

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -14,7 +14,6 @@ public partial class MainViewModel : ObservableObject
     private const string SupportWorkUrl = "https://yarygintech.com/support-work/";
 
     private readonly LocalizationService _localizationService;
-    private readonly ISettingsService _settingsService;
     private readonly ISystemService _systemService;
 
     [ObservableProperty]
@@ -34,8 +33,7 @@ public partial class MainViewModel : ObservableObject
     public string MenuSettingsLabel => _localizationService["MenuSettings"];
     public string MenuAboutLabel => _localizationService["MenuAbout"];
 
-    [ObservableProperty]
-    private bool _isSupportWorkVisible;
+    public bool IsSupportWorkVisible => true;
 
     public bool IsDecompileSelected => SelectedMenu == "Decompile";
     public bool IsBuildSelected => SelectedMenu == "Build";
@@ -56,14 +54,11 @@ public partial class MainViewModel : ObservableObject
     public MainViewModel(
         IServiceProvider serviceProvider,
         LocalizationService localizationService,
-        ISettingsService settingsService,
         ISystemService systemService)
     {
         _serviceProvider = serviceProvider;
         _localizationService = localizationService;
-        _settingsService = settingsService;
         _systemService = systemService;
-        IsSupportWorkVisible = !_settingsService.Settings.IsSupportWorkDismissed;
         WindowTitle = _localizationService["AppTitle"];
         _localizationService.PropertyChanged += HandleLocalizationChanged;
         SetInitialView();
@@ -131,14 +126,6 @@ public partial class MainViewModel : ObservableObject
     private void OpenSupportWork()
     {
         _systemService.OpenUrl(SupportWorkUrl);
-    }
-
-    [RelayCommand]
-    private void DismissSupportWork()
-    {
-        IsSupportWorkVisible = false;
-        _settingsService.Settings.IsSupportWorkDismissed = true;
-        _settingsService.Save();
     }
 
     partial void OnSelectedMenuChanged(string value)


### PR DESCRIPTION
### Motivation
- Reduce sidebar clutter by converting the dismissible Support Work panel into a compact, always-visible CTA that still opens the support URL. 
- Provide a subtle attention-grab on startup with a short pulse animation so the CTA is noticeable without being permanently dismissible.

### Description
- Simplified the support block in `src/PulseAPK.Avalonia/MainWindow.axaml` by removing the two-column Grid and the dismiss `Button`, replacing it with a single compact `Button` that binds to `OpenSupportWorkCommand` and displays `Support Work`.
- Added a new `Button.support-work-button` style in `MainWindow.axaml` that reduces padding/height/font size, defines hover/pressed cyberpunk states, and includes a short startup animation using `Animation` with `IterationCount="4"` to pulse background/border/foreground.
- Updated `src/PulseAPK.Core/ViewModels/MainViewModel.cs` to remove the dismiss logic by deleting `DismissSupportWork()` and the `ISettingsService` dependency, and changed `IsSupportWorkVisible` to always return `true` while keeping `OpenSupportWork()` unchanged.
- Removed the now-unused `IsSupportWorkDismissed` setting from `src/PulseAPK.Core/Services/SettingsService.cs` (deleted property from `AppSettings`).

### Testing
- Attempted to run an automated build with `dotnet build`, but it could not be run in this environment because `dotnet` is not installed, so a full build/test verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8e647cb88322b1b3270d803a5ac8)