### PR TITLE
Add macOS bundle signing step

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -132,6 +132,17 @@ cat > "${bundle_contents}/Info.plist" <<PLIST
 </plist>
 PLIST
 
+if command -v codesign >/dev/null 2>&1; then
+  echo "Ad-hoc signing macOS app bundle: ${bundle_dir}"
+  codesign --force --deep --sign - "${bundle_dir}"
+  codesign --verify --deep --strict "${bundle_dir}"
+elif [[ "$(uname -s)" == "Darwin" ]]; then
+  echo "codesign is required to sign macOS app bundles on Darwin but was not found in PATH." >&2
+  exit 1
+else
+  echo "Warning: codesign was not found in PATH; skipping macOS app bundle signing." >&2
+fi
+
 if command -v tar >/dev/null 2>&1; then
   rm -f "${archive_path}"
   (


### PR DESCRIPTION
### Motivation
- Ensure macOS app bundles are signed after `Info.plist` generation so distributions are valid on macOS and CI can enforce signing when appropriate.

### Description
- After the `Info.plist` block, add a `codesign` check that runs `codesign --force --deep --sign - "${bundle_dir}"` and then verifies with `codesign --verify --deep --strict "${bundle_dir}"` when `codesign` is available.
- If `codesign` is missing on Darwin the script now fails with a clear error, while on non-Darwin hosts it prints a warning and continues.

### Testing
- Ran a syntax check with `bash -n scripts/build-macos-binary.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45f20080688322943c1ce873a9ca31)