### PR TITLE
Add macOS arm64 CI job and consolidate release artifact uploads

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 jobs:
-  build-and-draft-release:
+  build-linux-windows:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,6 +33,49 @@ jobs:
       - name: Build Windows binaries
         run: OUTPUT_EXE_NAME=PulseAPK-win-x64.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
 
+      - name: Upload Linux and Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-linux-windows-release-assets
+          path: |
+            artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
+            artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe
+          if-no-files-found: error
+
+  build-macos-arm64:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build macOS arm64 app bundle
+        run: RID=osx-arm64 ./scripts/build-macos-binary.sh
+
+      - name: Upload macOS arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-osx-arm64-release-assets
+          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.tar.gz
+          if-no-files-found: error
+
+  draft-release:
+    needs:
+      - build-linux-windows
+      - build-macos-arm64
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
       - name: Create draft release with binary assets
         uses: softprops/action-gh-release@v2
         with:
@@ -40,5 +83,6 @@ jobs:
           name: CI Build ${{ github.run_number }}
           draft: true
           files: |
-            artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
-            artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe
+            release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-linux-x64.AppImage
+            release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-win-x64.exe
+            release-assets/PulseAPK-osx-arm64-release-assets/PulseAPK-osx-arm64.tar.gz

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -45,3 +45,25 @@ jobs:
             artifacts/windows/win-x64/publish/*.exe
             artifacts/windows/win-x64/PulseAPK-win-x64.zip
           if-no-files-found: error
+
+  build-macos-arm64:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build macOS arm64 app bundle
+        run: RID=osx-arm64 ./scripts/build-macos-binary.sh
+
+      - name: Upload macOS arm64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-osx-arm64-app
+          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.tar.gz
+          if-no-files-found: error

--- a/README.MD
+++ b/README.MD
@@ -92,6 +92,7 @@ PulseAPK includes a built-in static analyzer that scans decompiled code for comm
 2.  **Apktool**: You can download `apktool.jar` directly from PulseAPK by pressing the download button in **Settings**, or provide it manually from [ibotpeaches.github.io](https://ibotpeaches.github.io/Apktool/).
 3.  **Ubersign (Uber APK Signer)**: Required for signing rebuilt APKs. You can download the latest `uber-apk-signer.jar` automatically in **Settings**, or still provide it manually from the [GitHub releases](https://github.com/patrickfav/uber-apk-signer/releases).
 4.  **.NET 8.0 Runtime**: Required to run PulseAPK on supported platforms (Windows, Linux, and macOS).
+5.  **macOS hosts**: PulseAPK macOS release artifacts target Apple Silicon only (`osx-arm64`). Intel/x64 macOS builds are not produced.
 
 ## Quick Start Guide
 
@@ -99,6 +100,11 @@ PulseAPK includes a built-in static analyzer that scans decompiled code for comm
     ```powershell
     dotnet build
     dotnet run
+    ```
+
+    To create the macOS Apple Silicon app bundle artifact:
+    ```bash
+    RID=osx-arm64 ./scripts/build-macos-binary.sh
     ```
 
 2.  **Setup**

--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -13,7 +13,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
-rid="${RID:-osx-x64}"
+rid="${RID:-osx-arm64}"
 app_name="${APP_NAME:-PulseAPK}"
 bundle_name="${APP_BUNDLE_NAME:-PulseAPK}"
 app_exe="${app_name}"
@@ -28,8 +28,8 @@ if ! command -v dotnet >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ "${rid}" != osx-* ]]; then
-  echo "RID must target macOS (for example 'osx-x64' or 'osx-arm64'). Received '${rid}'." >&2
+if [[ "${rid}" != "osx-arm64" ]]; then
+  echo "PulseAPK macOS releases are arm64 only. Set RID=osx-arm64 (received '${rid}')." >&2
   exit 1
 fi
 


### PR DESCRIPTION
### Motivation
- Add a dedicated macOS Apple Silicon build to CI and ensure release drafts include macOS artifacts alongside Linux and Windows builds.
- Make macOS build expectations explicit by restricting macOS artifacts to `osx-arm64` and documenting that constraint in the README.

### Description
- Split the build workflow into `build-linux-windows` and `build-macos-arm64` jobs and add a `draft-release` job that downloads uploaded artifacts and creates a single draft release with all binaries.
- Upload Linux and Windows artifacts as a combined artifact and upload the macOS `osx-arm64` artifact separately, then update `softprops/action-gh-release` `files` to reference the downloaded artifact paths.
- Change `scripts/build-macos-binary.sh` to default `RID` to `osx-arm64` and enforce an arm64-only `RID` check with a clearer error message.
- Update `README.MD` to note that macOS release artifacts target Apple Silicon only and add the `RID=osx-arm64 ./scripts/build-macos-binary.sh` example.

### Testing
- No automated tests were executed as part of this change; CI workflow and build script behavior will be validated when the updated GitHub Actions run on push or via `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ebe6b6ac83229db3dd609b53dbb4)