### PR TITLE
Add decompile cancellation cleanup

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -38,6 +38,7 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
 
     private bool _isConsolePreviewActive = true;
     private bool _disposed;
+    private CancellationTokenSource? _activeDecompileCancellationTokenSource;
 
     private readonly IFilePickerService _filePickerService;
     private readonly ISettingsService _settingsService;
@@ -230,10 +231,12 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
         }
 
         IsRunning = true;
+        var cancellationTokenSource = new CancellationTokenSource();
+        _activeDecompileCancellationTokenSource = cancellationTokenSource;
 
         try
         {
-            var decompileResult = await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, forceOverwrite);
+            var decompileResult = await _apktoolRunner.RunDecompileAsync(ApkPath, normalizedOutputDir, DecodeResources, DecodeSources, KeepOriginalManifest, forceOverwrite, cancellationTokenSource.Token);
             var exitCode = decompileResult.ExitCode;
 
             if (exitCode == 0)
@@ -247,6 +250,10 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
                 await _dialogService.ShowErrorAsync(Properties.Resources.DecompileFailed);
             }
         }
+        catch (OperationCanceledException)
+        {
+            AppendLog("Decompile canceled.");
+        }
         catch (Exception ex)
         {
             AppendLog($"{Properties.Resources.DecompileFailed}: {ex.Message}");
@@ -254,6 +261,12 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            if (ReferenceEquals(_activeDecompileCancellationTokenSource, cancellationTokenSource))
+            {
+                _activeDecompileCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
             IsRunning = false;
             RunDecompileCommand.NotifyCanExecuteChanged();
         }
@@ -430,6 +443,9 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
             return;
         }
 
+        _activeDecompileCancellationTokenSource?.Cancel();
+        _activeDecompileCancellationTokenSource?.Dispose();
+        _activeDecompileCancellationTokenSource = null;
         _apktoolRunner.OutputDataReceived -= OnOutputDataReceived;
         _disposed = true;
     }


### PR DESCRIPTION
### Motivation
- Ensure the active decompile run can be cancelled and cleaned up to avoid leaving stray tokens or showing cancellation as an error.

### Description
- Add a `CancellationTokenSource? _activeDecompileCancellationTokenSource` field to track the currently running decompile operation.
- In `RunDecompile()` create a new `CancellationTokenSource`, assign it to the field, pass its `Token` into `_apktoolRunner.RunDecompileAsync`, and dispose/reset it in `finally`.
- Handle `OperationCanceledException` separately so cancellation logs as canceled instead of showing a generic error dialog.
- In `Dispose()` cancel and dispose the active token source (if any) and continue to unsubscribe from `_apktoolRunner.OutputDataReceived`.

### Testing
- `git diff --check` executed and passed.
- `dotnet test` attempted but could not be run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475c72bbc88322b9a3aca74695cbdd)