### PR TITLE
Split Linux and Windows artifact uploads

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -42,13 +42,18 @@ jobs:
           APP_VERSION: ${{ inputs.app-version }}
         run: OUTPUT_EXE_NAME=PulseAPK-win-x64.exe CREATE_ZIP=false ./scripts/build-windows-exe.sh
 
-      - name: Upload Linux and Windows artifacts
+      - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: PulseAPK-linux-windows-release-assets
-          path: |
-            artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
-            artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe
+          name: PulseAPK-linux-x64-release-asset
+          path: artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage
+          if-no-files-found: error
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: PulseAPK-win-x64-release-asset
+          path: artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe
           if-no-files-found: error
 
   build-macos-arm64:


### PR DESCRIPTION
### Motivation
- Separate Linux and Windows upload steps so each platform artifact is uploaded with its own name and path for clearer release assets and independent handling.

### Description
- Replaced the combined `Upload Linux and Windows artifacts` step with two `actions/upload-artifact@v4` steps named `PulseAPK-linux-x64-release-asset` and `PulseAPK-win-x64-release-asset` using the single-file paths `artifacts/linux/linux-x64/PulseAPK-linux-x64.AppImage` and `artifacts/windows/win-x64/publish/PulseAPK-win-x64.exe` respectively, and preserved `if-no-files-found: error`.
- Kept the existing macOS upload step unchanged (name remains `PulseAPK-osx-arm64-release-assets`).
- Ensured the workflow YAML remains valid after the change.

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build-binaries-draft-release.yml"); puts "workflow YAML parsed successfully"'` which parsed the workflow YAML successfully (passed).
- Attempted a Python YAML parse with `yaml.safe_load` but it failed because `PyYAML` was not installed in the environment (test aborted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47535c09c883228fb73af9d8859d85)