### PR TITLE
Gate Device Tools with persisted setting

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -104,6 +104,9 @@
                                 Command="{Binding BrowseAdbCommand}"
                                 Width="110" />
                     </Grid>
+
+                    <CheckBox Content="Enable Device Tools"
+                              IsChecked="{Binding IsDeviceToolsEnabled}" />
                 </StackPanel>
             </Border>
         </StackPanel>

--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -11,12 +11,14 @@ namespace PulseAPK.Core.Services
         public string AdbPath { get; set; } = string.Empty;
         public string SelectedLanguage { get; set; } = "en-US";
         public string ThemeMode { get; set; } = "dark_mode";
+        public bool IsDeviceToolsEnabled { get; set; } = false;
     }
 
     public interface ISettingsService
     {
         AppSettings Settings { get; }
         string SettingsDirectory { get; }
+        event EventHandler? SettingsChanged;
         void Save();
     }
 
@@ -29,6 +31,7 @@ namespace PulseAPK.Core.Services
         private readonly string _legacySettingsFilePath;
 
         public AppSettings Settings { get; private set; }
+        public event EventHandler? SettingsChanged;
         public string SettingsDirectory { get; }
 
         public SettingsService()
@@ -100,6 +103,7 @@ namespace PulseAPK.Core.Services
         public void Save()
         {
             Save(Settings);
+            SettingsChanged?.Invoke(this, EventArgs.Empty);
         }
 
         private void Save(AppSettings settings)

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -15,6 +15,7 @@ public partial class MainViewModel : ObservableObject
 
     private readonly LocalizationService _localizationService;
     private readonly ISystemService _systemService;
+    private readonly ISettingsService _settingsService;
 
     [ObservableProperty]
     private object _currentView = null!;
@@ -47,20 +48,23 @@ public partial class MainViewModel : ObservableObject
     public bool IsBuildEnabled => FeatureFlags.BuildApk;
     public bool IsPatchEnabled => FeatureFlags.PatchApk;
     public bool IsAnalyserEnabled => FeatureFlags.ApkAnalyser;
-    public bool IsDeviceToolsEnabled => FeatureFlags.DeviceTools;
+    public bool IsDeviceToolsEnabled => FeatureFlags.DeviceTools && _settingsService.Settings.IsDeviceToolsEnabled;
     public bool IsSettingsEnabled => FeatureFlags.Settings;
     public bool IsAboutEnabled => FeatureFlags.About;
 
     public MainViewModel(
         IServiceProvider serviceProvider,
         LocalizationService localizationService,
-        ISystemService systemService)
+        ISystemService systemService,
+        ISettingsService settingsService)
     {
         _serviceProvider = serviceProvider;
         _localizationService = localizationService;
         _systemService = systemService;
+        _settingsService = settingsService;
         WindowTitle = _localizationService["AppTitle"];
         _localizationService.PropertyChanged += HandleLocalizationChanged;
+        _settingsService.SettingsChanged += HandleSettingsChanged;
         SetInitialView();
     }
 
@@ -139,41 +143,86 @@ public partial class MainViewModel : ObservableObject
         OnPropertyChanged(nameof(IsAboutSelected));
     }
 
-    private static bool CanNavigateToDecompile() => FeatureFlags.Decompile;
-    private static bool CanNavigateToBuild() => FeatureFlags.BuildApk;
-    private static bool CanNavigateToPatch() => FeatureFlags.PatchApk;
-    private static bool CanNavigateToAnalyser() => FeatureFlags.ApkAnalyser;
-    private static bool CanNavigateToDeviceTools() => FeatureFlags.DeviceTools;
-    private static bool CanNavigateToSettings() => FeatureFlags.Settings;
-    private static bool CanNavigateToAbout() => FeatureFlags.About;
+    private bool CanNavigateToDecompile() => FeatureFlags.Decompile;
+    private bool CanNavigateToBuild() => FeatureFlags.BuildApk;
+    private bool CanNavigateToPatch() => FeatureFlags.PatchApk;
+    private bool CanNavigateToAnalyser() => FeatureFlags.ApkAnalyser;
+    private bool CanNavigateToDeviceTools() => IsDeviceToolsEnabled;
+    private bool CanNavigateToSettings() => FeatureFlags.Settings;
+    private bool CanNavigateToAbout() => FeatureFlags.About;
 
