### PR TITLE
Add `app-version` workflow input and propagate to dotnet build/publish

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -2,6 +2,11 @@ name: Build Binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      app-version:
+        description: "App version to stamp into the build"
+        required: true
+        default: "1.2.8"
 
 permissions:
   contents: read
@@ -28,9 +33,13 @@ jobs:
           sudo mv appimagetool /usr/local/bin/appimagetool
 
       - name: Build Linux AppImage
+        env:
+          APP_VERSION: ${{ inputs.app-version }}
         run: ./scripts/build-appimage.sh
 
       - name: Build Windows binaries
+        env:
+          APP_VERSION: ${{ inputs.app-version }}
         run: OUTPUT_EXE_NAME=PulseAPK-win-x64.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
 
       - name: Upload Linux and Windows artifacts
@@ -67,6 +76,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APP_VERSION: ${{ inputs.app-version }}
         run: RID=osx-arm64 ./scripts/build-macos-binary.sh
 
       - name: Upload macOS arm64 artifact

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -2,6 +2,11 @@ name: Build Binaries
 
 on:
   workflow_dispatch:
+    inputs:
+      app-version:
+        description: "App version to stamp into the build"
+        required: true
+        default: "1.2.8"
 
 jobs:
   build:
@@ -25,9 +30,13 @@ jobs:
           sudo mv appimagetool /usr/local/bin/appimagetool
 
       - name: Build Linux AppImage
+        env:
+          APP_VERSION: ${{ inputs.app-version }}
         run: ./scripts/build-appimage.sh
 
       - name: Build Windows binaries
+        env:
+          APP_VERSION: ${{ inputs.app-version }}
         run: ./scripts/build-windows-exe.sh
 
       - name: Upload Linux AppImage artifact
@@ -71,6 +80,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APP_VERSION: ${{ inputs.app-version }}
         run: RID=osx-arm64 ./scripts/build-macos-binary.sh
 
       - name: Upload macOS arm64 artifact

--- a/.github/workflows/build-desktop-portable.yml
+++ b/.github/workflows/build-desktop-portable.yml
@@ -2,6 +2,11 @@ name: Build Portable Desktop Release
 
 on:
   workflow_dispatch:
+    inputs:
+      app-version:
+        description: "App version to stamp into the build"
+        required: true
+        default: "1.2.8"
 
 jobs:
   build:
@@ -20,16 +25,23 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: >-
+          dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+          --configuration Release
+          --no-restore
+          -p:Version="${{ inputs.app-version }}"
+          -p:InformationalVersion="${{ inputs.app-version }}"
 
       - name: Publish
         run: >-
-          dotnet publish PulseAPK.csproj
+          dotnet publish src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
           --configuration Release
           --runtime win-x64
           --self-contained true
           -p:PublishSingleFile=true
           -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:Version="${{ inputs.app-version }}"
+          -p:InformationalVersion="${{ inputs.app-version }}"
           --output "${{ github.workspace }}\\publish"
 
       - name: Upload artifacts

--- a/.github/workflows/build-desktop-small.yml
+++ b/.github/workflows/build-desktop-small.yml
@@ -2,6 +2,11 @@ name: Build Small Desktop Release
 
 on:
   workflow_dispatch:
+    inputs:
+      app-version:
+        description: "App version to stamp into the build"
+        required: true
+        default: "1.2.8"
 
 jobs:
   build:
@@ -16,49 +21,21 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Bump patch version
-        shell: pwsh
-        run: |
-          $csprojPath = "PulseAPK.csproj"
-          $content = Get-Content $csprojPath -Raw
-
-          if ($content -notmatch '<Version>(?<version>[^<]+)</Version>') {
-            Write-Error "Version element not found in $csprojPath"
-            exit 1
-          }
-
-          $current = $Matches.version
-          try {
-            $version = [System.Version]::Parse($current)
-          }
-          catch {
-            Write-Error "Version '$current' is not a valid version string"
-            exit 1
-          }
-
-          if ($version.Build -lt 0) {
-            Write-Error "Version '$current' must contain at least three segments (e.g. 1.0.0)"
-            exit 1
-          }
-
-          $newPatch = $version.Build + 1
-          $newVersion = "{0}.{1}.{2}" -f $version.Major, $version.Minor, $newPatch
-
-          $updated = $content -replace "<Version>$current</Version>", "<Version>$newVersion</Version>"
-          Set-Content -Path $csprojPath -Value $updated
-
-          Write-Output "Bumped version from $current to $newVersion"
-
       - name: Restore dependencies
         run: dotnet restore
 
       - name: Build
-        run: dotnet build PulseAPK.csproj --configuration Release --no-restore
+        run: >-
+          dotnet build src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+          --configuration Release
+          --no-restore
+          -p:Version="${{ inputs.app-version }}"
+          -p:InformationalVersion="${{ inputs.app-version }}"
 
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: PulseAPK-windows-x64
-          path: bin/Release/net8.0-windows/PulseAPK.exe
+          path: src/PulseAPK.Avalonia/bin/Release/net8.0-windows/PulseAPK.exe
           if-no-files-found: error

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -8,6 +8,7 @@ project_relpath="src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 app_name="PulseAPK"
 entry_exe="PulseAPK"
 config="${CONFIGURATION:-Release}"
+app_version="${APP_VERSION:-}"
 rid="${RID:-linux-x64}"
 
 out_root="${repo_root}/artifacts/linux/${rid}"
@@ -67,6 +68,8 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  ${app_version:+-p:Version="${app_version}"} \
+  ${app_version:+-p:InformationalVersion="${app_version}"} \
   -p:DebugType=None \
   -p:DebugSymbols=false \
   /p:PublishSingleFile=false \

