### PR TITLE
DecompileViewModel: implement IDisposable and unsubscribe Apktool output handler

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -8,7 +8,7 @@ using Properties = PulseAPK.Core.Properties;
 
 namespace PulseAPK.Core.ViewModels;
 
-public partial class DecompileViewModel : ObservableObject
+public partial class DecompileViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
@@ -37,6 +37,7 @@ public partial class DecompileViewModel : ObservableObject
     private bool _isRunning;
 
     private bool _isConsolePreviewActive = true;
+    private bool _disposed;
 
     private readonly IFilePickerService _filePickerService;
     private readonly ISettingsService _settingsService;
@@ -260,6 +261,11 @@ public partial class DecompileViewModel : ObservableObject
 
     private void OnOutputDataReceived(string message)
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         if (!_dispatcherService.CheckAccess())
         {
             _dispatcherService.InvokeAsync(() => AppendLog(message));
@@ -415,6 +421,17 @@ public partial class DecompileViewModel : ObservableObject
             : basePath + Path.DirectorySeparatorChar;
 
         return candidatePath.StartsWith(basePathWithSeparator, comparison);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _apktoolRunner.OutputDataReceived -= OnOutputDataReceived;
+        _disposed = true;
     }
 
     private static string NormalizePath(string path)


### PR DESCRIPTION
### Motivation
- Prevent background `_apktoolRunner` output callbacks from invoking UI dispatch/logging after the view model has been torn down and keep behavior consistent with `SettingsViewModel : ObservableObject, IDisposable` and `MainViewModel.SetCurrentView()` disposal semantics.

### Description
- Implement `IDisposable` on `DecompileViewModel`.
- Add a private `_disposed` flag to track disposal state.
- Add `Dispose()` that unsubscribes `_apktoolRunner.OutputDataReceived -= OnOutputDataReceived;` and sets `_disposed` to `true`.
- Add an early return in `OnOutputDataReceived` when `_disposed` is `true` to avoid dispatching UI work for a disposed instance.

### Testing
- Ran `git diff --check`, which passed without issues.
- Attempted to run `dotnet test`, but it could not be executed in this environment because the `dotnet` command is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475b2a413c8322973d03987a94bf24)