### PR TITLE
Localize Support Work and About subtitle; translate Device Tools and Terminal to Russian

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -227,7 +227,7 @@
                     Margin="0,10,0,0">
                 <Button Classes="support-work-button"
                         Command="{Binding OpenSupportWorkCommand}">
-                    <TextBlock Text="Support Work"
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[SupportWork]}"
                                FontSize="12"
                                FontWeight="SemiBold"/>
                 </Button>

--- a/src/PulseAPK.Avalonia/Views/AboutView.axaml
+++ b/src/PulseAPK.Avalonia/Views/AboutView.axaml
@@ -37,7 +37,7 @@
                                    Foreground="{DynamicResource CyberAccentBrush}"
                                    HorizontalAlignment="Center"
                                    TextAlignment="Center" />
-                        <TextBlock Text="Android APK reverse engineering toolkit"
+                        <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[About_Subtitle]}"
                                    FontSize="15"
                                    Foreground="{DynamicResource CyberAccentSecondaryBrush}"
                                    HorizontalAlignment="Center"

--- a/src/PulseAPK.Core/Properties/Resources.resx
+++ b/src/PulseAPK.Core/Properties/Resources.resx
@@ -169,6 +169,12 @@
   <data name="JavaPathFound" xml:space="preserve">
     <value>JAVA Path: {0}</value>
   </data>
+  <data name="About_Subtitle" xml:space="preserve">
+    <value>Android APK reverse engineering toolkit</value>
+  </data>
+  <data name="SupportWork" xml:space="preserve">
+    <value>Support Work</value>
+  </data>
   <data name="About_DevelopedBy" xml:space="preserve">
     <value>Developed by</value>
   </data>

--- a/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
+++ b/src/PulseAPK.Core/Properties/Resources.ru-RU.resx
@@ -169,6 +169,12 @@
   <data name="JavaPathFound" xml:space="preserve">
     <value>Путь к JAVA: {0}</value>
   </data>
+  <data name="About_Subtitle" xml:space="preserve">
+    <value>Набор инструментов для реверс-инжиниринга Android APK</value>
+  </data>
+  <data name="SupportWork" xml:space="preserve">
+    <value>Поддержать проект</value>
+  </data>
   <data name="About_DevelopedBy" xml:space="preserve">
     <value>Разработано</value>
   </data>
@@ -302,7 +308,7 @@
     <value>Имя APK</value>
   </data>
   <data name="ConsoleLog" xml:space="preserve">
-    <value>Terminal</value>
+    <value>Терминал</value>
   </data>
   <data name="ApkPathPlaceholder" xml:space="preserve">
     <value>Путь будет отображен после выбора APK-файла.</value>
@@ -450,181 +456,181 @@
     <value>- Добавить пользовательский скрипт: {0}</value>
   </data>
   <data name="DeviceToolsHeader" xml:space="preserve">
-    <value>Device Tools</value>
+    <value>Инструменты устройства</value>
   </data>
   <data name="DeviceToolsSubtitle" xml:space="preserve">
-    <value>Install APKs, launch activities, and run common ADB shell commands.</value>
+    <value>Устанавливайте APK, запускайте активности и выполняйте часто используемые команды ADB shell.</value>
   </data>
   <data name="DeviceToolsConnection" xml:space="preserve">
-    <value>Connection</value>
+    <value>Подключение</value>
   </data>
   <data name="DeviceToolsSelectDeviceHelp" xml:space="preserve">
-    <value>Select a connected Android device for APK and shell tools.</value>
+    <value>Выберите подключённое Android-устройство для инструментов APK и shell.</value>
   </data>
   <data name="DeviceToolsRefreshDevices" xml:space="preserve">
-    <value>Refresh Devices</value>
+    <value>Обновить устройства</value>
   </data>
   <data name="DeviceToolsAdbPath" xml:space="preserve">
-    <value>ADB path</value>
+    <value>Путь к ADB</value>
   </data>
   <data name="DeviceToolsChooseWorkflow" xml:space="preserve">
-    <value>Choose a workflow</value>
+    <value>Выберите сценарий</value>
   </data>
   <data name="DeviceToolsWorkflowHelp" xml:space="preserve">
-    <value>Switch between install, launch, app management, and shell tools.</value>
+    <value>Переключайтесь между установкой, запуском, управлением приложением и shell-инструментами.</value>
   </data>
   <data name="DeviceToolsInstallApkPackage" xml:space="preserve">
-    <value>Install APK Package</value>
+    <value>Установка APK-пакета</value>
   </data>
   <data name="DeviceToolsInstallApkHelp" xml:space="preserve">
-    <value>Select an APK file, install it to the active device, or read package metadata from it.</value>
+    <value>Выберите APK-файл, установите его на активное устройство или прочитайте из него метаданные пакета.</value>
   </data>
   <data name="DeviceToolsApkFile" xml:space="preserve">
