### PR TITLE
ci: update version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,7 +21,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          current=$(grep -Po '(?<=<Version>)[^<]+' src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj)
+          current=$(grep -Po '<Version[^>]*>\K[^<]+' Directory.Build.props)
           IFS='.' read -r major minor patch <<< "$current"
           next_patch=$((patch + 1))
           next_version="${major}.${minor}.${next_patch}"
@@ -29,27 +29,12 @@ jobs:
           echo "current=${current}" >> "$GITHUB_OUTPUT"
           echo "next=${next_version}" >> "$GITHUB_OUTPUT"
 
-      - name: Update project version
+      - name: Update centralized version
         shell: bash
         run: |
           next="${{ steps.version.outputs.next }}"
           current="${{ steps.version.outputs.current }}"
-          sed -i "s#<Version>${current}</Version>#<Version>${next}</Version>#" src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
-
-      - name: Update About window fallback version
-        shell: python
-        run: |
-          from pathlib import Path
-
-          next_version = "${{ steps.version.outputs.next }}"
-          current_version = "${{ steps.version.outputs.current }}"
-
-          about_vm = Path("ViewModels/AboutViewModel.cs")
-          content = about_vm.read_text()
-          updated = content.replace(f'?? "{current_version}"', f'?? "{next_version}"')
-          if content == updated:
-            raise SystemExit("Failed to update AboutViewModel fallback version")
-          about_vm.write_text(updated)
+          sed -i -E "s#(<Version[^>]*>)${current}(</Version>)#\1${next}\2#" Directory.Build.props
 
       - name: Create version bump pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
### Motivation
- Avoid mutating project files during artifact builds and prefer non-mutating, build-time version stamping via MSBuild properties.
- Centralize persistent version state in `Directory.Build.props` so single-source version bumps affect all projects.
- Remove an obsolete source edit step that attempted to update an `AboutViewModel` fallback version in the repository.

### Description
- Confirmed the desktop artifact workflow uses build-time stamping with `-p:Version` and `-p:InformationalVersion` and left that non-mutating approach in place in `.github/workflows/build-desktop-small.yml`.
- Updated `.github/workflows/bump-version.yml` to read the current version from `Directory.Build.props` using `grep` and to write the bumped version back into `Directory.Build.props` using `sed -E`.
- Removed the Python step that modified `ViewModels/AboutViewModel.cs` as part of the bump workflow since it relied on an obsolete fallback editing approach.

### Testing
- Ran `git diff --check` to validate no whitespace or diff issues and it completed without errors.
- Simulated the bump logic with a Python snippet that read `Directory.Build.props` and computed `1.2.8 -> 1.2.9`, which succeeded.
- Verified the `grep` extraction of the `<Version>` value from `Directory.Build.props` returned the expected `1.2.8` before bumping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a474ef14ce883228bea3af5d1fa98aa)