### PR TITLE
Make Patch APK layout more compact

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -4,138 +4,143 @@
              xmlns:services="clr-namespace:PulseAPK.Core.Services;assembly=PulseAPK.Core"
              x:Class="PulseAPK.Avalonia.Views.PatchView"
              x:DataType="vm:PatchViewModel">
-    <Grid RowDefinitions="Auto,Auto,Auto,*"
-          RowSpacing="16"
-          Margin="20">
-        <StackPanel Spacing="6">
-            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchHeader]}"
-                       Classes="page-title" />
-            <Border Width="86"
-                    Height="3"
-                    HorizontalAlignment="Left"
-                    Background="{DynamicResource CyberAccentSecondaryBrush}"
-                    CornerRadius="2" />
-            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchBetaWarning]}"
-                       Classes="helper-text" />
-        </StackPanel>
+    <Grid RowDefinitions="Auto,Auto,*"
+          RowSpacing="10"
+          Margin="14">
+        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+            <StackPanel Spacing="3">
+                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchHeader]}"
+                           Classes="page-title" />
+                <Border Width="86"
+                        Height="3"
+                        HorizontalAlignment="Left"
+                        Background="{DynamicResource CyberAccentSecondaryBrush}"
+                        CornerRadius="2" />
+            </StackPanel>
+            <TextBlock Grid.Column="1"
+                       Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchBetaWarning]}"
+                       Classes="helper-text"
+                       VerticalAlignment="Center" />
+        </Grid>
 
-        <Border Grid.Row="1"
-                Classes="card">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
-                <StackPanel Spacing="6">
+        <Grid Grid.Row="1" RowDefinitions="Auto,Auto" RowSpacing="10">
+            <Border Classes="card compact"
+                    Padding="12">
+                <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="10">
                     <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SelectApk]}"
-                               FontWeight="SemiBold" />
-                    <TextBox Text="{Binding ApkPath}"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                    <TextBox Grid.Column="1"
+                             Text="{Binding ApkPath}"
                              Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApkPathPlaceholder]}"
+                             ToolTip.Tip="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseApkTip]}"
                              IsReadOnly="True"
                              IsTabStop="False"
                              IsHitTestVisible="False" />
-                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[BrowseApkTip]}"
-                               Classes="helper-text"
-                               IsVisible="{Binding IsHintVisible}" />
-                </StackPanel>
-                <StackPanel Grid.Column="1" Spacing="8" VerticalAlignment="Center">
-                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                    <Button Grid.Column="2"
+                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
                             Command="{Binding BrowseApkCommand}"
-                            MinWidth="120"
-                            Height="38"
-                            FontSize="14"
-                            VerticalContentAlignment="Center"
-                            Padding="16,0" />
-                    <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
+                            MinWidth="110"
+                            Height="36"
+                            Padding="14,0" />
+                    <Button Grid.Column="3"
+                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Run]}"
                             Command="{Binding RunPatchCommand}"
                             Classes="primary-action"
-                            MinWidth="120"
-                            Height="38"
-                            FontSize="14"
-                            VerticalContentAlignment="Center"
-                            Padding="16,0" />
-                </StackPanel>
-            </Grid>
-        </Border>
+                            MinWidth="110"
+                            Height="36"
+                            Padding="14,0" />
+                </Grid>
+            </Border>
 
-        <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="16">
-            <StackPanel Spacing="8">
-                <TextBlock Text="SIGNING"
-                           Foreground="{DynamicResource CyberAccentBrush}"
-                           FontSize="11"
-                           FontWeight="SemiBold" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
-                          IsChecked="{Binding SignApk}" />
-                <TextBlock Text="INJECTION"
-                           Foreground="{DynamicResource CyberHelperTextBrush}"
-                           FontSize="11"
-                           FontWeight="SemiBold"
-                           Margin="0,8,0,0" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
-                          IsChecked="{Binding InjectLibForAllArchitectures}" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
-                          IsChecked="{Binding SkipDexValidation}" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
-                          IsChecked="{Binding DecodeResources}" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
-                          IsChecked="{Binding DecodeSources}" />
-                <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
-                          IsChecked="{Binding UseAapt2ForBuild}" />
-                <Grid ColumnDefinitions="*,*"
-                      ColumnSpacing="16"
-                      Margin="0,8,0,0">
-                    <StackPanel Spacing="4">
-                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptProfile]}"
+            <Grid Grid.Row="1" ColumnDefinitions="*,1.25*" ColumnSpacing="14">
+                <Border Classes="card compact"
+                        Padding="12">
+                    <StackPanel Spacing="8">
+                        <TextBlock Text="PATCH OPTIONS"
+                                   Foreground="{DynamicResource CyberAccentBrush}"
+                                   FontSize="11"
                                    FontWeight="SemiBold" />
-                        <ComboBox ItemsSource="{Binding ScriptInjectionOptions}"
-                                  SelectedItem="{Binding SelectedScriptInjectionOption}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Label}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
+                        <WrapPanel ColumnSpacing="14" RowSpacing="4">
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
+                                      IsChecked="{Binding SignApk}" />
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
+                                      IsChecked="{Binding InjectLibForAllArchitectures}" />
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
+                                      IsChecked="{Binding SkipDexValidation}" />
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
+                                      IsChecked="{Binding DecodeResources}" />
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
+                                      IsChecked="{Binding DecodeSources}" />
+                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
+                                      IsChecked="{Binding UseAapt2ForBuild}" />
+                        </WrapPanel>
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <StackPanel Spacing="3">
+                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptProfile]}"
+                                           FontWeight="SemiBold" />
+                                <ComboBox ItemsSource="{Binding ScriptInjectionOptions}"
+                                          SelectedItem="{Binding SelectedScriptInjectionOption}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Label}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </StackPanel>
+                            <StackPanel Grid.Column="1" Spacing="3">
+                                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchDexPreservationMode]}"
+                                           FontWeight="SemiBold" />
+                                <ComboBox ItemsSource="{Binding DexPreservationOptions}"
+                                          SelectedItem="{Binding SelectedDexPreservationOption}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Label}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </StackPanel>
+                        </Grid>
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptSampleInjectionInfo]}"
+                                   Classes="helper-text"
+                                   IsVisible="{Binding IsSampleInjectionProfileSelected}" />
                     </StackPanel>
