### PR TITLE
Add Device Tools beta setting card

### DIFF
--- a/src/PulseAPK.Avalonia/Views/SettingsView.axaml
+++ b/src/PulseAPK.Avalonia/Views/SettingsView.axaml
@@ -104,9 +104,21 @@
                                 Command="{Binding BrowseAdbCommand}"
                                 Width="110" />
                     </Grid>
+                </StackPanel>
+            </Border>
 
-                    <CheckBox Content="Enable Device Tools"
-                              IsChecked="{Binding IsDeviceToolsEnabled}" />
+            <Border Classes="card">
+                <StackPanel Spacing="12">
+                    <TextBlock Text="Beta Features"
+                               FontSize="13"
+                               FontWeight="SemiBold"
+                               Foreground="{DynamicResource CyberAccentBrush}" />
+
+                    <ToggleSwitch Content="Device Tools"
+                                  IsChecked="{Binding IsDeviceToolsEnabled}" />
+                    <TextBlock Text="{Binding Source={x:Static services:LocalizationService.Instance}, Path=[PatchBetaWarning]}"
+                               Classes="helper-text"
+                               TextWrapping="Wrap" />
                 </StackPanel>
             </Border>
         </StackPanel>


### PR DESCRIPTION
### Motivation
- Expose a toggle for enabling the Device Tools beta feature from the Settings UI so users can opt in/out without editing config files.
- Provide the same beta helper label style used by Patch functionality to make the experimental nature clear.

### Description
- Added a new `Beta Features` settings card in `src/PulseAPK.Avalonia/Views/SettingsView.axaml` containing a `ToggleSwitch` labeled `Device Tools` bound to `IsDeviceToolsEnabled`.
- Placed a helper label under the toggle that reuses the existing `PatchBetaWarning` localized resource and `helper-text` styling.
- Verified that `IsDeviceToolsEnabled` is exposed in `src/PulseAPK.Core/ViewModels/SettingsViewModel.cs`, is initialized from `_settingsService.Settings.IsDeviceToolsEnabled`, and that `OnIsDeviceToolsEnabledChanged` saves the new value back to `_settingsService.Settings` and calls `_settingsService.Save()`.

### Testing
- Ran `git diff --check` and it reported no whitespace/merge problems (success).
- Attempted `dotnet build` but it could not be executed in this environment because `dotnet` is not installed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ff09f3f48322af4da4762611a144)