### PR TITLE
Add macOS production signing and notarization support

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -54,7 +54,19 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # Optional production signing/notarization secrets:
+      # - MACOS_CODESIGN_IDENTITY: Developer ID Application certificate identity installed in the runner keychain.
+      # - APPLE_ID: Apple Developer account email used by notarytool.
+      # - APPLE_TEAM_ID: Apple Developer team ID.
+      # - APPLE_APP_SPECIFIC_PASSWORD: App-specific password for the Apple ID.
+      # If MACOS_CODESIGN_IDENTITY is omitted, the build script falls back to ad-hoc signing.
+      # If all Apple notarization secrets are present, the ZIP is notarized and the ticket is stapled before upload.
       - name: Build macOS arm64 app bundle
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: RID=osx-arm64 ./scripts/build-macos-binary.sh
 
       - name: Upload macOS arm64 artifact

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -58,7 +58,19 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # Optional production signing/notarization secrets:
+      # - MACOS_CODESIGN_IDENTITY: Developer ID Application certificate identity installed in the runner keychain.
+      # - APPLE_ID: Apple Developer account email used by notarytool.
+      # - APPLE_TEAM_ID: Apple Developer team ID.
+      # - APPLE_APP_SPECIFIC_PASSWORD: App-specific password for the Apple ID.
+      # If MACOS_CODESIGN_IDENTITY is omitted, the build script falls back to ad-hoc signing.
+      # If all Apple notarization secrets are present, the ZIP is notarized and the ticket is stapled before upload.
       - name: Build macOS arm64 app bundle
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
         run: RID=osx-arm64 ./scripts/build-macos-binary.sh
 
       - name: Upload macOS arm64 artifact