-                    <StackPanel Grid.Column="1" Spacing="4">
-                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchDexPreservationMode]}"
+                </Border>
+                <Border Grid.Column="1"
+                        Classes="card compact"
+                        Padding="12">
+                    <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="8">
+                        <TextBlock Text="OUTPUT"
+                                   Foreground="{DynamicResource CyberAccentBrush}"
+                                   FontSize="11"
                                    FontWeight="SemiBold" />
-                        <ComboBox ItemsSource="{Binding DexPreservationOptions}"
-                                  SelectedItem="{Binding SelectedDexPreservationOption}">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Label}" />
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-                    </StackPanel>
-                </Grid>
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchScriptSampleInjectionInfo]}"
-                           Classes="helper-text"
-                           IsVisible="{Binding IsSampleInjectionProfileSelected}" />
-            </StackPanel>
-            <StackPanel Grid.Column="1" Spacing="8">
-                <TextBlock Text="OUTPUT"
-                           Foreground="{DynamicResource CyberAccentBrush}"
-                           FontSize="11"
-                           FontWeight="SemiBold" />
-                <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputLabel]}"
-                           FontWeight="SemiBold" />
-                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                    <TextBox Text="{Binding OutputFolderPath}" />
-                    <Button Grid.Column="1"
-                            Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
-                            Command="{Binding BrowseOutputFolderCommand}"
-                            Width="100" />
-                </Grid>
-                <TextBox Text="{Binding OutputApkName}"
-                         Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputApkNamePlaceholder]}" />
-                <Button Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOpenFolder]}"
-                        Command="{Binding OpenOutputFolderCommand}"
-                        Width="100"
-                        HorizontalAlignment="Left" />
-            </StackPanel>
+                        <Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                            <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputLabel]}"
+                                       FontWeight="SemiBold"
+                                       VerticalAlignment="Center" />
+                            <TextBox Grid.Column="1" Text="{Binding OutputFolderPath}" />
+                            <Button Grid.Column="2"
+                                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[Browse]}"
+                                    Command="{Binding BrowseOutputFolderCommand}"
+                                    Width="96" />
+                        </Grid>
+                        <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                            <TextBox Text="{Binding OutputApkName}"
+                                     Watermark="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOutputApkNamePlaceholder]}" />
+                            <Button Grid.Column="1"
+                                    Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchOpenFolder]}"
+                                    Command="{Binding OpenOutputFolderCommand}"
+                                    Width="110" />
+                        </Grid>
+                    </Grid>
+                </Border>
+            </Grid>
         </Grid>
 
-        <Expander Grid.Row="3"
+        <Expander Grid.Row="2"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch"
-                  IsExpanded="False">
+                  IsExpanded="True">
             <Expander.Header>
                 <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
                     <Border Classes="console-header-dot"
@@ -153,21 +158,18 @@
                 </Grid>
             </Expander.Header>
             <Border Classes="console-card compact"
+                    Padding="10"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch">
-                <Grid RowDefinitions="Auto,*" RowSpacing="8">
-                    <Border Classes="console-divider" />
-                    <TextBox Grid.Row="1"
-                             Text="{Binding ConsoleLog}"
-                             IsReadOnly="True"
-                             AcceptsReturn="True"
-                             TextWrapping="Wrap"
-                             HorizontalAlignment="Stretch"
-                             VerticalAlignment="Stretch"
-                             Classes="terminal-output"
-                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             ScrollViewer.HorizontalScrollBarVisibility="Auto" />
-                </Grid>
+                <TextBox Text="{Binding ConsoleLog}"
+                         IsReadOnly="True"
+                         AcceptsReturn="True"
+                         TextWrapping="Wrap"
+                         HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         Classes="terminal-output"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.HorizontalScrollBarVisibility="Auto" />
             </Border>
         </Expander>
     </Grid>


### PR DESCRIPTION
### Motivation
- Reduce the vertical space used by the `Patch APK` view so more area is available for terminal output while keeping all controls and features intact.
- Improve the visual density of header, selection, options and output sections to make the UI more compact and usable on smaller screens.

### Description
- Adjusted the layout in `src/PulseAPK.Avalonia/Views/PatchView.axaml` by reducing margins and row spacing and moving the beta warning beside the title instead of stacking it vertically.
- Collapsed APK selection into a single compact row with `Browse` and `Run` controls and preserved the browse hint as a tooltip on the APK path field.
- Reworked patch options into a wrapping `WrapPanel` so checkboxes use horizontal space before wrapping, and grouped script/dex combo boxes in a compact grid.
- Moved output folder/name controls into a compact side card and expanded the console log by default while reducing console-card padding to give terminal output more visible space.

### Testing
- Ran an XML parse check with `ET.parse('src/PulseAPK.Avalonia/Views/PatchView.axaml')` to validate AXAML and it succeeded.
- Ran `git diff --check` to validate whitespace/formatting issues and it reported no problems.
- Attempted `dotnet build PulseAPK.sln` but it could not be executed in this environment due to `dotnet` not being available (build not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f93ec7ff88322a17951aa4076a38c)