### PR TITLE
Remove sidebar shortcut hints and improve light-mode selected contrast

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -204,6 +204,7 @@
                     <SolidColorBrush x:Key="CyberPointerOverBrush" Color="#111827" />
                     <SolidColorBrush x:Key="CyberSelectedBrush" Color="#20104A" />
                     <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#7A2CFF" />
+                    <SolidColorBrush x:Key="CyberSelectedForegroundBrush" Color="#F4F7FF" />
                     <SolidColorBrush x:Key="CyberPrimaryButtonForegroundBrush" Color="#03111A" />
                     <SolidColorBrush x:Key="CyberPressedButtonForegroundBrush" Color="#FFFFFF" />
                     <SolidColorBrush x:Key="CyberFocusBorderBrush" Color="#FFB000" />
@@ -245,8 +246,9 @@
                     <SolidColorBrush x:Key="CyberAccentPressedBrush" Color="#FCE0F6" />
                     <SolidColorBrush x:Key="CyberButtonPressedBrush" Color="#FFD7F7" />
                     <SolidColorBrush x:Key="CyberPointerOverBrush" Color="#EAF7FF" />
-                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#FFD7F7" />
+                    <SolidColorBrush x:Key="CyberSelectedBrush" Color="#FFC1EF" />
                     <SolidColorBrush x:Key="CyberSelectedBorderBrush" Color="#B0007C" />
+                    <SolidColorBrush x:Key="CyberSelectedForegroundBrush" Color="#6F004F" />
                     <SolidColorBrush x:Key="CyberPrimaryButtonForegroundBrush" Color="#001B22" />
                     <SolidColorBrush x:Key="CyberPressedButtonForegroundBrush" Color="#101018" />
                     <SolidColorBrush x:Key="CyberFocusBorderBrush" Color="#7A4D00" />

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -50,22 +50,9 @@
             <Setter Property="BorderBrush" Value="{DynamicResource CyberSelectedBorderBrush}" />
             <Setter Property="BorderThickness" Value="6,1,1,1" />
             <Setter Property="CornerRadius" Value="4" />
-            <Setter Property="Foreground" Value="#F4F7FF" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberSelectedForegroundBrush}" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Opacity" Value="1" />
-        </Style>
-
-        <Style Selector="TextBlock.nav-glyph">
-            <Setter Property="FontSize" Value="13" />
-            <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="{DynamicResource CyberHelperTextBrush}" />
-            <Setter Property="Width" Value="42" />
-            <Setter Property="TextAlignment" Value="Center" />
-            <Setter Property="VerticalAlignment" Value="Center" />
-        </Style>
-
-        <Style Selector="Button.nav-button.active TextBlock.nav-glyph">
-            <Setter Property="Foreground" Value="{DynamicResource CyberAccentBrush}" />
         </Style>
 
         <Style Selector="Button.support-work-button">
@@ -164,7 +151,6 @@
                         Classes.active="{Binding IsDecompileSelected}"
                         IsVisible="{Binding IsDecompileEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[D]"/>
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuDecompile]}"/>
                     </StackPanel>
                 </Button>
@@ -173,7 +159,6 @@
                         Classes.active="{Binding IsBuildSelected}"
                         IsVisible="{Binding IsBuildEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[B]"/>
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuBuild]}"/>
                     </StackPanel>
                 </Button>
@@ -182,7 +167,6 @@
                         Classes.active="{Binding IsPatchSelected}"
                         IsVisible="{Binding IsPatchEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[P]"/>
                         <TextBlock Text="{Binding MenuPatchLabel}"/>
                     </StackPanel>
                 </Button>
@@ -191,7 +175,6 @@
                         Classes.active="{Binding IsAnalyserSelected}"
                         IsVisible="{Binding IsAnalyserEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[A]"/>
                         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[MenuAnalyser]}"/>
                     </StackPanel>
                 </Button>
@@ -200,7 +183,6 @@
                         Classes.active="{Binding IsDeviceToolsSelected}"
                         IsVisible="{Binding IsDeviceToolsEnabled}">
                     <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Classes="nav-glyph" Text="[DEV]"/>
                         <TextBlock Text="{Binding MenuDeviceToolsLabel}"/>
                     </StackPanel>
                 </Button>


### PR DESCRIPTION
### Motivation
- Remove the bracket-style shortcut hints shown next to sidebar menu labels and make the selected (active) sidebar item color more distinguishable in light theme.

### Description
- Deleted the `TextBlock` glyph hint elements from the sidebar buttons in `src/PulseAPK.Avalonia/MainWindow.axaml` so buttons display only their localized menu text.
- Removed the `TextBlock.nav-glyph` style and references so shortcut hints are no longer styled or shown.
- Replaced the hard-coded active-button foreground with a theme resource in `src/PulseAPK.Avalonia/MainWindow.axaml` and added `CyberSelectedForegroundBrush` to the theme dictionaries in `src/PulseAPK.Avalonia/App.axaml`.
- Increased light-mode contrast by adjusting `CyberSelectedBrush` (light) and setting `CyberSelectedForegroundBrush` (light) to a stronger pairing, while adding a dark-mode selected foreground color.

### Testing
- Attempted to run automated tests with `dotnet test` but it could not be executed because `dotnet` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa8e369548322baeb3c220042a29e)