### PR TITLE
Add missing localized strings for Patch and Device Tools

### DIFF
--- a/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ar-SA.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>تصحيح APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>وظيفة تجريبية. استخدمها على مسؤوليتك الخاصة</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>إضافة سكربت مخصص</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>حقن تجريبي</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>يضيف الحقن التجريبي مساعد سجل smali فقط؛ ولا يتم تحميل أي مكتبة أصلية.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>يرجى تحديد ملف APK لتصحيحه.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>ملف APK مفقود</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>قد يؤدي استبدال كل ملفات dex إلى تجاهل تغييرات smali المحقونة. تابع فقط إذا كنت تفهم هذا الخطر.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>استبدال dex خطير</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] ألغى المستخدم استبدال dex الخطير.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>بدء مسار التصحيح...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] ملف السكربت: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>تصحيح '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>تم إنشاء APK المصحح: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>اكتمل التصحيح بنجاح.
+الإخراج: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>اكتمل التصحيح</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>فشل التصحيح. راجع إخراج وحدة التحكم للتفاصيل.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>فشل التصحيح</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>معاينة التصحيح:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>APK الإدخال: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;اختر apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>APK الإخراج: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;apk الإخراج&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>فك ترميز الموارد: {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>فك ترميز المصادر: {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>استخدام AAPT2: {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>ملف السكربت: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>الحقن لكل المعماريات: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>تخطي التحقق من DEX: {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>إضافة سكربت مخصص: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>الحفاظ على Dex: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>توقيع الإخراج: {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>الجهاز: متصل</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>الجهاز: غير متصل</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.de-DE.resx
+++ b/src/PulseAPK.Core/Properties/Resources.de-DE.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>APK patchen</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Beta-Funktion. Verwendung auf eigene Gefahr</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Benutzerdefiniertes Skript hinzufügen</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Beispiel-Injektion</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>Die Beispiel-Injektion fügt nur einen smali-Log-Helfer hinzu; es wird keine native Bibliothek geladen.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Bitte wählen Sie eine APK-Datei zum Patchen aus.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>APK fehlt</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Alle dex-Dateien zu ersetzen kann injizierte smali-Änderungen verwerfen. Fahren Sie nur fort, wenn Sie dieses Risiko verstehen.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Gefährlicher dex-Ersatz</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] Gefährlicher dex-Ersatz wurde vom Benutzer abgebrochen.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Patch-Pipeline wird gestartet...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Skriptprofil: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Patche '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>Gepatchte APK erstellt: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Patch erfolgreich abgeschlossen.
+Ausgabe: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Patch abgeschlossen</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Patch fehlgeschlagen. Details finden Sie in der Konsolenausgabe.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Patch fehlgeschlagen</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Patch-Vorschau:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>Eingabe-APK: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;apk auswählen&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>Ausgabe-APK: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;ausgabe-apk&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Ressourcen dekodieren: {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Quellen dekodieren: {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>AAPT2 verwenden: {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Skriptprofil: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Für alle Architekturen injizieren: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>DEX-Validierung überspringen: {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>Benutzerdefiniertes Skript hinzufügen: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Dex-Beibehaltung: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Ausgabe signieren: {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Gerät: online</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Gerät: offline</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.es-ES.resx
+++ b/src/PulseAPK.Core/Properties/Resources.es-ES.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Parchear APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Funcionalidad beta. Úsala bajo tu responsabilidad</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Añadir script personalizado</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Inyección de ejemplo</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>La inyección de ejemplo solo añade un ayudante de registro smali; no se carga ninguna biblioteca nativa.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Selecciona un archivo APK para parchear.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>Falta el APK</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Reemplazar todos los dex puede descartar los cambios smali inyectados. Continúa solo si entiendes este riesgo.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Reemplazo dex peligroso</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] El usuario canceló el reemplazo dex peligroso.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Iniciando canalización de parcheo...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Perfil de script: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Parcheando '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>APK parcheado creado: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Parche completado correctamente.
+Salida: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Parche completado</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>El parche falló. Consulta la salida de la consola para más detalles.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Parche fallido</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Vista previa del parche:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>APK de entrada: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;seleccionar apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>APK de salida: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;apk de salida&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Decodificar recursos: {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Decodificar fuentes: {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Usar AAPT2: {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Perfil de script: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Inyectar para todas las arquitecturas: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>Omitir validación DEX: {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>Añadir script personalizado: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Conservación de Dex: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Firmar salida: {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Dispositivo: en línea</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Dispositivo: sin conexión</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.fr-FR.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Patcher APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Fonctionnalité bêta. À utiliser à vos risques et périls</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Ajouter un script personnalisé</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Injection d’exemple</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>L’injection d’exemple ajoute uniquement un assistant de journal smali ; aucune bibliothèque native n’est chargée.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Veuillez sélectionner un fichier APK à patcher.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>APK manquant</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Remplacer tous les dex peut supprimer les modifications smali injectées. Continuez uniquement si vous comprenez ce risque.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Remplacement dex dangereux</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] Le remplacement dex dangereux a été annulé par l’utilisateur.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Démarrage du pipeline de patch...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Profil de script : {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Patch de '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>APK patché créé : {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Patch terminé avec succès.
+Sortie : {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Patch terminé</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Le patch a échoué. Consultez la sortie de la console pour plus de détails.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Échec du patch</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Aperçu du patch :</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>APK d’entrée : {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;sélectionner apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>APK de sortie : {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;apk de sortie&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Décoder les ressources : {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Décoder les sources : {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Utiliser AAPT2 : {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Profil de script : {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Injecter pour toutes les architectures : {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>Ignorer la validation DEX : {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>Ajouter un script personnalisé : {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Préservation Dex : {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Signer la sortie : {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Appareil : en ligne</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Appareil : hors ligne</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
+++ b/src/PulseAPK.Core/Properties/Resources.pt-BR.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Aplicar patch no APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Funcionalidade beta. Use por sua conta e risco</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Adicionar script personalizado</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Injeção de exemplo</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>A injeção de exemplo adiciona apenas um auxiliar de log smali; nenhuma biblioteca nativa é carregada.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Selecione um arquivo APK para aplicar o patch.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>APK ausente</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Substituir todos os dex pode descartar alterações smali injetadas. Continue apenas se entender esse risco.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Substituição dex perigosa</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] A substituição dex perigosa foi cancelada pelo usuário.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Iniciando pipeline de patch...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Perfil do script: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Aplicando patch em '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>APK com patch criado: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Patch concluído com sucesso.
+Saída: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Patch concluído</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Falha ao aplicar o patch. Veja a saída do console para detalhes.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Falha no patch</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Prévia do patch:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>APK de entrada: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;selecionar apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>APK de saída: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;apk de saída&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Decodificar recursos: {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Decodificar fontes: {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Usar AAPT2: {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Perfil do script: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Injetar para todas as arquiteturas: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>Ignorar validação DEX: {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>Adicionar script personalizado: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Preservação de Dex: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Assinar saída: {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Dispositivo: online</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Dispositivo: offline</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -695,4 +695,22 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Бета-функция. Используйте на свой риск</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Добавить пользовательский скрипт</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Пример внедрения</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>Пример внедрения добавляет только помощник журнала smali; нативная библиотека не загружается.</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Устройство: онлайн</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Устройство: офлайн</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
+++ b/src/PulseAPK.Core/Properties/Resources.uk-UA.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>Патч APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>Бета-функція. Використовуйте на власний ризик</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>Додати власний скрипт</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>Приклад ін’єкції</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>Приклад ін’єкції лише додає помічник журналу smali; нативна бібліотека не завантажується.</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>Виберіть файл APK для патчу.</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>APK відсутній</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>Заміна всіх dex може відкинути ін’єктовані зміни smali. Продовжуйте лише якщо розумієте цей ризик.</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>Небезпечна заміна dex</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] Небезпечну заміну dex скасовано користувачем.</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>Запуск конвеєра патчу...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] Профіль скрипта: {0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>Патч '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>Створено пропатчений APK: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>Патч успішно завершено.
+Вихід: {0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>Патч завершено</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>Патч не вдався. Дивіться вивід консолі для деталей.</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>Помилка патчу</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>Попередній перегляд патчу:</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>Вхідний APK: {0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;виберіть apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>Вихідний APK: {0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;вихідний apk&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>Декодувати ресурси: {0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>Декодувати джерела: {0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>Використовувати AAPT2: {0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>Профіль скрипта: {0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>Ін’єктувати для всіх архітектур: {0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>Пропустити перевірку DEX: {0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>Додати власний скрипт: {0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Збереження Dex: {0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>Підписати вихід: {0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>Пристрій: онлайн</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>Пристрій: офлайн</value>
+  </data>
 </root>

--- a/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
+++ b/src/PulseAPK.Core/Properties/Resources.zh-CN.resx
@@ -610,4 +610,107 @@
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
     <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
   </data>
+  <data name="MenuPatch" xml:space="preserve">
+    <value>修补 APK</value>
+  </data>
+  <data name="PatchBetaWarning" xml:space="preserve">
+    <value>测试版功能。使用风险自负</value>
+  </data>
+  <data name="PatchAddCustomScript" xml:space="preserve">
+    <value>添加自定义脚本</value>
+  </data>
+  <data name="PatchScriptSampleInjection" xml:space="preserve">
+    <value>示例注入</value>
+  </data>
+  <data name="PatchScriptSampleInjectionInfo" xml:space="preserve">
+    <value>示例注入只添加一个 smali 日志助手；不会加载原生库。</value>
+  </data>
+  <data name="PatchErrorSelectApk" xml:space="preserve">
+    <value>请选择要修补的 APK 文件。</value>
+  </data>
+  <data name="PatchErrorMissingApkTitle" xml:space="preserve">
+    <value>缺少 APK</value>
+  </data>
+  <data name="PatchDangerousDexConfirmation" xml:space="preserve">
+    <value>替换所有 dex 可能会丢弃已注入的 smali 更改。仅在了解风险后继续。</value>
+  </data>
+  <data name="PatchDangerousDexTitle" xml:space="preserve">
+    <value>危险的 dex 替换</value>
+  </data>
+  <data name="PatchLogDangerousDexCancelled" xml:space="preserve">
+    <value>[WARN] 用户已取消危险的 dex 替换。</value>
+  </data>
+  <data name="PatchLogStartingPipeline" xml:space="preserve">
+    <value>正在启动修补流程...</value>
+  </data>
+  <data name="PatchLogScriptProfile" xml:space="preserve">
+    <value>[INFO] 脚本配置：{0}</value>
+  </data>
+  <data name="PatchLogRunSummary" xml:space="preserve">
+    <value>正在修补 '{0}' -&gt; '{1}' (sign={2}, decodeRes={3}, decodeSrc={4}, aapt2={5}, dexMode={6})</value>
+  </data>
+  <data name="PatchLogCreated" xml:space="preserve">
+    <value>已创建修补后的 APK：{0}</value>
+  </data>
+  <data name="PatchInfoCompleteMessage" xml:space="preserve">
+    <value>修补成功完成。
+输出：{0}</value>
+  </data>
+  <data name="PatchInfoCompleteTitle" xml:space="preserve">
+    <value>修补完成</value>
+  </data>
+  <data name="PatchErrorFailedMessage" xml:space="preserve">
+    <value>修补失败。请查看控制台输出了解详情。</value>
+  </data>
+  <data name="PatchErrorFailedTitle" xml:space="preserve">
+    <value>修补失败</value>
+  </data>
+  <data name="PatchPreviewHeader" xml:space="preserve">
+    <value>修补预览：</value>
+  </data>
+  <data name="PatchPreviewInputApk" xml:space="preserve">
+    <value>输入 APK：{0}</value>
+  </data>
+  <data name="PatchPreviewSelectApk" xml:space="preserve">
+    <value>&lt;选择 apk&gt;</value>
+  </data>
+  <data name="PatchPreviewOutputApk" xml:space="preserve">
+    <value>输出 APK：{0}</value>
+  </data>
+  <data name="PatchPreviewOutputApkPlaceholder" xml:space="preserve">
+    <value>&lt;输出 apk&gt;</value>
+  </data>
+  <data name="PatchPreviewDecodeResources" xml:space="preserve">
+    <value>解码资源：{0}</value>
+  </data>
+  <data name="PatchPreviewDecodeSources" xml:space="preserve">
+    <value>解码源码：{0}</value>
+  </data>
+  <data name="PatchPreviewUseAapt2" xml:space="preserve">
+    <value>使用 AAPT2：{0}</value>
+  </data>
+  <data name="PatchPreviewScriptProfile" xml:space="preserve">
+    <value>脚本配置：{0}</value>
+  </data>
+  <data name="PatchPreviewInjectAllArchitectures" xml:space="preserve">
+    <value>为所有架构注入：{0}</value>
+  </data>
+  <data name="PatchPreviewSkipDexValidation" xml:space="preserve">
+    <value>跳过 DEX 验证：{0}</value>
+  </data>
+  <data name="PatchPreviewAddCustomScript" xml:space="preserve">
+    <value>添加自定义脚本：{0}</value>
+  </data>
+  <data name="PatchPreviewDexPreservation" xml:space="preserve">
+    <value>Dex 保留：{0}</value>
+  </data>
+  <data name="PatchPreviewSignOutput" xml:space="preserve">
+    <value>签名输出：{0}</value>
+  </data>
+  <data name="DeviceToolsDeviceOnline" xml:space="preserve">
+    <value>设备：在线</value>
+  </data>
+  <data name="DeviceToolsDeviceOffline" xml:space="preserve">
+    <value>设备：离线</value>
+  </data>
 </root>


### PR DESCRIPTION
### Motivation
- Ensure all localized `.resx` files contain translations for the Patch workflow and device online/offline status to avoid untranslated UI text and fallbacks.

### Description
- Inserted the full set of Patch-related keys and preview/log messages into the Arabic (`Resources.ar-SA.resx`), German (`Resources.de-DE.resx`), Spanish (`Resources.es-ES.resx`), French (`Resources.fr-FR.resx`), Portuguese (Brazil) (`Resources.pt-BR.resx`), Ukrainian (`Resources.uk-UA.resx`), and Chinese (`Resources.zh-CN.resx`) resource files. 
- Added the remaining missing Patch strings and sample-injection info to the Russian (`Resources.ru-RU.resx`) resource file. 
- Added localized device status strings (`DeviceToolsDeviceOnline`, `DeviceToolsDeviceOffline`) for all supported cultures. 
- Changes affect only resource files under `src/PulseAPK.Core/Properties/Resources.*.resx` and add the missing `<data>` entries from the default `Resources.resx`.

### Testing
- Verified with a Python XML comparison script that every localized `.resx` now contains the same set of keys as the default `Resources.resx`, with zero missing or extra keys. 
- Attempted to run `dotnet test PulseAPK.sln`, but the `dotnet` CLI is not available in the environment so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9957e34883228c8e294d2460ffb6)