### PR TITLE
Derive macOS bundle version from project

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -23,6 +23,16 @@ publish_dir="${out_root}/publish"
 bundle_dir="${out_root}/${bundle_name}.app"
 archive_path="${out_root}/${bundle_name}-${rid}.tar.gz"
 
+version="${VERSION:-}"
+if [[ -z "${version}" ]]; then
+  version="$(sed -nE 's:^[[:space:]]*<Version>([^<]+)</Version>[[:space:]]*$:\1:p' "${project_path}" | head -n 1)"
+fi
+
+if [[ -z "${version}" ]]; then
+  version="1.0.0"
+  echo "Unable to determine project version; falling back to ${version}." >&2
+fi
+
 if ! command -v dotnet >/dev/null 2>&1; then
   echo "dotnet is required but was not found in PATH." >&2
   exit 1
@@ -111,9 +121,9 @@ cat > "${bundle_contents}/Info.plist" <<PLIST
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>${version}</string>
   <key>CFBundleVersion</key>
-  <string>1.0.0</string>
+  <string>${version}</string>
   <key>LSMinimumSystemVersion</key>
   <string>11.0</string>
   <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
### Motivation
- Prevent hardcoded macOS bundle versions and keep the app bundle metadata in sync with the project version declared in the csproj.
- Allow CI/packaging to override the version via an environment variable while providing a safe fallback when extraction fails.

### Description
- Added a `version` variable in `scripts/build-macos-binary.sh` that prefers the `VERSION` environment variable and otherwise extracts the `<Version>` element from `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` using `sed`.
- Fall back to `1.0.0` and emit a warning to stderr if no version can be determined.
- Updated the generated `Info.plist` in the macOS bundle to set both `CFBundleShortVersionString` and `CFBundleVersion` to `${version}` instead of a hardcoded value.
- Changes are contained in `scripts/build-macos-binary.sh` and use the existing `project_path` variable to locate the csproj file.

### Testing
- Ran the `sed` extraction used by the script (`sed -nE 's:^[[:space:]]*<Version>([^<]+)</Version>[[:space:]]*$:\1:p' src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj | head -n 1`) which returned `1.2.8` as expected.
- Validated the script syntax with `bash -n scripts/build-macos-binary.sh` which succeeded without errors.
- Verified `git diff --check` reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45f152013c8322992ac855393be079)