### PR TITLE
Fix sidebar navigation label spacing

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -54,7 +54,7 @@
             <Setter Property="FontSize" Value="13" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Foreground" Value="{DynamicResource CyberHelperTextBrush}" />
-            <Setter Property="Width" Value="34" />
+            <Setter Property="Width" Value="42" />
             <Setter Property="TextAlignment" Value="Center" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
@@ -129,7 +129,7 @@
         </DataTemplate>
     </Window.DataTemplates>
 
-    <Grid ColumnDefinitions="240, *">
+    <Grid ColumnDefinitions="270, *">
         <!-- Sidebar -->
         <Border Grid.Column="0" Background="{DynamicResource CyberSidebarBrush}" Padding="16">
             <Grid RowDefinitions="Auto,*,Auto">


### PR DESCRIPTION
### Motivation
- Prevent the navigation glyph (e.g. `[DEV]`) from being clipped and give localized menu labels (longer translations like Russian) a bit more horizontal room.

### Description
- Increased the `TextBlock.nav-glyph` `Width` from `34` to `42` and widened the sidebar `Grid` column from `240` to `270` in `src/PulseAPK.Avalonia/MainWindow.axaml`.

### Testing
- Ran `git diff --check` which completed without warnings; `dotnet build` could not be executed because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa565bf008322963ceb72a5793832)