### PR TITLE
Refine support work button pulse

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -74,22 +74,19 @@
             <Setter Property="MinHeight" Value="30" />
             <Setter Property="Padding" Value="8,5" />
             <Style.Animations>
-                <Animation Duration="0:0:0.45"
-                           IterationCount="4">
+                <Animation Duration="0:0:0.30"
+                           IterationCount="3">
                     <KeyFrame Cue="0%">
                         <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
                         <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
-                        <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
                     </KeyFrame>
                     <KeyFrame Cue="50%">
                         <Setter Property="Background" Value="{DynamicResource CyberAccentPressedBrush}" />
                         <Setter Property="BorderBrush" Value="{DynamicResource CyberWarningBrush}" />
-                        <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
                     </KeyFrame>
                     <KeyFrame Cue="100%">
                         <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
                         <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
-                        <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
                     </KeyFrame>
                 </Animation>
             </Style.Animations>


### PR DESCRIPTION
### Motivation
- Add a short, finite highlight pulse to the Support Work button that pulses the border/background (not the text) and returns to the normal resting style.

### Description
- Replace the existing animation with an Avalonia `Animation` using `Duration="0:0:0.30"` and `IterationCount="3"`, animate only `Background` and `BorderBrush` keyframes, and remove `Foreground` keyframes so text does not blink while the final keyframe restores the resting values.

### Testing
- Ran `git diff --check` (succeeded) and validated the AXAML with `python3` XML parsing (`ET.parse`) (succeeded); `dotnet build PulseAPK.sln` could not be executed in the environment because `dotnet` is not installed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f8f8777188322a3d9b38c1a01a35c)