### PR TITLE
Fix PatchView WrapPanel spacing compilation error

### DIFF
--- a/src/PulseAPK.Avalonia/Views/PatchView.axaml
+++ b/src/PulseAPK.Avalonia/Views/PatchView.axaml
@@ -61,18 +61,18 @@
                                    Foreground="{DynamicResource CyberAccentBrush}"
                                    FontSize="11"
                                    FontWeight="SemiBold" />
-                        <WrapPanel ColumnSpacing="14" RowSpacing="4">
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
+                        <WrapPanel>
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSignOutputApk]}"
                                       IsChecked="{Binding SignApk}" />
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchInjectForAllArchitectures]}"
                                       IsChecked="{Binding InjectLibForAllArchitectures}" />
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchSkipDexValidation]}"
                                       IsChecked="{Binding SkipDexValidation}" />
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeResources]}"
                                       IsChecked="{Binding DecodeResources}" />
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[DecodeSources]}"
                                       IsChecked="{Binding DecodeSources}" />
-                            <CheckBox Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
+                            <CheckBox Margin="0,0,14,4" Content="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[UseAapt2]}"
                                       IsChecked="{Binding UseAapt2ForBuild}" />
                         </WrapPanel>
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="10">


### PR DESCRIPTION
### Motivation
- The `WrapPanel` in `src/PulseAPK.Avalonia/Views/PatchView.axaml` used unsupported attached properties `ColumnSpacing` and `RowSpacing`, causing Avalonia AVLN2000 errors during build.

### Description
- Remove `ColumnSpacing` and `RowSpacing` from the `WrapPanel` and add `Margin="0,0,14,4"` to each patch-option `CheckBox` to preserve the intended spacing.

### Testing
- Ran `git diff --check` which passed, and attempted `dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj -c Release` but it could not be executed because `dotnet` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f950865a483229a9780a984a65622)