--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -20,6 +20,7 @@ rid="${RID:-osx-arm64}"
 app_name="${APP_NAME:-PulseAPK}"
 bundle_name="${APP_BUNDLE_NAME:-PulseAPK}"
 app_exe="${app_name}"
+app_version="${APP_VERSION:-}"
 
 out_root="${repo_root}/artifacts/macos/${rid}"
 publish_dir="${out_root}/publish"
@@ -28,7 +29,7 @@ zip_path="${out_root}/${bundle_name}-${rid}.zip"
 notary_zip_path="${out_root}/${bundle_name}-${rid}-notary.zip"
 bundle_identifier_name="$(printf '%s' "${bundle_name}" | tr '[:upper:]' '[:lower:]')"
 
-version="${VERSION:-}"
+version="${APP_VERSION:-${VERSION:-}}"
 if [[ -z "${version}" ]]; then
   version="$(sed -nE 's:^[[:space:]]*<Version>([^<]+)</Version>[[:space:]]*$:\1:p' "${project_path}" | head -n 1)"
 fi
@@ -75,6 +76,8 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  ${app_version:+-p:Version="${app_version}"} \
+  ${app_version:+-p:InformationalVersion="${app_version}"} \
   /p:UseAppHost=true \
   /p:PublishSingleFile=true \
   /p:IncludeNativeLibrariesForSelfExtract=true \

--- a/scripts/build-windows-exe.ps1
+++ b/scripts/build-windows-exe.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$Configuration = $(if ($env:CONFIGURATION) { $env:CONFIGURATION } else { "Release" }),
     [string]$Rid = $(if ($env:RID) { $env:RID } else { "win-x64" }),
-    [string]$AppName = $(if ($env:APP_NAME) { $env:APP_NAME } else { "PulseAPK" })
+    [string]$AppName = $(if ($env:APP_NAME) { $env:APP_NAME } else { "PulseAPK" }),
+    [string]$AppVersion = $(if ($env:APP_VERSION) { $env:APP_VERSION } else { "" })
 )
 
 $ErrorActionPreference = "Stop"
@@ -30,10 +31,17 @@ if (Test-Path $publishDir) {
 }
 New-Item -Path $publishDir -ItemType Directory -Force | Out-Null
 
+$versionProperties = @()
+if ($AppVersion) {
+    $versionProperties += "-p:Version=$AppVersion"
+    $versionProperties += "-p:InformationalVersion=$AppVersion"
+}
+
 & dotnet publish $projectPath `
     -c $Configuration `
     -r $Rid `
     --self-contained true `
+    @versionProperties `
     /p:UseAppHost=true `
     /p:PublishSingleFile=true `
     /p:IncludeNativeLibrariesForSelfExtract=true `

--- a/scripts/build-windows-exe.sh
+++ b/scripts/build-windows-exe.sh
@@ -5,6 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 project_path="${repo_root}/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj"
 
 config="${CONFIGURATION:-Release}"
+app_version="${APP_VERSION:-}"
 rid="${RID:-win-x64}"
 app_name="${APP_NAME:-PulseAPK}"
 app_exe="${app_name}.exe"
@@ -32,6 +33,8 @@ dotnet publish "${project_path}" \
   -c "${config}" \
   -r "${rid}" \
   --self-contained true \
+  ${app_version:+-p:Version="${app_version}"} \
+  ${app_version:+-p:InformationalVersion="${app_version}"} \
   /p:UseAppHost=true \
   /p:PublishSingleFile=true \
   /p:IncludeNativeLibrariesForSelfExtract=true \


### PR DESCRIPTION
### Motivation
- Make release builds stamp the application assembly version from a user-provided workflow input so published artifacts and macOS bundle metadata match the app's About screen and release metadata.
- Allow manual `workflow_dispatch` runs to specify the version without editing project files.

### Description
- Add a `workflow_dispatch` input `app-version` (default `1.2.8`) to the release workflows in `/.github/workflows/build-binaries.yml`, `/.github/workflows/build-binaries-draft-release.yml`, `/.github/workflows/build-desktop-portable.yml`, and `/.github/workflows/build-desktop-small.yml`.
- Pass the dispatch input into scripted builds as `APP_VERSION` and conditionally append `-p:Version="${app_version}" -p:InformationalVersion="${app_version}"` to `dotnet publish` calls in `scripts/build-appimage.sh`, `scripts/build-windows-exe.sh`, and `scripts/build-macos-binary.sh`.
- Update the Windows PowerShell publisher `scripts/build-windows-exe.ps1` to accept an `AppVersion` parameter (read from `APP_VERSION`) and add matching MSBuild properties to the `dotnet publish` invocation.
- Change the desktop workflows to build/publish the Avalonia project directly (`src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`) and pass `-p:Version` / `-p:InformationalVersion` from the workflow input; remove the small-workflow patch-bump step and upload artifacts from the Avalonia output path.

### Testing
- ✅ Parsed all modified workflow YAML files successfully with `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }'`.
- ✅ Performed shell syntax checks with `bash -n` for `scripts/build-appimage.sh`, `scripts/build-windows-exe.sh`, and `scripts/build-macos-binary.sh`.
- ✅ Ran `git diff --check` to validate no whitespace/errors introduced.
- ⚠️ Attempted `dotnet build` with `-p:Version` / `-p:InformationalVersion` but the environment running tests does not have `dotnet` installed so the build could not be executed here.
- ⚠️ PowerShell AST/parse check was not executed because `pwsh` is not available in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474aca47f083228a3edabbc75bf5d7)