### PR TITLE
Propagate macOS app icon

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -11,6 +11,8 @@ umask 077
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
+macos_icon_path="${repo_root}/Resources/PulseAPK.icns"
+macos_icon_name="PulseAPK.icns"
 
 config="${CONFIGURATION:-Release}"
 rid="${RID:-osx-arm64}"
@@ -50,6 +52,11 @@ fi
 
 if [[ ! "${bundle_name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
   echo "APP_BUNDLE_NAME contains unsupported characters. Allowed: letters, digits, '.', '_' and '-'." >&2
+  exit 1
+fi
+
+if [[ ! -f "${macos_icon_path}" ]]; then
+  echo "macOS icon '${macos_icon_path}' was not found." >&2
   exit 1
 fi
 
@@ -97,6 +104,7 @@ bundle_resources="${bundle_contents}/Resources"
 
 mkdir -p "${bundle_macos}" "${bundle_resources}"
 cp -a "${publish_dir}/." "${bundle_macos}/"
+cp "${macos_icon_path}" "${bundle_resources}/${macos_icon_name}"
 chmod +x "${bundle_macos}/${app_exe}"
 
 # PDB files can include local source paths and machine/user details.
@@ -114,6 +122,8 @@ cat > "${bundle_contents}/Info.plist" <<PLIST
   <string>${app_exe}</string>
   <key>CFBundleIdentifier</key>
   <string>com.pulseapk.${bundle_name,,}</string>
+  <key>CFBundleIconFile</key>
+  <string>${macos_icon_name}</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <AvaloniaResource Include="..\..\Resources\CyberUnpack.ico" Link="Assets\CyberUnpack.ico" />
     <AvaloniaResource Include="..\..\Resources\CyberUnpack.png" Link="Assets\CyberUnpack.png" />
+    <AvaloniaResource Include="..\..\Resources\PulseAPK.icns" Link="Assets\PulseAPK.icns" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Ensure the newly added macOS `.icns` icon in `Resources` is included in the app bundle and used by macOS when the `.app` is created.

### Description
- Add the `.icns` asset to the Avalonia project resources by adding an `AvaloniaResource` entry for `Resources/PulseAPK.icns` in `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`. 
- Update `scripts/build-macos-binary.sh` to declare `macos_icon_path`/`macos_icon_name`, validate the icon exists, and fail early if missing. 
- Copy `Resources/PulseAPK.icns` into the app bundle `Contents/Resources` during packaging and add the `CFBundleIconFile` key to the generated `Info.plist` so the bundle uses the supplied icon.

### Testing
- Ran `bash -n scripts/build-macos-binary.sh` to verify script syntax, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which succeeded. 
- Verified the `.icns` file contents with `od -An -tx1 -N8 Resources/PulseAPK.icns`, which produced expected output. 
- Attempted `dotnet build PulseAPK.sln --configuration Release --no-restore`, but it could not be executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4612e5b1ac8322ada2880d64c94658)