### PR TITLE
Add object scaling slider and background color choices in Settings (persisted)

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml.cs
+++ b/src/PulseAPK.Avalonia/App.axaml.cs
@@ -31,7 +31,7 @@ public partial class App : Application
         var settingsService = Services.GetRequiredService<ISettingsService>();
         LocalizationService.Instance.Initialize(settingsService);
         var themeService = Services.GetRequiredService<IThemeService>();
-        themeService.ApplyTheme(settingsService.Settings.ThemeMode);
+        themeService.ApplyVisualPreferences(settingsService.Settings.ThemeMode, settingsService.Settings.BackgroundColor, settingsService.Settings.ObjectScale);
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -67,7 +67,12 @@
 
         <!-- Content -->
         <Border Grid.Column="1" Background="{DynamicResource MainBackgroundBrush}" Padding="20">
-            <ContentControl Content="{Binding CurrentView}"/>
+            <ContentControl Content="{Binding CurrentView}">
+                <ContentControl.LayoutTransform>
+                    <ScaleTransform ScaleX="{DynamicResource UiObjectScale}"
+                                    ScaleY="{DynamicResource UiObjectScale}" />
+                </ContentControl.LayoutTransform>
+            </ContentControl>
         </Border>
     </Grid>
 </Window>

--- a/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
+++ b/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Media;
 using Avalonia.Styling;
 using PulseAPK.Core.Abstractions;
 using System;
@@ -7,15 +8,40 @@ namespace PulseAPK.Avalonia.Services;
 
 public sealed class AvaloniaThemeService : IThemeService
 {
+    private const string DefaultBackground = "#121212";
+    private const double DefaultScale = 1.0;
+    private const double MinimumScale = 0.75;
+    private const double MaximumScale = 1.5;
+
     public void ApplyTheme(string? themeMode)
+    {
+        ApplyVisualPreferences(themeMode, DefaultBackground, DefaultScale);
+    }
+
+    public void ApplyVisualPreferences(string? themeMode, string? backgroundColor, double objectScale)
     {
         if (Application.Current is null)
         {
             return;
         }
 
-        Application.Current.RequestedThemeVariant = string.Equals(themeMode, "light_mode", StringComparison.OrdinalIgnoreCase)
-            ? ThemeVariant.Light
-            : ThemeVariant.Dark;
+        var isLightMode = string.Equals(themeMode, "light_mode", StringComparison.OrdinalIgnoreCase);
+        Application.Current.RequestedThemeVariant = isLightMode ? ThemeVariant.Light : ThemeVariant.Dark;
+
+        var resources = Application.Current.Resources;
+        var normalizedScale = Math.Clamp(objectScale, MinimumScale, MaximumScale);
+        resources["UiObjectScale"] = normalizedScale;
+
+        if (string.IsNullOrWhiteSpace(backgroundColor)
+            || string.Equals(backgroundColor, DefaultBackground, StringComparison.OrdinalIgnoreCase))
+        {
+            resources["MainBackgroundBrush"] = new SolidColorBrush(isLightMode ? Color.Parse("#FFFFFF") : Color.Parse("#121212"));
+            return;
+        }
+
+        if (Color.TryParse(backgroundColor, out var color))
+        {
+            resources["MainBackgroundBrush"] = new SolidColorBrush(color);
+        }
     }
 }

--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -33,6 +33,31 @@
             </ComboBox.ItemTemplate>
         </ComboBox>
 
+        <TextBlock Text="Object size"
+                   FontWeight="SemiBold" />
+        <Grid ColumnDefinitions="260,Auto" ColumnSpacing="12">
+            <Slider Minimum="0.75"
+                    Maximum="1.5"
+                    TickFrequency="0.05"
+                    IsSnapToTickEnabled="True"
+                    Value="{Binding ObjectScale}" />
+            <TextBlock Grid.Column="1"
+                       VerticalAlignment="Center"
+                       Text="{Binding ObjectScale, StringFormat={}{0:P0}}" />
+        </Grid>
+
+        <TextBlock Text="Background color"
+                   FontWeight="SemiBold" />
+        <ComboBox ItemsSource="{Binding AvailableBackgroundColors}"
+                  SelectedItem="{Binding SelectedBackgroundColor}"
+                  Width="260">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}" />
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
+
         <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[ApktoolPath]}"
                    FontWeight="SemiBold" />
         <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">

--- a/src/PulseAPK.Core/Abstractions/IThemeService.cs
+++ b/src/PulseAPK.Core/Abstractions/IThemeService.cs
@@ -6,4 +6,5 @@ namespace PulseAPK.Core.Abstractions;
 public interface IThemeService
 {
     void ApplyTheme(string? themeMode);
+    void ApplyVisualPreferences(string? themeMode, string? backgroundColor, double objectScale);
 }

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -10,6 +10,8 @@ namespace PulseAPK.Core.Services
         public string UbersignPath { get; set; } = string.Empty;
         public string SelectedLanguage { get; set; } = "en-US";
         public string ThemeMode { get; set; } = "dark_mode";
+        public string BackgroundColor { get; set; } = "#121212";
+        public double ObjectScale { get; set; } = 1.0;
     }
 
     public interface ISettingsService

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -31,14 +31,27 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     private ThemeModeItem _selectedThemeMode = null!;
+
+    [ObservableProperty]
+    private BackgroundColorItem _selectedBackgroundColor = null!;
+
+    [ObservableProperty]
+    private double _objectScale = 1.0;
     
     public List<LanguageItem> AvailableLanguages => _localizationService.AvailableLanguages;
     private List<ThemeModeItem> _availableThemeModes = [];
