### PR TITLE
Fix terminal hover/focus colors to respect light/dark themes

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -80,7 +80,7 @@
 
 
         <Style Selector="TextBox.terminal-output">
-            <Setter Property="Background" Value="#02060D" />
+            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
             <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="6" />
@@ -89,6 +89,18 @@
             <Setter Property="Padding" Value="14,10" />
             <Setter Property="SelectionBrush" Value="{DynamicResource CyberAccentMutedBrush}" />
             <Setter Property="SelectionForegroundBrush" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
+        <Style Selector="TextBox.terminal-output:pointerover">
+            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberAccentBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
+        </Style>
+
+        <Style Selector="TextBox.terminal-output:focus">
+            <Setter Property="Background" Value="{DynamicResource CyberConsoleBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource CyberFocusBorderBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource CyberConsoleForegroundBrush}" />
         </Style>
 
         <Style Selector="ComboBox">


### PR DESCRIPTION
### Motivation
- Prevent the terminal area from flashing to white in light mode by making hover/focus styling theme-aware.
- Keep terminal foreground, background and border consistent across light and dark modes so the console remains readable.

### Description
- Replace hard-coded terminal background (`#02060D`) with the theme resource `CyberConsoleBackgroundBrush` in `src/PulseAPK.Avalonia/App.axaml`.
- Add explicit styles for `TextBox.terminal-output:pointerover` and `TextBox.terminal-output:focus` to preserve background, border and foreground using theme resources.
- Change affects only styling in `App.axaml` and does not alter runtime logic.

### Testing
- Ran `git diff --check` and it completed without issues.
- Attempted `dotnet build PulseAPK.sln` but it could not be executed in this environment because `dotnet` is not installed (build not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2faabbcd848322ad29736247ce9aeb)