### PR TITLE
Move APK workspace defaults out of app data

### DIFF
--- a/src/PulseAPK.Core/Utils/PathUtils.cs
+++ b/src/PulseAPK.Core/Utils/PathUtils.cs
@@ -5,12 +5,14 @@ namespace PulseAPK.Core.Utils
 {
     public static class PathUtils
     {
+        private const string AppDirectoryName = "PulseAPK";
+
         public static string GetWritableAppDataRoot()
         {
             var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             if (!string.IsNullOrWhiteSpace(localAppData))
             {
-                return Path.Combine(localAppData, "PulseAPK");
+                return Path.Combine(localAppData, AppDirectoryName);
             }
 
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -19,19 +21,42 @@ namespace PulseAPK.Core.Utils
                 return Path.Combine(userProfile, ".pulseapk");
             }
 
-            return Path.Combine(Path.GetTempPath(), "PulseAPK");
+            return Path.Combine(Path.GetTempPath(), AppDirectoryName);
+        }
+
+        public static string GetDefaultWorkspaceRoot()
+        {
+            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            if (TryResolveWritableDirectory(documents, AppDirectoryName, out var documentsWorkspace))
+            {
+                return documentsWorkspace;
+            }
+
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            if (TryResolveWritableDirectory(userProfile, AppDirectoryName, out var profileWorkspace))
+            {
+                return profileWorkspace;
+            }
+
+            var appDataRoot = GetWritableAppDataRoot();
+            if (TryResolveWritableDirectory(appDataRoot, "workspace", out var appDataWorkspace))
+            {
+                return appDataWorkspace;
+            }
+
+            return Path.Combine(Path.GetTempPath(), AppDirectoryName, "workspace");
         }
 
         public static string GetDefaultDecompilePath()
         {
-            var writableRoot = GetWritableAppDataRoot();
-            return Path.Combine(writableRoot, "decompiled");
+            var workspaceRoot = GetDefaultWorkspaceRoot();
+            return Path.Combine(workspaceRoot, "decompiled");
         }
 
         public static string GetDefaultCompiledPath()
         {
-            var writableRoot = GetWritableAppDataRoot();
-            return Path.Combine(writableRoot, "compiled");
+            var workspaceRoot = GetDefaultWorkspaceRoot();
+            return Path.Combine(workspaceRoot, "compiled");
         }
 
         public static string GetDefaultReportsPath()
@@ -44,6 +69,28 @@ namespace PulseAPK.Core.Utils
         {
             var writableRoot = GetWritableAppDataRoot();
             return Path.Combine(writableRoot, "scripts");
+        }
+
+        private static bool TryResolveWritableDirectory(string? parentDirectory, string childDirectory, out string path)
+        {
+            path = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(parentDirectory))
+            {
+                return false;
+            }
+
+            try
+            {
+                path = Path.Combine(parentDirectory, childDirectory);
+                Directory.CreateDirectory(path);
+                return true;
+            }
+            catch
+            {
+                path = string.Empty;
+                return false;
+            }
         }
     }
 }

--- a/tests/unit/PulseAPK.Tests/Utils/PathUtilsTests.cs
+++ b/tests/unit/PulseAPK.Tests/Utils/PathUtilsTests.cs
@@ -15,5 +15,34 @@ namespace PulseAPK.Tests.Utils
             Assert.False(string.IsNullOrWhiteSpace(path));
             Assert.EndsWith($"PulseAPK{Path.DirectorySeparatorChar}reports", path, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public void GetDefaultWorkspaceRoot_ShouldResolveWritableDirectory()
+        {
+            var path = PathUtils.GetDefaultWorkspaceRoot();
+
+            Assert.False(string.IsNullOrWhiteSpace(path));
+            Assert.True(Directory.Exists(path));
+        }
+
+        [Fact]
+        public void GetDefaultDecompilePath_ShouldUseWorkspaceDirectory()
+        {
+            var workspaceRoot = PathUtils.GetDefaultWorkspaceRoot();
+            var path = PathUtils.GetDefaultDecompilePath();
+
+            Assert.False(string.IsNullOrWhiteSpace(path));
+            Assert.Equal(Path.Combine(workspaceRoot, "decompiled"), path);
+        }
+
+        [Fact]
+        public void GetDefaultCompiledPath_ShouldUseWorkspaceDirectory()
+        {
+            var workspaceRoot = PathUtils.GetDefaultWorkspaceRoot();
+            var path = PathUtils.GetDefaultCompiledPath();
+
+            Assert.False(string.IsNullOrWhiteSpace(path));
+            Assert.Equal(Path.Combine(workspaceRoot, "compiled"), path);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Defaulting decompiled/compiled outputs to Application Support/app data is not ideal for large binary work products and user workflows. 
- Provide a clearer, user-accessible workspace (Documents) while keeping safe fallbacks to avoid breaking headless or restricted environments.

### Description
- Add `GetDefaultWorkspaceRoot()` to prefer `SpecialFolder.MyDocuments` then `UserProfile`, then an app-data `workspace`, and finally a temp `PulseAPK/workspace` fallback. 
- Change `GetDefaultDecompilePath()` and `GetDefaultCompiledPath()` to use the new workspace root instead of the writable app-data root, and keep `GetDefaultReportsPath()`/`GetDefaultScriptsPath()` in app data. 
- Introduce `TryResolveWritableDirectory()` helper and `AppDirectoryName` constant and ensure candidate directories are created when resolving writable locations. 
- Add unit tests in `PathUtilsTests` covering `GetDefaultWorkspaceRoot`, `GetDefaultDecompilePath`, and `GetDefaultCompiledPath` behaviors.

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace — no issues found. 
- Attempted to run unit tests with `dotnet test` but the `dotnet` SDK is not available in this environment so the new tests were added but not executed (tests present: `GetDefaultWorkspaceRoot_ShouldResolveWritableDirectory`, `GetDefaultDecompilePath_ShouldUseWorkspaceDirectory`, `GetDefaultCompiledPath_ShouldUseWorkspaceDirectory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a460760c60c83229ec56b663fa6439f)