-    private void SetInitialView()
+
+    private void HandleSettingsChanged(object? sender, EventArgs e)
     {
-        if (FeatureFlags.Decompile)
+        OnPropertyChanged(nameof(IsDeviceToolsEnabled));
+        NavigateToDeviceToolsCommand.NotifyCanExecuteChanged();
+
+        if (IsDeviceToolsSelected && !CanNavigateToDeviceTools())
+        {
+            NavigateToFirstAvailableEnabledTab();
+        }
+    }
+
+    private void NavigateToFirstAvailableEnabledTab()
+    {
+        if (CanNavigateToDecompile())
         {
             NavigateToDecompile();
         }
-        else if (FeatureFlags.BuildApk)
+        else if (CanNavigateToBuild())
         {
             NavigateToBuild();
         }
-        else if (FeatureFlags.PatchApk)
+        else if (CanNavigateToPatch())
         {
             NavigateToPatch();
         }
-        else if (FeatureFlags.ApkAnalyser)
+        else if (CanNavigateToAnalyser())
         {
             NavigateToAnalyser();
         }
-        else if (FeatureFlags.DeviceTools)
-        {
-            NavigateToDeviceTools();
-        }
-        else if (FeatureFlags.Settings)
+        else if (CanNavigateToSettings())
         {
             NavigateToSettings();
         }
-        else if (FeatureFlags.About)
+        else if (CanNavigateToAbout())
+        {
+            NavigateToAbout();
+        }
+        else
+        {
+            CurrentView = "No features are enabled.";
+            SelectedMenu = string.Empty;
+        }
+    }
+
+    private void SetInitialView()
+    {
+        if (CanNavigateToDecompile())
+        {
+            NavigateToDecompile();
+        }
+        else if (CanNavigateToBuild())
+        {
+            NavigateToBuild();
+        }
+        else if (CanNavigateToPatch())
+        {
+            NavigateToPatch();
+        }
+        else if (CanNavigateToAnalyser())
+        {
+            NavigateToAnalyser();
+        }
+        else if (CanNavigateToDeviceTools())
+        {
+            NavigateToDeviceTools();
+        }
+        else if (CanNavigateToSettings())
+        {
+            NavigateToSettings();
+        }
+        else if (CanNavigateToAbout())
         {
             NavigateToAbout();
         }

--- a/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/SettingsViewModel.cs
@@ -32,6 +32,9 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     private bool _isDownloadingTools;
+
+    [ObservableProperty]
+    private bool _isDeviceToolsEnabled;
     
     [ObservableProperty]
     private LanguageItem _selectedLanguage;
@@ -71,6 +74,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _ubersignPath = _settingsService.Settings.UbersignPath;
         _adbPath = _settingsService.Settings.AdbPath;
         _selectedLanguage = _localizationService.CurrentLanguage;
+        _isDeviceToolsEnabled = _settingsService.Settings.IsDeviceToolsEnabled;
 
         RefreshThemeModes(_settingsService.Settings.ThemeMode);
         _localizationService.PropertyChanged += OnLocalizationChanged;
@@ -98,6 +102,12 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _ = RefreshAdbPathWatermarkAsync();
     }
     
+    partial void OnIsDeviceToolsEnabledChanged(bool value)
+    {
+        _settingsService.Settings.IsDeviceToolsEnabled = value;
+        _settingsService.Save();
+    }
+
     partial void OnSelectedLanguageChanged(LanguageItem value)
     {
         if (value != null && value.Code != _localizationService.CurrentLanguage.Code)


### PR DESCRIPTION
### Motivation
- Allow users to enable/disable Device Tools via a persisted setting while retaining `FeatureFlags.DeviceTools` as the global feature gate.
- Ensure the UI and navigation respect the persisted setting and update immediately when the user toggles it.

### Description
- Added `AppSettings.IsDeviceToolsEnabled` defaulting to `false` and exposed a `SettingsChanged` event on `ISettingsService` that is raised when `Save()` is called (`SettingsService`, `AppSettings`).
- Injected `ISettingsService` into `MainViewModel`, changed `IsDeviceToolsEnabled` to `FeatureFlags.DeviceTools && _settingsService.Settings.IsDeviceToolsEnabled`, and replaced static can-navigate checks with instance-level `CanNavigateTo*()` methods that use the persisted flag for Device Tools.
- Added `HandleSettingsChanged` in `MainViewModel` to raise `OnPropertyChanged(nameof(IsDeviceToolsEnabled))`, call `NavigateToDeviceToolsCommand.NotifyCanExecuteChanged()`, and navigate away to the first available enabled tab (preferring Decompile) if Device Tools is disabled while selected.
- Wired `SettingsViewModel` to surface and persist the new `IsDeviceToolsEnabled` setting via an `[ObservableProperty]` and `OnIsDeviceToolsEnabledChanged(bool)` that saves the setting, and added a `CheckBox` to `SettingsView.axaml` bound to `IsDeviceToolsEnabled`.

### Testing
- Ran `git diff --check` with no warnings (success).
- Attempted `dotnet build --no-restore` but it could not run in this environment because `dotnet` is not installed (build not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fcc3629c8322a2279f8bb95b1fde)