### PR TITLE
Clarify macOS ZIP artifact naming

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -61,7 +61,7 @@ jobs:
       # - APPLE_APP_SPECIFIC_PASSWORD: App-specific password for the Apple ID.
       # If MACOS_CODESIGN_IDENTITY is omitted, the build script falls back to ad-hoc signing.
       # If all Apple notarization secrets are present, the ZIP is notarized and the ticket is stapled before upload.
-      - name: Build macOS arm64 app bundle
+      - name: Build macOS arm64 ZIP
         env:
           MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -65,7 +65,7 @@ jobs:
       # - APPLE_APP_SPECIFIC_PASSWORD: App-specific password for the Apple ID.
       # If MACOS_CODESIGN_IDENTITY is omitted, the build script falls back to ad-hoc signing.
       # If all Apple notarization secrets are present, the ZIP is notarized and the ticket is stapled before upload.
-      - name: Build macOS arm64 app bundle
+      - name: Build macOS arm64 ZIP
         env:
           MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -237,7 +237,7 @@ if [[ "${notarize_requested}" == "true" ]]; then
 fi
 
 create_zip "${zip_path}"
-echo "macOS app bundle ZIP created: ${zip_path}"
+echo "macOS ZIP package created: ${zip_path}"
 
 echo "macOS app bundle created: ${bundle_dir}"
 echo "Executable entry point: ${bundle_macos}/${app_exe}"


### PR DESCRIPTION
### Motivation
- Ensure the macOS build step and logs communicate that the downloadable artifact is a ZIP file so users see a clear `ZIP` package in CI and release UIs.
- Prioritize an explicit ZIP package message while retaining the `.app` bundle path information for debugging and notarization steps.

### Description
- Rename the macOS build step in ` .github/workflows/build-binaries.yml` from `Build macOS arm64 app bundle` to `Build macOS arm64 ZIP`.
- Apply the same step-name change in `.github/workflows/build-binaries-draft-release.yml`.
- Update `scripts/build-macos-binary.sh` to print `macOS ZIP package created: ${zip_path}` instead of the previous ZIP message while keeping the `macOS app bundle created: ${bundle_dir}` and executable path logs.

### Testing
- Ran `bash -n scripts/build-macos-binary.sh` to validate the script syntax and it succeeded.
- Ran a Python assertion that verifies `Build macOS arm64 ZIP` is present and `Build macOS arm64 app bundle` is absent in both workflow files and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4746c6f9a483229dd0ada306e58e44)