--- a/README.MD
+++ b/README.MD
@@ -107,6 +107,8 @@ PulseAPK includes a built-in static analyzer that scans decompiled code for comm
     RID=osx-arm64 ./scripts/build-macos-binary.sh
     ```
 
+    The macOS build uses ad-hoc signing by default for local and test builds. For production signing, install a Developer ID Application certificate in the macOS keychain and set `MACOS_CODESIGN_IDENTITY` to that certificate identity before running the script. To notarize the generated ZIP and staple the notarization ticket to the `.app` before the final ZIP is created, also set `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD`. GitHub Actions release builds read these values from repository secrets with the same names: `MACOS_CODESIGN_IDENTITY`, `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD`.
+
 2.  **Setup**
     - Open **Settings**.
     - Link your `apktool.jar` and `uber-apk-signer.jar` paths.

--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -25,6 +25,7 @@ out_root="${repo_root}/artifacts/macos/${rid}"
 publish_dir="${out_root}/publish"
 bundle_dir="${out_root}/${bundle_name}.app"
 zip_path="${out_root}/${bundle_name}-${rid}.zip"
+notary_zip_path="${out_root}/${bundle_name}-${rid}-notary.zip"
 bundle_identifier_name="$(printf '%s' "${bundle_name}" | tr '[:upper:]' '[:lower:]')"
 
 version="${VERSION:-}"
@@ -164,9 +165,47 @@ fi
 # pick up the icon when the freshly built app is launched.
 touch "${bundle_dir}" "${bundle_contents}/Info.plist" "${bundle_resources}/${macos_icon_file}"
 
+codesign_identity="${MACOS_CODESIGN_IDENTITY:-}"
+notarize_requested=false
+if [[ -n "${APPLE_ID:-}" || -n "${APPLE_TEAM_ID:-}" || -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+  notarize_requested=true
+fi
+
+create_zip() {
+  local destination="$1"
+
+  rm -f "${destination}"
+  (
+    cd "${out_root}"
+    COPYFILE_DISABLE=1 zip -r "${destination}" "${bundle_name}.app"
+  )
+}
+
+if [[ "${notarize_requested}" == "true" ]]; then
+  missing_notarization_vars=()
+  [[ -n "${APPLE_ID:-}" ]] || missing_notarization_vars+=("APPLE_ID")
+  [[ -n "${APPLE_TEAM_ID:-}" ]] || missing_notarization_vars+=("APPLE_TEAM_ID")
+  [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] || missing_notarization_vars+=("APPLE_APP_SPECIFIC_PASSWORD")
+
+  if [[ ${#missing_notarization_vars[@]} -gt 0 ]]; then
+    printf 'Notarization was requested, but these variables are missing: %s\n' "${missing_notarization_vars[*]}" >&2
+    exit 1
+  fi
+
+  if [[ -z "${codesign_identity}" ]]; then
+    echo "Notarization requires MACOS_CODESIGN_IDENTITY; ad-hoc signed apps cannot be notarized." >&2
+    exit 1
+  fi
+fi
+
 if command -v codesign >/dev/null 2>&1; then
-  echo "Ad-hoc signing macOS app bundle: ${bundle_dir}"
-  codesign --force --deep --sign - "${bundle_dir}"
+  if [[ -n "${codesign_identity}" ]]; then
+    echo "Signing macOS app bundle with identity '${codesign_identity}': ${bundle_dir}"
+    codesign --force --deep --options runtime --timestamp --sign "${codesign_identity}" "${bundle_dir}"
+  else
+    echo "Ad-hoc signing macOS app bundle: ${bundle_dir}"
+    codesign --force --deep --sign - "${bundle_dir}"
+  fi
   codesign --verify --deep --strict "${bundle_dir}"
 elif [[ "$(uname -s)" == "Darwin" ]]; then
   echo "codesign is required to sign macOS app bundles on Darwin but was not found in PATH." >&2
@@ -175,11 +214,29 @@ else
   echo "Warning: codesign was not found in PATH; skipping macOS app bundle signing." >&2
 fi
 
-rm -f "${zip_path}"
-(
-  cd "${out_root}"
-  COPYFILE_DISABLE=1 zip -r "${zip_path}" "${bundle_name}.app"
-)
+if [[ "${notarize_requested}" == "true" ]]; then
+  if ! command -v xcrun >/dev/null 2>&1; then
+    echo "xcrun is required for macOS notarization but was not found in PATH." >&2
+    exit 1
+  fi
+
+  echo "Creating notarization ZIP: ${notary_zip_path}"
+  create_zip "${notary_zip_path}"
+
+  echo "Submitting macOS app bundle ZIP for notarization."
+  xcrun notarytool submit "${notary_zip_path}" \
+    --apple-id "${APPLE_ID}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+    --wait
+
+  echo "Stapling notarization ticket to app bundle: ${bundle_dir}"
+  xcrun stapler staple "${bundle_dir}"
+  xcrun stapler validate "${bundle_dir}"
+  rm -f "${notary_zip_path}"
+fi
+
+create_zip "${zip_path}"
 echo "macOS app bundle ZIP created: ${zip_path}"
 
 echo "macOS app bundle created: ${bundle_dir}"


### PR DESCRIPTION
### Motivation
- Enable production-ready macOS code signing and notarization for release artifacts while preserving ad-hoc signing as the default for local/test builds. 
- Allow CI to drive signing/notarization via repository secrets so releases can be signed with a Developer ID and notarized by Apple.

### Description
- Add environment-variable driven signing support in `scripts/build-macos-binary.sh` using `MACOS_CODESIGN_IDENTITY`, falling back to ad-hoc signing when unset. 
- Add optional notarization flow that validates `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD`, creates a notarization ZIP, runs `xcrun notarytool submit --wait`, staples the notarization ticket with `xcrun stapler`, and re-creates the final ZIP. 
- Introduce a reusable `create_zip` helper and temporary `notary_zip_path` to support the notarization+staple-before-final-zip flow. 
- Wire macOS jobs in `.github/workflows/build-binaries.yml` and `.github/workflows/build-binaries-draft-release.yml` to read the optional secrets and add inline documentation, and document the variables in `README.MD`.

### Testing
- Ran `git diff --check` with no reported issues. 
- Ran `bash -n scripts/build-macos-binary.sh` (shell syntax check) with no syntax errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4745064ba88322a9a2760a9563dfbf)