### PR TITLE
Expand sidebar navigation width

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -129,7 +129,7 @@
         </DataTemplate>
     </Window.DataTemplates>
 
-    <Grid ColumnDefinitions="270, *">
+    <Grid ColumnDefinitions="290, *">
         <!-- Sidebar -->
         <Border Grid.Column="0" Background="{DynamicResource CyberSidebarBrush}" Padding="16">
             <Grid RowDefinitions="Auto,*,Auto">


### PR DESCRIPTION
### Motivation
- The DEV device tools label in the left sidebar appeared cramped and needs a small increase in horizontal space in the development layout.

### Description
- Increased the left sidebar width by changing the `Grid` `ColumnDefinitions` from `270, *` to `290, *` in `src/PulseAPK.Avalonia/MainWindow.axaml`.

### Testing
- Ran `git diff --check` which reported no issues, and attempted `dotnet test` but it could not run because the `dotnet` executable is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa68064348322ae6420818be92dc1)