-    <value>APK file</value>
+    <value>APK-файл</value>
   </data>
   <data name="DeviceToolsApkPathWatermark" xml:space="preserve">
     <value>/path/to/app.apk</value>
   </data>
   <data name="DeviceToolsInstallApk" xml:space="preserve">
-    <value>Install APK</value>
+    <value>Установить APK</value>
   </data>
   <data name="DeviceToolsDetectPackage" xml:space="preserve">
-    <value>Detect Package</value>
+    <value>Определить пакет</value>
   </data>
   <data name="DeviceToolsClearApkSelection" xml:space="preserve">
-    <value>Clear APK Selection</value>
+    <value>Очистить выбор APK</value>
   </data>
   <data name="DeviceToolsConnectDeviceHint" xml:space="preserve">
-    <value>Connect a usable Android device to enable these actions.</value>
+    <value>Подключите доступное Android-устройство, чтобы включить эти действия.</value>
   </data>
   <data name="DeviceToolsLaunchInstalledApp" xml:space="preserve">
-    <value>Launch an Installed App</value>
+    <value>Запуск установленного приложения</value>
   </data>
   <data name="DeviceToolsLaunchHelp" xml:space="preserve">
-    <value>Enter a package, optionally choose an activity, then launch or inspect the current foreground activity.</value>
+    <value>Введите пакет, при необходимости выберите активность, затем запустите её или проверьте текущую активность на переднем плане.</value>
   </data>
   <data name="DeviceToolsPackageName" xml:space="preserve">
-    <value>Package name</value>
+    <value>Имя пакета</value>
   </data>
   <data name="DeviceToolsPackageWatermark" xml:space="preserve">
     <value>com.example.app</value>
   </data>
   <data name="DeviceToolsActivity" xml:space="preserve">
-    <value>Activity</value>
+    <value>Активность</value>
   </data>
   <data name="DeviceToolsActivityWatermark" xml:space="preserve">
-    <value>.MainActivity or full class name</value>
+    <value>.MainActivity или полное имя класса</value>
   </data>
   <data name="DeviceToolsDetectedActivities" xml:space="preserve">
-    <value>Detected activities</value>
+    <value>Найденные активности</value>
   </data>
   <data name="DeviceToolsLaunchApp" xml:space="preserve">
-    <value>Launch App</value>
+    <value>Запустить приложение</value>
   </data>
   <data name="DeviceToolsLaunchActivity" xml:space="preserve">
-    <value>Launch Activity</value>
+    <value>Запустить активность</value>
   </data>
   <data name="DeviceToolsCurrentActivity" xml:space="preserve">
-    <value>Current Activity</value>
+    <value>Текущая активность</value>
   </data>
   <data name="DeviceToolsClear" xml:space="preserve">
-    <value>Clear</value>
+    <value>Очистить</value>
   </data>
   <data name="DeviceToolsPackageRequiredHint" xml:space="preserve">
-    <value>Enter a package name to continue.</value>
+    <value>Введите имя пакета, чтобы продолжить.</value>
   </data>
   <data name="DeviceToolsManageInstalledApp" xml:space="preserve">
-    <value>Manage Installed App</value>
+    <value>Управление установленным приложением</value>
   </data>
   <data name="DeviceToolsManageHelp" xml:space="preserve">
-    <value>Target a package, then stop it, reset data, remove it, or inspect package details.</value>
+    <value>Укажите пакет, затем остановите его, сбросьте данные, удалите или просмотрите сведения о пакете.</value>
   </data>
   <data name="DeviceToolsForceStop" xml:space="preserve">
-    <value>Force Stop</value>
+    <value>Остановить принудительно</value>
   </data>
   <data name="DeviceToolsClearData" xml:space="preserve">
-    <value>Clear Data</value>
+    <value>Очистить данные</value>
   </data>
   <data name="DeviceToolsUninstall" xml:space="preserve">
-    <value>Uninstall</value>
+    <value>Удалить</value>
   </data>
   <data name="DeviceToolsSearchPackage" xml:space="preserve">
-    <value>Search Package</value>
+    <value>Найти пакет</value>
   </data>
   <data name="DeviceToolsAppPath" xml:space="preserve">
-    <value>App Path</value>
+    <value>Путь приложения</value>
   </data>
   <data name="DeviceToolsUtilities" xml:space="preserve">
-    <value>Utilities</value>
+    <value>Утилиты</value>
   </data>
   <data name="DeviceToolsPackageUtilitiesHelp" xml:space="preserve">
-    <value>Non-destructive shortcuts for the selected device and package.</value>
+    <value>Безопасные действия для выбранного устройства и пакета.</value>
   </data>
   <data name="DeviceToolsOpenAppSettings" xml:space="preserve">