+    private List<BackgroundColorItem> _availableBackgroundColors = [];
 
     public List<ThemeModeItem> AvailableThemeModes
     {
         get => _availableThemeModes;
         private set => SetProperty(ref _availableThemeModes, value);
+    }
+
+    public List<BackgroundColorItem> AvailableBackgroundColors
+    {
+        get => _availableBackgroundColors;
+        private set => SetProperty(ref _availableBackgroundColors, value);
     }
 
     public SettingsViewModel(
@@ -61,8 +74,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _apktoolPath = _settingsService.Settings.ApktoolPath;
         _ubersignPath = _settingsService.Settings.UbersignPath;
         _selectedLanguage = _localizationService.CurrentLanguage;
+        _objectScale = ClampObjectScale(_settingsService.Settings.ObjectScale);
 
         RefreshThemeModes(_settingsService.Settings.ThemeMode);
+        RefreshBackgroundColors(_settingsService.Settings.BackgroundColor);
         _localizationService.PropertyChanged += OnLocalizationChanged;
 
         NormalizeManagedToolPathsIfMissing();
@@ -99,7 +114,33 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
         _settingsService.Settings.ThemeMode = value.Key;
         _settingsService.Save();
-        _themeService.ApplyTheme(value.Key);
+        ApplyVisualPreferences();
+    }
+
+    partial void OnSelectedBackgroundColorChanged(BackgroundColorItem value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        _settingsService.Settings.BackgroundColor = value.ColorValue;
+        _settingsService.Save();
+        ApplyVisualPreferences();
+    }
+
+    partial void OnObjectScaleChanged(double value)
+    {
+        var normalized = ClampObjectScale(value);
+        if (Math.Abs(normalized - value) > 0.001)
+        {
+            ObjectScale = normalized;
+            return;
+        }
+
+        _settingsService.Settings.ObjectScale = normalized;
+        _settingsService.Save();
+        ApplyVisualPreferences();
     }
 
     [RelayCommand]
@@ -221,6 +262,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         if (e.PropertyName == "Item[]" || e.PropertyName == string.Empty)
         {
             RefreshThemeModes(SelectedThemeMode?.Key);
+            RefreshBackgroundColors(SelectedBackgroundColor?.ColorValue);
         }
     }
 
@@ -233,6 +275,37 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         ];
 
         SelectedThemeMode = ResolveThemeMode(selectedThemeKey);
+    }
+
+    private void RefreshBackgroundColors(string? selectedColor)
+    {
+        AvailableBackgroundColors =
+        [
+            new BackgroundColorItem("#121212", "Charcoal"),
+            new BackgroundColorItem("#1E3A8A", "Blue"),
+            new BackgroundColorItem("#14532D", "Green"),
+            new BackgroundColorItem("#581C87", "Purple"),
+            new BackgroundColorItem("#7F1D1D", "Red"),
+            new BackgroundColorItem("#78350F", "Amber"),
+            new BackgroundColorItem("#134E4A", "Teal"),
+            new BackgroundColorItem("#4A044E", "Magenta"),
+            new BackgroundColorItem("#111827", "Slate"),
+            new BackgroundColorItem("#701A75", "Fuchsia")
+        ];
+
+        SelectedBackgroundColor = AvailableBackgroundColors.FirstOrDefault(color =>
+                                      string.Equals(color.ColorValue, selectedColor, StringComparison.OrdinalIgnoreCase))
+                                  ?? AvailableBackgroundColors[0];
+    }
+
+    private void ApplyVisualPreferences()
+    {
+        _themeService.ApplyVisualPreferences(SelectedThemeMode?.Key, SelectedBackgroundColor?.ColorValue, ObjectScale);
+    }
+
+    private static double ClampObjectScale(double value)
+    {
+        return Math.Clamp(value, 0.75, 1.5);
     }
 
     private ThemeModeItem ResolveThemeMode(string? themeMode)
@@ -255,3 +328,5 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 }
 
 public sealed record ThemeModeItem(string Key, string Name);
+
+public sealed record BackgroundColorItem(string ColorValue, string Name);


### PR DESCRIPTION
### Motivation
- Enable users to make UI objects smaller or larger with a simple control while preserving the current default scale.
- Allow choosing a background color from a short, curated palette to customise the main view while keeping the existing dark default.
- Provide persistence so visual preferences survive restarts and apply at startup.

### Description
- Added persistent settings fields `BackgroundColor` and `ObjectScale` to `AppSettings` in `src/PulseAPK.Core/Services/SettingsService.cs` with defaults `#121212` and `1.0` respectively.
- Extended the theme abstraction by adding `ApplyVisualPreferences(string? themeMode, string? backgroundColor, double objectScale)` to `IThemeService` and implemented it in `src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs` to apply theme variant, background brush and a clamped UI scale resource (`UiObjectScale`).
- Apply saved visual preferences on startup by calling `ApplyVisualPreferences` from `src/PulseAPK.Avalonia/App.axaml.cs` using settings values.
- Added a slider and background-color picker UI to `src/PulseAPK.Avalonia/Views/SettingsView.axaml` and the corresponding view-model support in `src/PulseAPK.Core/ViewModels/SettingsViewModel.cs` including `BackgroundColorItem`, `ObjectScale`, persistence on change, and a `ClampObjectScale` helper; the slider range is `0.75`–`1.5` with default `1.0` and the picker exposes 10 named color choices.
- Apply object scaling to the main content by using a `ScaleTransform` bound to the dynamic resource `UiObjectScale` in `src/PulseAPK.Avalonia/MainWindow.axaml` so changes take effect immediately.
- Searched the repository for the misspelling `Mous` and found no matching source text to update, so no renaming was required.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues and it completed without errors.
- Attempted to run `dotnet build PulseAPK.sln` but it could not be executed in this environment because `dotnet` is not installed, so a full build verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44644323248322a31ebed4d755bda3)