### PR TITLE
Fix crash when running Decompile with invalid output folder

### DIFF
--- a/src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs
+++ b/src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs
@@ -42,7 +42,7 @@ public class AvaloniaDialogService : IDialogService
             ContentMessage = message,
             ButtonDefinitions = buttons,
             Icon = icon,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            WindowStartupLocation = WindowStartupLocation.CenterScreen,
             CanResize = true,
             Width = 420,
             MaxWidth = 720

--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -189,8 +189,19 @@ public partial class DecompileViewModel : ObservableObject
 
         SetConsoleLog(Properties.Resources.StartingApktool);
 
-        var outputDir = ResolveOutputDirectory();
-        var normalizedOutputDir = Path.GetFullPath(outputDir);
+        string normalizedOutputDir;
+
+        try
+        {
+            var outputDir = ResolveOutputDirectory();
+            normalizedOutputDir = Path.GetFullPath(outputDir);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or IOException or UnauthorizedAccessException)
+        {
+            AppendLog($"{Properties.Resources.DecompileFailed}: {ex.Message}");
+            await _dialogService.ShowErrorAsync($"The selected output folder is invalid: {ex.Message}", "Invalid output folder");
+            return;
+        }
 
         if (IsHighRiskOutputDirectory(normalizedOutputDir))
         {

--- a/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
+++ b/tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using PulseAPK.Core.Abstractions;
 using PulseAPK.Core.Services;
@@ -42,6 +43,32 @@ public class DecompileViewModelTests
         Assert.Contains(dialogService.Warnings, warning => warning.message.Contains("apktool", StringComparison.OrdinalIgnoreCase));
     }
 
+
+    [Fact]
+    public async Task RunCommand_ShowsError_WhenOutputFolderIsInvalid()
+    {
+        var apktoolPath = Path.GetTempFileName();
+        var apkPath = Path.GetTempFileName();
+
+        try
+        {
+            var dialogService = new TestDialogService();
+            var viewModel = CreateViewModel(apktoolPath: apktoolPath, dialogService: dialogService);
+            viewModel.ApkPath = apkPath;
+            viewModel.OutputFolder = "invalid\0folder";
+
+            await viewModel.RunDecompileCommand.ExecuteAsync(null);
+
+            Assert.True(viewModel.RunDecompileCommand.CanExecute(null));
+            Assert.Contains(dialogService.Errors, error => error.title == "Invalid output folder");
+        }
+        finally
+        {
+            File.Delete(apktoolPath);
+            File.Delete(apkPath);
+        }
+    }
+
     private static DecompileViewModel CreateViewModel(string apktoolPath, TestDialogService? dialogService = null)
     {
         return new DecompileViewModel(
@@ -75,6 +102,7 @@ public class DecompileViewModelTests
     private sealed class TestDialogService : IDialogService
     {
         public List<(string message, string? title)> Warnings { get; } = new();
+        public List<(string message, string? title)> Errors { get; } = new();
 
         public Task ShowInfoAsync(string message, string? title = null) => Task.CompletedTask;
 
@@ -84,7 +112,11 @@ public class DecompileViewModelTests
             return Task.CompletedTask;
         }
 
-        public Task ShowErrorAsync(string message, string? title = null) => Task.CompletedTask;
+        public Task ShowErrorAsync(string message, string? title = null)
+        {
+            Errors.Add((message, title));
+            return Task.CompletedTask;
+        }
 
         public Task<bool> ShowQuestionAsync(string message, string? title = null) => Task.FromResult(false);
     }


### PR DESCRIPTION
### Motivation
- The Decompile flow could crash when normalizing the configured output folder because `Path.GetFullPath` can throw for invalid or inaccessible paths. 
- Message boxes were using an owner-based startup location which can trigger owner-related dialog failures in some environments.

### Description
- Wrap `ResolveOutputDirectory()`/`Path.GetFullPath` in a try/catch and report failures to the UI instead of letting the exception propagate, returning early from `RunDecompile` (`src/PulseAPK.Core/ViewModels/DecompileViewModel.cs`).
- Append the failure to the console log and show a descriptive error dialog when output path normalization fails using `IDialogService`.
- Change the message box parameters to use `WindowStartupLocation.CenterScreen` to avoid owner-related dialog crashes (`src/PulseAPK.Avalonia/Services/AvaloniaDialogService.cs`).
- Add a regression unit test `RunCommand_ShowsError_WhenOutputFolderIsInvalid` and update the test `TestDialogService` to capture error dialogs (`tests/unit/PulseAPK.Tests/ViewModels/DecompileViewModelTests.cs`).

### Testing
- Added an automated unit test `RunCommand_ShowsError_WhenOutputFolderIsInvalid` that verifies an invalid `OutputFolder` shows an error dialog and leaves the command enabled. 
- Attempted to run `dotnet test --no-restore` in the environment but `dotnet` is not installed here, so the test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4757b15c74832285df33763c58214e)