-    <value>Open App Settings</value>
+    <value>Открыть настройки приложения</value>
   </data>
   <data name="DeviceToolsCopyApkFromDevice" xml:space="preserve">
-    <value>Copy APK from Device</value>
+    <value>Скопировать APK с устройства</value>
   </data>
   <data name="DeviceToolsLogcatForPackage" xml:space="preserve">
-    <value>Logcat for Package</value>
+    <value>Logcat для пакета</value>
   </data>
   <data name="DeviceToolsRunAdbShellCommands" xml:space="preserve">
-    <value>Run ADB Shell Commands</value>
+    <value>Выполнение команд ADB shell</value>
   </data>
   <data name="DeviceToolsShellHelp" xml:space="preserve">
-    <value>Run a preset command, or type shell/raw ADB arguments for the selected device.</value>
+    <value>Запустите готовую команду или введите shell/raw ADB-аргументы для выбранного устройства.</value>
   </data>
   <data name="DeviceToolsPreset" xml:space="preserve">
-    <value>Preset</value>
+    <value>Шаблон</value>
   </data>
   <data name="DeviceToolsRunPreset" xml:space="preserve">
-    <value>Run Preset</value>
+    <value>Запустить шаблон</value>
   </data>
   <data name="DeviceToolsCommand" xml:space="preserve">
-    <value>Command</value>
+    <value>Команда</value>
   </data>
   <data name="DeviceToolsCommandWatermark" xml:space="preserve">
     <value>getprop ro.product.model</value>
   </data>
   <data name="DeviceToolsRunShell" xml:space="preserve">
-    <value>Run Shell</value>
+    <value>Запустить shell</value>
   </data>
   <data name="DeviceToolsRunAdbArgs" xml:space="preserve">
-    <value>Run ADB Args</value>
+    <value>Запустить ADB-аргументы</value>
   </data>
   <data name="DeviceToolsRunAdbArgsTip" xml:space="preserve">
-    <value>Runs the text as raw adb arguments after the selected device (-s &lt;serial&gt;). Example: devices -l or shell getprop ro.product.model.</value>
+    <value>Выполняет текст как raw adb-аргументы после выбранного устройства (-s &lt;serial&gt;). Пример: devices -l или shell getprop ro.product.model.</value>
   </data>
   <data name="DeviceToolsScreenUtilitiesHelp" xml:space="preserve">
-    <value>Capture the screen or record a short MP4 without modifying app data.</value>
+    <value>Сделайте скриншот или запишите короткий MP4 без изменения данных приложения.</value>
   </data>
   <data name="DeviceToolsScreenshot" xml:space="preserve">
-    <value>Screenshot</value>
+    <value>Скриншот</value>
   </data>
   <data name="DeviceToolsStartScreenRecord" xml:space="preserve">
-    <value>Start Screen Record</value>
+    <value>Начать запись экрана</value>
   </data>
   <data name="DeviceToolsStopScreenRecord" xml:space="preserve">
-    <value>Stop Screen Record</value>
+    <value>Остановить запись экрана</value>
   </data>
   <data name="DeviceToolsRecordingActiveHint" xml:space="preserve">
-    <value>Recording is active on the selected device until you stop it.</value>
+    <value>Запись активна на выбранном устройстве, пока вы её не остановите.</value>
   </data>
   <data name="DeviceToolsCommandOutput" xml:space="preserve">
-    <value>Command output</value>
+    <value>Вывод команды</value>
   </data>
   <data name="DeviceToolsCommandOutputHelp" xml:space="preserve">
-    <value>Latest command output appears below.</value>
+    <value>Последний вывод команды отображается ниже.</value>
   </data>
   <data name="MenuDeviceTools" xml:space="preserve">
-    <value>Device Tools</value>
+    <value>Инструменты устройства</value>
   </data>
   <data name="DeviceToolsPresetModel" xml:space="preserve">
-    <value>Model</value>
+    <value>Модель</value>
   </data>
   <data name="DeviceToolsPresetAndroidRelease" xml:space="preserve">
-    <value>Android Release</value>
+    <value>Версия Android</value>
   </data>
   <data name="DeviceToolsPresetSdk" xml:space="preserve">
     <value>SDK</value>
@@ -633,67 +639,67 @@
     <value>CPU ABI</value>
   </data>
   <data name="DeviceToolsPresetListPackages" xml:space="preserve">
-    <value>List Packages</value>
+    <value>Список пакетов</value>
   </data>
   <data name="DeviceToolsPresetThirdPartyPackages" xml:space="preserve">
-    <value>Third-Party Packages</value>
+    <value>Сторонние пакеты</value>
   </data>
   <data name="DeviceToolsPresetSearchPackage" xml:space="preserve">
