### PR TITLE
Add draft release creation to binary build workflow

### DIFF
--- a/.github/workflows/build-binaries-draft-release.yml
+++ b/.github/workflows/build-binaries-draft-release.yml
@@ -9,7 +9,7 @@ on:
         default: "1.2.8"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-linux-windows:
@@ -90,3 +90,26 @@ jobs:
           name: PulseAPK-osx-arm64-release-assets
           path: artifacts/macos/osx-arm64/PulseAPK-osx-arm64.zip
           if-no-files-found: error
+
+  create-draft-release:
+    runs-on: ubuntu-latest
+    needs: [build-linux-windows, build-macos-arm64]
+
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: PulseAPK-*-release-asset*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: v${{ inputs.app-version }}
+          name: PulseAPK v${{ inputs.app-version }}
+          files: |
+            release-assets/PulseAPK-linux-x64.AppImage
+            release-assets/PulseAPK-win-x64.exe
+            release-assets/PulseAPK-osx-arm64.zip


### PR DESCRIPTION
### Motivation

- Enable the workflow to create GitHub releases and upload built artifacts by granting write access to repository contents.
- Automate packaging of the three built binaries into a draft release tagged and named from the `app-version` input.

### Description

- Updated top-level permission from `contents: read` to `contents: write` in `.github/workflows/build-binaries-draft-release.yml`.
- Added a new `create-draft-release` job that runs on `ubuntu-latest` and `needs: [build-linux-windows, build-macos-arm64]`.
- Added an artifact download step using `actions/download-artifact@v4` with `pattern: PulseAPK-*-release-asset*`, `path: release-assets`, and `merge-multiple: true` to collect built files.
- Added a release creation step using `softprops/action-gh-release@v2` configured with `draft: true`, `tag_name: v${{ inputs.app-version }}`, `name: PulseAPK v${{ inputs.app-version }}`, and `files:` pointing to `release-assets/PulseAPK-linux-x64.AppImage`, `release-assets/PulseAPK-win-x64.exe`, and `release-assets/PulseAPK-osx-arm64.zip`.

### Testing

- Ran a Python content check against `.github/workflows/build-binaries-draft-release.yml` to verify the required release configuration is present and it passed.
- Ran `git diff --check` to validate the patch and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4753d9bd4c83229bf56bc7d73cbf7e)