### PR TITLE
Validate derived decompile output path

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -196,6 +196,12 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
         try
         {
             var outputDir = ResolveOutputDirectory();
+            if (string.IsNullOrWhiteSpace(outputDir))
+            {
+                await _dialogService.ShowErrorAsync("Unable to derive an output folder from the selected APK. Choose an output folder and try again.", "Invalid output folder");
+                return;
+            }
+
             normalizedOutputDir = Path.GetFullPath(outputDir);
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or IOException or UnauthorizedAccessException)
@@ -382,7 +388,13 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
             return string.Empty;
         }
 
-        return Path.Combine(Path.GetDirectoryName(apkPath)!, Path.GetFileNameWithoutExtension(apkPath));
+        var apkDirectory = Path.GetDirectoryName(apkPath);
+        if (string.IsNullOrWhiteSpace(apkDirectory))
+        {
+            apkDirectory = Directory.GetCurrentDirectory();
+        }
+
+        return Path.Combine(apkDirectory, Path.GetFileNameWithoutExtension(apkPath));
     }
 
     private static bool IsHighRiskOutputDirectory(string outputDir)


### PR DESCRIPTION
### Motivation
- Prevent an empty or invalid derived output folder from reaching `Path.GetFullPath` and causing an exception by showing a user-friendly error dialog instead. 
- Make deriving an APK-based output folder robust when the APK path has no directory component and avoid the null-forgiving operator.

### Description
- Added a guard in `RunDecompile()` that checks the result of `ResolveOutputDirectory()` and shows an error dialog and returns if the resolved `outputDir` is null, empty, or whitespace before calling `Path.GetFullPath`.
- Updated `GetApkDerivedOutputFolder(string? apkPath)` to store `Path.GetDirectoryName(apkPath)` in a local `apkDirectory` variable, fall back to `Directory.GetCurrentDirectory()` when that value is null or whitespace, and combine paths without using the null-forgiving operator.

### Testing
- Ran `git diff --check` which completed without reported issues.
- Attempted `dotnet build PulseAPK.sln` but the command could not be executed because `dotnet` is not installed in the environment, so a full build could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475d305fac83229a50ef73f5c3aa9a)