### PR TITLE
Tighten decompile command availability

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -12,6 +12,7 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
 {
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
+    [NotifyCanExecuteChangedFor(nameof(RunDecompileCommand))]
     private string _apkPath = string.Empty;
 
     [ObservableProperty]
@@ -24,9 +25,11 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
     private bool _keepOriginalManifest;
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RunDecompileCommand))]
     private bool _extractToApkFolder;
 
     [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RunDecompileCommand))]
     private string? _outputFolder;
 
     [ObservableProperty]
@@ -327,7 +330,19 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
 
     private bool CanRunDecompile()
     {
-        return !IsRunning;
+        if (IsRunning || string.IsNullOrWhiteSpace(ApkPath) || !File.Exists(ApkPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            return !string.IsNullOrWhiteSpace(ResolveOutputDirectory());
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
     }
 
     private string BuildCommandPreview()


### PR DESCRIPTION
### Motivation
- Prevent the decompile command from being invoked when required inputs are missing or invalid by ensuring the command only becomes executable for valid APK and output folder combinations.
- Ensure UI command state updates when relevant observable properties change by notifying `RunDecompileCommand` when those properties are modified.

### Description
- Add `[NotifyCanExecuteChangedFor(nameof(RunDecompileCommand))]` to the observable backing fields for `ApkPath`, `OutputFolder`, and `ExtractToApkFolder` so command availability is reevaluated when they change.
- Replace `CanRunDecompile()` with logic that returns false if `IsRunning`, `ApkPath` is null/whitespace, or `File.Exists(ApkPath)` is false, and otherwise returns true only when `ResolveOutputDirectory()` yields a non-empty string while catching output-path related exceptions and returning false.
- Keep existing command preview and output-resolution helpers and handle invalid output resolution by disabling the command instead of throwing.

### Testing
- Ran `git diff --check` which completed successfully.
- Attempted `dotnet test PulseAPK.sln` but could not run automated tests in this environment because the `dotnet` command was not found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475df66c8883229a54830d254f50ff)