### PR TITLE
Notify shell when device tools setting changes

### DIFF
--- a/src/PulseAPK.Core/Services/SettingsService.cs
+++ b/src/PulseAPK.Core/Services/SettingsService.cs
@@ -29,6 +29,7 @@ namespace PulseAPK.Core.Services
 
         private readonly string _settingsFilePath;
         private readonly string _legacySettingsFilePath;
+        private bool _lastSavedIsDeviceToolsEnabled;
 
         public AppSettings Settings { get; private set; }
         public event EventHandler? SettingsChanged;
@@ -42,6 +43,7 @@ namespace PulseAPK.Core.Services
             _settingsFilePath = Path.Combine(settingsFolder, SettingsFileName);
             _legacySettingsFilePath = Path.Combine(baseDirectory, SettingsFileName);
             Settings = LoadSettings();
+            _lastSavedIsDeviceToolsEnabled = Settings.IsDeviceToolsEnabled;
         }
 
         private static string ResolveSettingsFolder(string baseDirectory)
@@ -102,8 +104,15 @@ namespace PulseAPK.Core.Services
 
         public void Save()
         {
+            var didDeviceToolsSettingChange = _lastSavedIsDeviceToolsEnabled != Settings.IsDeviceToolsEnabled;
+
             Save(Settings);
-            SettingsChanged?.Invoke(this, EventArgs.Empty);
+
+            if (didDeviceToolsSettingChange)
+            {
+                _lastSavedIsDeviceToolsEnabled = Settings.IsDeviceToolsEnabled;
+                SettingsChanged?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         private void Save(AppSettings settings)

--- a/src/PulseAPK.Core/ViewModels/MainViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/MainViewModel.cs
@@ -8,7 +8,7 @@ using Properties = PulseAPK.Core.Properties;
 
 namespace PulseAPK.Core.ViewModels;
 
-public partial class MainViewModel : ObservableObject
+public partial class MainViewModel : ObservableObject, IDisposable
 {
     private readonly IServiceProvider _serviceProvider;
     private const string SupportWorkUrl = "https://yarygintech.com/support-work/";
@@ -16,6 +16,7 @@ public partial class MainViewModel : ObservableObject
     private readonly LocalizationService _localizationService;
     private readonly ISystemService _systemService;
     private readonly ISettingsService _settingsService;
+    private bool _disposed;
 
     [ObservableProperty]
     private object _currentView = null!;
@@ -254,6 +255,18 @@ public partial class MainViewModel : ObservableObject
         if (service == null)
             throw new InvalidOperationException($"Could not resolve service of type {typeof(T).Name}");
         return (T)service;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _localizationService.PropertyChanged -= HandleLocalizationChanged;
+        _settingsService.SettingsChanged -= HandleSettingsChanged;
+        _disposed = true;
     }
 
     private void HandleLocalizationChanged(object? sender, PropertyChangedEventArgs e)

--- a/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
@@ -129,9 +129,9 @@ public class ApktoolRunnerTests
         }
 
         public AppSettings Settings { get; }
+        public string SettingsDirectory => Environment.CurrentDirectory;
+        public event EventHandler? SettingsChanged;
 
-        public void Save()
-        {
-        }
+        public void Save() => SettingsChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
+++ b/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
@@ -67,7 +67,9 @@ public class DecompileViewModelTests
         }
 
         public AppSettings Settings { get; }
-        public void Save() { }
+        public string SettingsDirectory => Environment.CurrentDirectory;
+        public event EventHandler? SettingsChanged;
+        public void Save() => SettingsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class TestDialogService : IDialogService

--- a/tests/unit/PulseAPK.Tests/ViewModels/PatchViewModelTests.cs
+++ b/tests/unit/PulseAPK.Tests/ViewModels/PatchViewModelTests.cs
@@ -145,7 +145,8 @@ public class PatchViewModelTests
     {
         public AppSettings Settings { get; } = new() { ApktoolPath = string.Empty };
         public string SettingsDirectory => Environment.CurrentDirectory;
-        public void Save() { }
+        public event EventHandler? SettingsChanged;
+        public void Save() => SettingsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     private sealed class TestDialogService : IDialogService


### PR DESCRIPTION
### Motivation
- Ensure the UI shell is only notified when the `IsDeviceToolsEnabled` setting actually changes to avoid unnecessary UI updates and command recalculations. 
- Make the main shell react to changes in the device-tools setting so it can update `IsDeviceToolsEnabled` bindings and disable navigation when appropriate. 
- Prevent subscription leakage by providing unsubscribe logic if `MainViewModel` is later disposed.

### Description
- Added a `_lastSavedIsDeviceToolsEnabled` field to `SettingsService` and adjusted `Save()` to raise `SettingsChanged` only when `Settings.IsDeviceToolsEnabled` changes in `src/PulseAPK.Core/Services/SettingsService.cs`.
- Implemented `IDisposable` on `MainViewModel` and added a `Dispose()` method that unsubscribes from `LocalizationService.PropertyChanged` and `ISettingsService.SettingsChanged` in `src/PulseAPK.Core/ViewModels/MainViewModel.cs`.
- Updated unit-test fake implementations of `ISettingsService` to expose the `SettingsChanged` event and to invoke it from `Save()` in `tests/unit/PulseAPK.Tests/*` so tests reflect the event contract.

### Testing
- Ran `git diff --check` to validate the working tree and found no whitespace or diff problems (success).
- Attempts to run `dotnet test` in this environment failed because the `dotnet` CLI is not installed, so unit tests were not executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45ffc2f3b08322aae1d2eb8c93b3cb)