### PR TITLE
Use theme-aware brushes for sidebar navigation hover/active states

### DIFF
--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -17,7 +17,7 @@
 
     <Window.Styles>
         <Style Selector="Button.nav-button">
-            <Setter Property="Background" Value="#33141B2E" />
+            <Setter Property="Background" Value="{DynamicResource CyberAccentMutedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
             <Setter Property="BorderThickness" Value="4,1,1,1" />
             <Setter Property="CornerRadius" Value="10" />
@@ -28,10 +28,15 @@
         </Style>
 
         <Style Selector="Button.nav-button:pointerover">
-            <Setter Property="Background" Value="#10131F" />
+            <Setter Property="Background" Value="{DynamicResource CyberPointerOverBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
             <Setter Property="BorderThickness" Value="6,1.5,1.5,1.5" />
             <Setter Property="Foreground" Value="{DynamicResource CyberAccentSecondaryBrush}" />
+        </Style>
+
+        <Style Selector="Button.nav-button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{DynamicResource CyberPointerOverBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentSecondaryBrush}" />
         </Style>
 
         <Style Selector="Button.nav-button:pressed">
@@ -41,7 +46,7 @@
         </Style>
 
         <Style Selector="Button.nav-button.active">
-            <Setter Property="Background" Value="#11131D" />
+            <Setter Property="Background" Value="{DynamicResource CyberSelectedBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberSelectedBorderBrush}" />
             <Setter Property="BorderThickness" Value="6,1,1,1" />
             <Setter Property="CornerRadius" Value="4" />


### PR DESCRIPTION
### Motivation
- The sidebar nav hover used a hardcoded gray which looks wrong in both light and dark themes and allowed Avalonia’s default gray to show through. 
- Replace hardcoded colors with theme-aware brushes so the highlight matches the app palette in light and dark modes.

### Description
- Replace the nav button base `Background` value with the theme resource `CyberAccentMutedBrush` instead of a hardcoded color. 
- Change the hover style to use `CyberPointerOverBrush` so hover looks correct in both theme variants. 
- Add a template-level hover override for `ContentPresenter#PART_ContentPresenter` to prevent the default gray hover fill from showing through. 
- Use `CyberSelectedBrush` for the active nav background instead of another hardcoded dark color.

### Testing
- Parsed `src/PulseAPK.Avalonia/MainWindow.axaml` with Python's `xml.etree.ElementTree` and the file parsed successfully. 
- Attempted `dotnet build PulseAPK.sln --no-restore` but the build could not be run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa716e5a88322b1e7b9db27678f07)