### PR TITLE
Fix light theme contrast

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -19,7 +19,7 @@
         </Style>
 
         <Style Selector="Button:pointerover">
-            <Setter Property="Background" Value="#111827" />
+            <Setter Property="Background" Value="{DynamicResource CyberPointerOverBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
@@ -40,7 +40,7 @@
         </Style>
 
         <Style Selector="Button.primary-action:pointerover">
-            <Setter Property="Background" Value="#10131F" />
+            <Setter Property="Background" Value="{DynamicResource CyberPointerOverBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
@@ -201,6 +201,7 @@
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#0A2636" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#122B3D" />
                     <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#20104A" />
+                    <SolidColorBrush x:Key="CyberPointerOverBrush" Color="#111827" />
                     <SolidColorBrush x:Key="CyberSelectedBrush" Color="#20104A" />
                     <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#7A2CFF" />
                     <SolidColorBrush x:Key="CyberPrimaryButtonForegroundBrush" Color="#03111A" />
@@ -210,6 +211,12 @@
                     <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#17485C" />
                     <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#6FE7FF" />
                     <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#91A3C2" />
+                    <SolidColorBrush x:Key="CyberStatusOnlineTextBrush" Color="#ECFDF5" />
+                    <SolidColorBrush x:Key="CyberStatusOfflineTextBrush" Color="#FFB3C1" />
+                    <SolidColorBrush x:Key="CyberDestructiveForegroundBrush" Color="#FFB3C1" />
+                    <SolidColorBrush x:Key="CyberDestructivePointerOverForegroundBrush" Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="CyberDestructivePointerOverBrush" Color="#10131F" />
+                    <SolidColorBrush x:Key="CyberDestructivePressedBrush" Color="#14070D" />
                     <BoxShadows x:Key="CyberCardBoxShadow">0 0 0 0 #00000000</BoxShadows>
                     <BoxShadows x:Key="CyberConsoleCardBoxShadow">0 0 0 0 #00000000</BoxShadows>
                     <BoxShadows x:Key="CyberNeonPillBoxShadow">0 0 10 0 #557A2CFF</BoxShadows>
@@ -233,6 +240,7 @@
                     <SolidColorBrush x:Key="CyberAccentMutedBrush" Color="#DDF8FF" />
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#FCE0F6" />
                     <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#FFD7F7" />
+                    <SolidColorBrush x:Key="CyberPointerOverBrush" Color="#EAF7FF" />
                     <SolidColorBrush x:Key="CyberSelectedBrush" Color="#FFD7F7" />
                     <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#B0007C" />
                     <SolidColorBrush x:Key="CyberPrimaryButtonForegroundBrush" Color="#001B22" />
@@ -242,6 +250,12 @@
                     <SolidColorBrush x:Key="CyberDisabledButtonBorderBrush" Color="#58BCD1" />
                     <SolidColorBrush x:Key="CyberDisabledButtonForegroundBrush" Color="#007C91" />
                     <SolidColorBrush x:Key="CyberHelperTextBrush" Color="#52677A" />
+                    <SolidColorBrush x:Key="CyberStatusOnlineTextBrush" Color="#005A33" />
+                    <SolidColorBrush x:Key="CyberStatusOfflineTextBrush" Color="#B00025" />
+                    <SolidColorBrush x:Key="CyberDestructiveForegroundBrush" Color="#B00025" />
+                    <SolidColorBrush x:Key="CyberDestructivePointerOverForegroundBrush" Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="CyberDestructivePointerOverBrush" Color="#B00025" />
+                    <SolidColorBrush x:Key="CyberDestructivePressedBrush" Color="#7A001A" />
                     <BoxShadows x:Key="CyberCardBoxShadow">0 0 0 0 #00000000</BoxShadows>
                     <BoxShadows x:Key="CyberConsoleCardBoxShadow">0 0 0 0 #00000000</BoxShadows>
                     <BoxShadows x:Key="CyberNeonPillBoxShadow">0 0 8 0 #33B0007C</BoxShadows>

