### PR TITLE
Move shared version metadata to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <Version Condition="'$(Version)' == ''">1.2.8</Version>
+    <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(Version)</InformationalVersion>
+  </PropertyGroup>
+</Project>

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -5,8 +5,6 @@
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-    <Version>1.2.8</Version>
-    <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <PathMap>$(MSBuildProjectDirectory)=/src</PathMap>

--- a/src/PulseAPK.Core/PulseAPK.Core.csproj
+++ b/src/PulseAPK.Core/PulseAPK.Core.csproj
@@ -5,8 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>PulseAPK.Core</RootNamespace>
-    <Version>1.2.8</Version>
-    <InformationalVersion>$(Version)</InformationalVersion>
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <PathMap>$(MSBuildProjectDirectory)=/src</PathMap>


### PR DESCRIPTION
### Motivation
- Centralize the default package `Version` and `InformationalVersion` so all projects inherit a single source of truth.
- Allow CI to override versions by passing `-p:Version=... -p:InformationalVersion=...` while keeping a sensible local default.

### Description
- Add a root-level `Directory.Build.props` that sets `<Version>` to `1.2.8` and `<InformationalVersion>` to `$(Version)` only when those properties are unset.
- Remove the duplicate `<Version>` and `<InformationalVersion>` elements from `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.
- Remove the duplicate `<Version>` and `<InformationalVersion>` elements from `src/PulseAPK.Core/PulseAPK.Core.csproj`.

### Testing
- An attempt to run `dotnet build` was performed but failed because the `dotnet` CLI is not installed in the environment, so build verification could not be completed automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474bfb4ecc83229e3693eee4240b41)