### PR TITLE
Center button content alignment

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -13,6 +13,8 @@
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="6" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Padding" Value="14,8" />
         </Style>
 


### PR DESCRIPTION
### Motivation
- Action button text appeared off-center vertically in fixed-height buttons, so button content needs explicit centering for correct alignment.

### Description
- Added `HorizontalContentAlignment="Center"` and `VerticalContentAlignment="Center"` to the global `Button` style in `src/PulseAPK.Avalonia/App.axaml` so button text is centered.

### Testing
- Attempted `dotnet build` but it could not run because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f96134a2c8322a9f07f3047ebe050)