### PR TITLE
fix: use app project path in workflows

### DIFF
--- a/.github/workflows/build-desktop-portable.yml
+++ b/.github/workflows/build-desktop-portable.yml
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore PulseAPK.sln
 
       - name: Build
         run: >-

--- a/.github/workflows/build-desktop-small.yml
+++ b/.github/workflows/build-desktop-small.yml
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore PulseAPK.sln
 
       - name: Build
         run: >-

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,7 +21,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          current=$(grep -Po '(?<=<Version>)[^<]+' PulseAPK.csproj)
+          current=$(grep -Po '(?<=<Version>)[^<]+' src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj)
           IFS='.' read -r major minor patch <<< "$current"
           next_patch=$((patch + 1))
           next_version="${major}.${minor}.${next_patch}"
@@ -34,7 +34,7 @@ jobs:
         run: |
           next="${{ steps.version.outputs.next }}"
           current="${{ steps.version.outputs.current }}"
-          sed -i "s#<Version>${current}</Version>#<Version>${next}</Version>#" PulseAPK.csproj
+          sed -i "s#<Version>${current}</Version>#<Version>${next}</Version>#" src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
 
       - name: Update About window fallback version
         shell: python


### PR DESCRIPTION
### Motivation
- Workflows referenced a removed root-level `PulseAPK.csproj`, which breaks version bumping and publish steps for the desktop app. 
- Solution-wide restore/build steps should target the repository solution and publishing should target the real Avalonia app project at `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.

### Description
- Updated `.github/workflows/bump-version.yml` to read and update the version from `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` instead of `PulseAPK.csproj`.
- Updated `.github/workflows/build-desktop-small.yml` to run `dotnet restore PulseAPK.sln` before building the Avalonia app project at `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.
- Updated `.github/workflows/build-desktop-portable.yml` to run `dotnet restore PulseAPK.sln` before building/publishing the Avalonia app project at `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj`.
- Modified files: ` .github/workflows/bump-version.yml`, `.github/workflows/build-desktop-small.yml`, and `.github/workflows/build-desktop-portable.yml`.

### Testing
- Ran `rg -n "PulseAPK\.csproj" .github/workflows` to verify workflow references now point to the app project, which succeeded.
- Ran `git diff --check` to ensure there are no diff/whitespace problems, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474ce2854483229d74628ef9a5cb76)