### PR TITLE
Remove draft-release job from build workflow

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -1,10 +1,10 @@
-name: Build Binaries (Draft Release)
+name: Build Binaries
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build-linux-windows:
@@ -63,26 +63,3 @@ jobs:
           name: PulseAPK-osx-arm64-release-assets
           path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip
           if-no-files-found: error
-
-  draft-release:
-    needs:
-      - build-linux-windows
-      - build-macos-arm64
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download release artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets
-
-      - name: Create draft release with binary assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ci-build-${{ github.run_id }}
-          name: CI Build ${{ github.run_number }}
-          draft: true
-          files: |
-            release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-linux-x64.AppImage
-            release-assets/PulseAPK-linux-windows-release-assets/PulseAPK-win-x64.exe
-            release-assets/PulseAPK-osx-arm64-release-assets/PulseAPK-osx-arm64.zip


### PR DESCRIPTION
### Motivation
- Stop automatically creating draft GitHub Releases from CI and convert the workflow to artifact-only builds.
- Reduce workflow permissions since release creation is no longer performed.
- Retain cross-platform build jobs to continue producing Linux, Windows and macOS artifacts.

### Description
- Rename the workflow from `Build Binaries (Draft Release)` to `Build Binaries` and change `permissions.contents` from `write` to `read`.
- Remove the `draft-release` job and the `softprops/action-gh-release@v2` release step.
- Preserve the `build-linux-windows` and `build-macos-arm64` jobs which upload artifacts using `actions/upload-artifact@v4`.
- Ensure the macOS artifact path stays as `artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip`.

### Testing
- Ran a YAML parse/validation check with Ruby using `ruby -e "require 'yaml'; f='.github/workflows/build-binaries-draft-release.yml'; data=YAML.load_file(f); raise 'bad name' unless data['name']=='Build Binaries'; raise 'draft-release still present' if data['jobs'].key?('draft-release'); puts \"workflow yaml parsed; jobs: #{data['jobs'].keys.join(', ')}\""` which succeeded and confirmed the changes.
- Ran a Python-based YAML check via `python3 - <<'PY' ...` which could not complete because `PyYAML` was unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47428cd9848322bcf4fca7c645d905)