### PR TITLE
Enable terminal logging for macOS launches

### DIFF
--- a/src/PulseAPK.Avalonia/Program.cs
+++ b/src/PulseAPK.Avalonia/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using System;
+using System.Diagnostics;
 
 namespace PulseAPK.Avalonia;
 
@@ -9,8 +10,11 @@ class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        ConfigureTerminalLogging();
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
@@ -18,4 +22,30 @@ class Program
             .UsePlatformDetect()
             .WithInterFont()
             .LogToTrace();
+
+    private static void ConfigureTerminalLogging()
+    {
+        Trace.AutoFlush = true;
+
+        if (!HasConsoleTraceListener())
+        {
+            Trace.Listeners.Add(new ConsoleTraceListener(useErrorStream: false));
+        }
+
+        Console.WriteLine($"PulseAPK starting at {DateTimeOffset.Now:O}");
+        Trace.TraceInformation("PulseAPK trace logging is enabled.");
+    }
+
+    private static bool HasConsoleTraceListener()
+    {
+        foreach (TraceListener listener in Trace.Listeners)
+        {
+            if (listener is ConsoleTraceListener)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
+++ b/src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType Condition="$([MSBuild]::IsOSPlatform('Windows'))">WinExe</OutputType>
+    <OutputType Condition="!$([MSBuild]::IsOSPlatform('Windows'))">Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
### Motivation
- Improve debugging when launching the app on macOS from the terminal by ensuring startup and Avalonia trace logs are emitted to stdout. 
- Make the published app behave as a console executable on non-Windows platforms so `open`/terminal launches can show logs.

### Description
- Added `ConfigureTerminalLogging()` and invoked it from `Main` to enable timestamped startup output and to initialize trace logging in `src/PulseAPK.Avalonia/Program.cs`. 
- Added a `ConsoleTraceListener` (if one is not already present) so `.LogToTrace()` output is written to stdout. 
- Updated `src/PulseAPK.Avalonia/PulseAPK.Avalonia.csproj` to use `<OutputType Condition="$([MSBuild]::IsOSPlatform('Windows'))">WinExe</OutputType>` and `<OutputType Condition="!$([MSBuild]::IsOSPlatform('Windows'))">Exe</OutputType>` so the app builds as a console `Exe` on non-Windows platforms while preserving `WinExe` on Windows. 

### Testing
- Parsed the modified project file with `python3` and `xml.etree.ElementTree` which succeeded. 
- Ran `git diff --check` which reported no whitespace or diff issues. 
- Attempted `dotnet format --verify-no-changes` but it was not run in this environment because `dotnet` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4760a775a08322b6cd221f44ede633)