### PR TITLE
Update macOS artifact paths to ZIP

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: PulseAPK-osx-arm64-release-assets
-          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.tar.gz
+          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip
           if-no-files-found: error
 
   draft-release:
@@ -85,4 +85,4 @@ jobs:
           files: |
             release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-linux-x64.AppImage
             release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-win-x64.exe
-            release-assets/PulseAPK-osx-arm64-release-assets/PulseAPK-osx-arm64.tar.gz
+            release-assets/PulseAPK-osx-arm64-release-assets/PulseAPK-osx-arm64.zip

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Upload macOS arm64 artifact
         uses: actions/upload-artifact@v4
         with:
-          name: PulseAPK-osx-arm64-app
-          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.tar.gz
+          name: PulseAPK-osx-arm64-zip
+          path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip
           if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Replace the macOS tarball artifacts with ZIPs so release automation attaches the ZIP instead of the tarball.
- Use a clearer artifact name for the manual macOS upload to indicate it is the ZIP artifact.

### Description
- Updated `.github/workflows/build-binaries.yml` to rename the macOS upload `name` to `PulseAPK-osx-arm64-zip` and set `path` to `artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip`.
- Updated `.github/workflows/build-binaries-draft-release.yml` to set the macOS upload `path` to `artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip` and to include `release-assets/PulseAPK-osx-arm64-release-assets/PulseAPK-osx-arm64.zip` in the draft release `files` list.
- Replaced all occurrences of `PulseAPK-osx-arm64.tar.gz` with `PulseAPK-osx-arm64.zip` across the two workflow files.

### Testing
- Ran `rg "PulseAPK-osx-arm64\.(tar\.gz|zip)|PulseAPK-osx-arm64-app|PulseAPK-osx-arm64-zip" .github/workflows/build-binaries.yml .github/workflows/build-binaries-draft-release.yml` and it reported only the updated `.zip` entries, indicating replacements succeeded.
- Inspected the updated workflow snippets with `nl`/`sed` to verify the `Upload macOS arm64 artifact` steps reference the ZIP path, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4741d856cc8322b44c093368969ca4)