-    <value>Search Package</value>
+    <value>Найти пакет</value>
   </data>
   <data name="DeviceToolsPresetAppPath" xml:space="preserve">
-    <value>App Path</value>
+    <value>Путь приложения</value>
   </data>
   <data name="DeviceToolsPresetCurrentActivity" xml:space="preserve">
-    <value>Current Activity</value>
+    <value>Текущая активность</value>
   </data>
   <data name="DeviceToolsPresetReboot" xml:space="preserve">
-    <value>Reboot</value>
+    <value>Перезагрузка</value>
   </data>
   <data name="DeviceToolsPresetAdbRoot" xml:space="preserve">
-    <value>ADB Root</value>
+    <value>ADB root</value>
   </data>
   <data name="DeviceToolsPresetAdbRemount" xml:space="preserve">
-    <value>ADB Remount</value>
+    <value>ADB remount</value>
   </data>
   <data name="DeviceToolsPresetLogcatForPackage" xml:space="preserve">
-    <value>Logcat for Package</value>
+    <value>Logcat для пакета</value>
   </data>
   <data name="DeviceToolsModeInstallApk" xml:space="preserve">
-    <value>Install APK</value>
+    <value>Установить APK</value>
   </data>
   <data name="DeviceToolsModeLaunch" xml:space="preserve">
-    <value>Launch</value>
+    <value>Запуск</value>
   </data>
   <data name="DeviceToolsModeManageApp" xml:space="preserve">
-    <value>Manage App</value>
+    <value>Управление приложением</value>
   </data>
   <data name="DeviceToolsModeShell" xml:space="preserve">
     <value>Shell</value>
   </data>
   <data name="DeviceToolsAdbChecking" xml:space="preserve">
-    <value>ADB: checking...</value>
+    <value>ADB: проверка...</value>
   </data>
   <data name="DeviceToolsAdbFound" xml:space="preserve">
-    <value>ADB: found</value>
+    <value>ADB: найден</value>
   </data>
   <data name="DeviceToolsAdbNotFound" xml:space="preserve">
-    <value>ADB: not found</value>
+    <value>ADB: не найден</value>
   </data>
   <data name="DeviceToolsAdbNotChecked" xml:space="preserve">
-    <value>ADB: not checked</value>
+    <value>ADB: не проверен</value>
   </data>
   <data name="DeviceToolsCheckingDevices" xml:space="preserve">
-    <value>Checking devices...</value>
+    <value>Проверка устройств...</value>
   </data>
   <data name="DeviceToolsNoConnectedDevices" xml:space="preserve">
-    <value>No Android device connected. Connect a device and enable USB debugging.</value>
+    <value>Android-устройство не подключено. Подключите устройство и включите отладку по USB.</value>
   </data>
   <data name="DeviceToolsScreenRecordInProgress" xml:space="preserve">
-    <value>Recording in progress. Tap Stop Screen Record to end the adb shell screenrecord session, then PulseAPK will pull the MP4.</value>
+    <value>Идёт запись. Нажмите «Остановить запись экрана», чтобы завершить сеанс adb shell screenrecord, после чего PulseAPK скачает MP4.</value>
   </data>
   <data name="DeviceToolsScreenRecordReady" xml:space="preserve">
-    <value>Start Screen Record runs adb shell screenrecord and saves the pulled MP4 after you stop it.</value>
+    <value>«Начать запись экрана» запускает adb shell screenrecord и сохраняет MP4 после остановки.</value>
   </data>
   <data name="PatchBetaWarning" xml:space="preserve">
     <value>Бета-функция. Используйте на свой риск</value>


### PR DESCRIPTION
### Motivation
- Finish localization of UI strings that were still hardcoded or untranslated for Russian, including the sidebar "Support Work" button and the About view subtitle.
- Translate the Device Tools area and console labels so the Russian `ru-RU` resource file contains full UI text for that feature.

### Description
- Replace hardcoded `Support Work` text with a resource binding in `src/PulseAPK.Avalonia/MainWindow.axaml` (binds to `SupportWork`).
- Replace hardcoded About subtitle with a resource binding in `src/PulseAPK.Avalonia/Views/AboutView.axaml` (binds to `About_Subtitle`).
- Add new resource keys `About_Subtitle` and `SupportWork` to `src/PulseAPK.Core/Properties/Resources.resx` with English fallback values.
- Add corresponding Russian translations and translate many `DeviceTools*` entries plus `ConsoleLog`/terminal text in `src/PulseAPK.Core/Properties/Resources.ru-RU.resx`.

### Testing
- Verified updated RESX XML parses successfully using `xml.etree.ElementTree` in a Python script, which returned OK for both modified RESX files.
- `dotnet build` was not executed because `dotnet` is not available in the current environment, so a full build/test could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9c0fb25c8322a4c9c921697f34c4)