--- a/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml
@@ -12,18 +12,18 @@
             <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
             <Setter Property="BorderBrush" Value="#FF174D" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Foreground" Value="#FFB3C1" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberDestructiveForegroundBrush}" />
         </Style>
         <Style Selector="Button.destructive:pointerover">
-            <Setter Property="Background" Value="#10131F" />
+            <Setter Property="Background" Value="{DynamicResource CyberDestructivePointerOverBrush}" />
             <Setter Property="BorderBrush" Value="#FF5A36" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="Foreground" Value="#FFFFFF" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberDestructivePointerOverForegroundBrush}" />
         </Style>
         <Style Selector="Button.destructive:pressed">
-            <Setter Property="Background" Value="#14070D" />
+            <Setter Property="Background" Value="{DynamicResource CyberDestructivePressedBrush}" />
             <Setter Property="BorderBrush" Value="#FF2BD6" />
-            <Setter Property="Foreground" Value="#FFFFFF" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberDestructivePointerOverForegroundBrush}" />
         </Style>
         <Style Selector="Border.connection-card.online">
             <Setter Property="BorderBrush" Value="#00E5FF" />
@@ -42,14 +42,14 @@
             <Setter Property="BorderBrush" Value="#00E5FF" />
         </Style>
         <Style Selector="Border.connection-status-pill.online TextBlock">
-            <Setter Property="Foreground" Value="#ECFDF5" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberStatusOnlineTextBrush}" />
         </Style>
         <Style Selector="Border.connection-status-pill.offline">
             <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
             <Setter Property="BorderBrush" Value="#FF174D" />
         </Style>
         <Style Selector="Border.connection-status-pill.offline TextBlock">
-            <Setter Property="Foreground" Value="#FFB3C1" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberDestructiveForegroundBrush}" />
         </Style>
         <Style Selector="ListBox.workflow-tabs">
             <Setter Property="Background" Value="Transparent" />
@@ -64,7 +64,7 @@
             <Setter Property="Padding" Value="16,8" />
         </Style>
         <Style Selector="ListBox.workflow-tabs ListBoxItem:pointerover">
-            <Setter Property="Background" Value="#111827" />
+            <Setter Property="Background" Value="{DynamicResource CyberPointerOverBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />


### PR DESCRIPTION
### Motivation
- The light theme had low-contrast hover and pill elements which made status pills and destructive actions hard to read. 
- Centralize pointer-over and destructive color choices so hover and status visuals pick appropriate colors for both `Light` and `Dark` themes.

### Description
- Added a theme-aware `CyberPointerOverBrush` resource in `Application` theme dictionaries and replaced hard-coded hover colors with `CyberPointerOverBrush` in `src/PulseAPK.Avalonia/App.axaml` and `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`.
- Added status and destructive brushes (`CyberStatusOnlineTextBrush`, `CyberStatusOfflineTextBrush`, `CyberDestructiveForegroundBrush`, `CyberDestructivePointerOverBrush`, `CyberDestructivePointerOverForegroundBrush`, `CyberDestructivePressedBrush`) to both `Light` and `Dark` theme dictionaries in `src/PulseAPK.Avalonia/App.axaml`.
- Updated `DeviceToolsView` to use the new dynamic brushes for connection status pills, destructive buttons, workflow tab hover, and other UI states instead of hard-coded color literals.
- Verified the modified XAML still parses without XML errors for the changed files `src/PulseAPK.Avalonia/App.axaml` and `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`.

### Testing
- Ran an XML parse check with `python3` using `xml.etree.ElementTree` for `src/PulseAPK.Avalonia/App.axaml` and `src/PulseAPK.Avalonia/Views/DeviceToolsView.axaml`, which succeeded.
- Ran `git diff --check` to ensure no whitespace/merge markers, which passed. 
- Attempted `dotnet build PulseAPK.sln` but it could not be run in this environment because the `dotnet` CLI is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9daa9d4c83228c8a0102e4ce6f30)