### PR TITLE
Remove Settings and About navigation hints

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -204,7 +204,6 @@
                         Classes.active="{Binding IsSettingsSelected}"
                         IsVisible="{Binding IsSettingsEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[CFG]"/>
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuSettings]}"/>
                     </StackPanel>
                 </Button>
@@ -213,7 +212,6 @@
                         Classes.active="{Binding IsAboutSelected}"
                         IsVisible="{Binding IsAboutEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[?]"/>
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAbout]}"/>
                     </StackPanel>
                 </Button>


### PR DESCRIPTION
### Motivation
- The sidebar showed small glyph hints (`[CFG]` and `[?]`) next to the Settings and About buttons which are not desired for those two items.

### Description
- Removed the `TextBlock` glyphs for Settings and About in `src/PulseAPK.Avalonia/MainWindow.axaml` so each button now displays only its localized label.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues; `dotnet build PulseAPK.sln` could not be executed because `dotnet` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f97b051f083228b9858696e5d70e1)