### PR TITLE
Add macOS folder privacy descriptions

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -151,6 +151,16 @@ cat > "${bundle_contents}/Info.plist" <<PLIST
   <string>11.0</string>
   <key>NSHighResolutionCapable</key>
   <true/>
+  <key>NSDesktopFolderUsageDescription</key>
+  <string>PulseAPK needs access to APK files and output folders you select on the Desktop so it can decompile and rebuild APK projects.</string>
+  <key>NSDocumentsFolderUsageDescription</key>
+  <string>PulseAPK needs access to APK files and output folders you select in Documents so it can decompile and rebuild APK projects.</string>
+  <key>NSDownloadsFolderUsageDescription</key>
+  <string>PulseAPK needs access to APK files and output folders you select in Downloads so it can decompile and rebuild APK projects.</string>
+  <key>NSRemovableVolumesUsageDescription</key>
+  <string>PulseAPK needs access to APK files and output folders you select on removable volumes so it can decompile and rebuild APK projects.</string>
+  <key>NSNetworkVolumesUsageDescription</key>
+  <string>PulseAPK needs access to APK files and output folders you select on network volumes so it can decompile and rebuild APK projects.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
### Motivation
- macOS can block access to protected user folders when an app hasn't declared why it needs them, which can cause decompile/build flows that read APKs or write output folders to fail or not prompt the user for permission. 

### Description
- Add `NSDesktopFolderUsageDescription`, `NSDocumentsFolderUsageDescription`, `NSDownloadsFolderUsageDescription`, `NSRemovableVolumesUsageDescription`, and `NSNetworkVolumesUsageDescription` entries to the generated `Info.plist` in `scripts/build-macos-binary.sh` with text explaining why PulseAPK needs access to APK files and output folders.

### Testing
- Performed a syntax check with `bash -n scripts/build-macos-binary.sh` which succeeded, ran `git diff --check` which reported no issues, and `dotnet test PulseAPK.sln --no-restore` was not executed in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a475f71a6b08322b730c7b0b5504aa5)