### PR TITLE
Fix patch live log expansion layout

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -166,8 +166,7 @@
                              VerticalAlignment="Stretch"
                              Classes="terminal-output"
                              ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                             MinHeight="260" />
+                             ScrollViewer.HorizontalScrollBarVisibility="Auto" />
                 </Grid>
             </Border>
         </Expander>


### PR DESCRIPTION
### Motivation
- The live log `TextBox` in the Patch view used a fixed `MinHeight` which caused the log to overflow and appear broken when the `Expander` was opened, so it should resize to the available space instead.

### Description
- Removed the `MinHeight` attribute from the `TextBox` (class `terminal-output`) in `src/PulseAPK.Avalonia/Views/PatchView.axaml` so the live log can stretch within the `Expander` and not overlap other controls.

### Testing
- Attempted to run `dotnet build PulseAPK.sln` but `dotnet` is not installed in the environment, so no automated build or tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f91db43708322aa277e3e5a056c9f)