### PR TITLE
Propagate visual preferences across UI

### DIFF
--- a/src/PulseAPK.Avalonia/App.axaml
+++ b/src/PulseAPK.Avalonia/App.axaml
@@ -10,6 +10,7 @@
 
     <Application.Resources>
         <ResourceDictionary>
+            <SolidColorBrush x:Key="MainBackgroundBrush" Color="#121212" />
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Dark">
                     <SolidColorBrush x:Key="SidebarBackgroundBrush" Color="#202020" />

--- a/src/PulseAPK.Avalonia/MainWindow.axaml
+++ b/src/PulseAPK.Avalonia/MainWindow.axaml
@@ -33,7 +33,12 @@
         </DataTemplate>
     </Window.DataTemplates>
 
-    <Grid ColumnDefinitions="220, *">
+    <Grid ColumnDefinitions="220, *"
+          Background="{DynamicResource MainBackgroundBrush}">
+        <Grid.LayoutTransform>
+            <ScaleTransform ScaleX="{DynamicResource UiObjectScale}"
+                            ScaleY="{DynamicResource UiObjectScale}" />
+        </Grid.LayoutTransform>
         <!-- Sidebar -->
         <Border Grid.Column="0" Background="{DynamicResource SidebarBackgroundBrush}" Padding="16">
             <StackPanel Spacing="10">
@@ -67,12 +72,7 @@
 
         <!-- Content -->
         <Border Grid.Column="1" Background="{DynamicResource MainBackgroundBrush}" Padding="20">
-            <ContentControl Content="{Binding CurrentView}">
-                <ContentControl.LayoutTransform>
-                    <ScaleTransform ScaleX="{DynamicResource UiObjectScale}"
-                                    ScaleY="{DynamicResource UiObjectScale}" />
-                </ContentControl.LayoutTransform>
-            </ContentControl>
+            <ContentControl Content="{Binding CurrentView}" />
         </Border>
     </Grid>
 </Window>

--- a/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
+++ b/src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media;
 using Avalonia.Styling;
 using PulseAPK.Core.Abstractions;
@@ -8,14 +9,15 @@ namespace PulseAPK.Avalonia.Services;
 
 public sealed class AvaloniaThemeService : IThemeService
 {
-    private const string DefaultBackground = "#121212";
+    private const string DefaultDarkBackground = "#121212";
+    private const string DefaultLightBackground = "#FFFFFF";
     private const double DefaultScale = 1.0;
     private const double MinimumScale = 0.75;
     private const double MaximumScale = 1.5;
 
     public void ApplyTheme(string? themeMode)
     {
-        ApplyVisualPreferences(themeMode, DefaultBackground, DefaultScale);
+        ApplyVisualPreferences(themeMode, DefaultDarkBackground, DefaultScale);
     }
 
     public void ApplyVisualPreferences(string? themeMode, string? backgroundColor, double objectScale)
@@ -32,16 +34,36 @@ public sealed class AvaloniaThemeService : IThemeService
         var normalizedScale = Math.Clamp(objectScale, MinimumScale, MaximumScale);
         resources["UiObjectScale"] = normalizedScale;
 
-        if (string.IsNullOrWhiteSpace(backgroundColor)
-            || string.Equals(backgroundColor, DefaultBackground, StringComparison.OrdinalIgnoreCase))
-        {
-            resources["MainBackgroundBrush"] = new SolidColorBrush(isLightMode ? Color.Parse("#FFFFFF") : Color.Parse("#121212"));
-            return;
-        }
+        var backgroundBrush = CreateBackgroundBrush(backgroundColor, isLightMode);
+        SetApplicationResource(resources, "MainBackgroundBrush", backgroundBrush);
 
-        if (Color.TryParse(backgroundColor, out var color))
+        if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop
+            && desktop.MainWindow is not null)
         {
-            resources["MainBackgroundBrush"] = new SolidColorBrush(color);
+            desktop.MainWindow.Background = backgroundBrush;
+        }
+    }
+
+    private static SolidColorBrush CreateBackgroundBrush(string? backgroundColor, bool isLightMode)
+    {
+        var defaultBackground = isLightMode ? DefaultLightBackground : DefaultDarkBackground;
+        var colorValue = string.IsNullOrWhiteSpace(backgroundColor)
+            || (!isLightMode && string.Equals(backgroundColor, DefaultDarkBackground, StringComparison.OrdinalIgnoreCase))
+            ? defaultBackground
+            : backgroundColor;
+
+        return Color.TryParse(colorValue, out var color)
+            ? new SolidColorBrush(color)
+            : new SolidColorBrush(Color.Parse(defaultBackground));
+    }
+
+    private static void SetApplicationResource(ResourceDictionary resources, string key, object value)
+    {
+        resources[key] = value;
+
+        foreach (var themeDictionary in resources.ThemeDictionaries.Values)
+        {
+            themeDictionary[key] = value;
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the user-selected background color and object-size (scale) preferences affect the whole window (sidebar, navigation and content) rather than only the active page content. 
- Provide a stable app-level background resource that can be updated at runtime and propagated into theme dictionaries and the desktop main window.

### Description
- Move the `UiObjectScale` application from the inner `ContentControl` to the main window root so the entire shell scales together (`src/PulseAPK.Avalonia/MainWindow.axaml`).
- Add a default `MainBackgroundBrush` application-level resource so the background brush exists outside theme dictionaries (`src/PulseAPK.Avalonia/App.axaml`).
- Update `AvaloniaThemeService` to clamp and publish `UiObjectScale`, create a `MainBackgroundBrush` from settings, update that brush in app resources and all theme dictionaries, and apply it to the desktop `MainWindow.Background` when available (`src/PulseAPK.Avalonia/Services/AvaloniaThemeService.cs`).
- Remove the redundant per-content layout-transform and keep content rendering bound to `CurrentView` so scale and background changes come from the window shell.

### Testing
- Ran `git diff --check` which completed without issues.
- Attempted `dotnet build PulseAPK.sln` but it could not be executed in this environment because `dotnet` is not installed, so a full build/test was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4465fac294832298dbf4eb27656db0)