### PR TITLE
Mirror AnalyserViewModel log buffering in DecompileViewModel

### DIFF
--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -1,6 +1,9 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using PulseAPK.Core.Abstractions;
 using PulseAPK.Core.Services;
 using PulseAPK.Core.Utils;
@@ -10,6 +13,17 @@ namespace PulseAPK.Core.ViewModels;
 
 public partial class DecompileViewModel : ObservableObject, IDisposable
 {
+    private const int MaxLogCharacters = 900_000;
+    private const int LogTrimTargetCharacters = 850_000;
+    private const int LogFlushDelayMilliseconds = 150;
+
+    private readonly Queue<string> _logLines = new();
+    private readonly object _logLock = new();
+    private int _logCharCount;
+    private bool _logFlushScheduled;
+    private long _logVersion;
+    private CancellationTokenSource? _logFlushCancellationTokenSource;
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsHintVisible))]
     [NotifyCanExecuteChangedFor(nameof(RunDecompileCommand))]
@@ -288,34 +302,126 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
             return;
         }
 
-        if (!_dispatcherService.CheckAccess())
-        {
-            _dispatcherService.InvokeAsync(() => AppendLog(message));
-        }
-        else
-        {
-            AppendLog(message);
-        }
+        AppendLog(message);
     }
 
     private void AppendLog(string message)
     {
         _isConsolePreviewActive = false;
 
-        if (string.IsNullOrWhiteSpace(ConsoleLog) || ConsoleLog == "Waiting for command...")
+        lock (_logLock)
         {
-            ConsoleLog = message;
-        }
-        else
-        {
-            ConsoleLog += $"{Environment.NewLine}{message}";
+            var sanitized = message ?? string.Empty;
+            _logLines.Enqueue(sanitized);
+            _logCharCount += sanitized.Length;
+
+            TrimLogIfNeeded();
+            _logVersion++;
+            ScheduleLogFlushLocked();
         }
     }
 
     private void SetConsoleLog(string message)
     {
         _isConsolePreviewActive = false;
-        ConsoleLog = message;
+
+        lock (_logLock)
+        {
+            _logLines.Clear();
+            _logCharCount = 0;
+
+            var sanitized = message ?? string.Empty;
+            _logLines.Enqueue(sanitized);
+            _logCharCount = sanitized.Length;
+            _logVersion++;
+
+            ScheduleLogFlushLocked();
+        }
+    }
+
+    private void ScheduleLogFlushLocked()
+    {
+        if (_disposed || _logFlushScheduled)
+        {
+            return;
+        }
+
+        _logFlushCancellationTokenSource ??= new CancellationTokenSource();
+        var cancellationToken = _logFlushCancellationTokenSource.Token;
+        _logFlushScheduled = true;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(LogFlushDelayMilliseconds, cancellationToken);
+                FlushLog(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }, cancellationToken);
+    }
+
+    private void FlushLog(CancellationToken cancellationToken)
+    {
+        string logText;
+        long logVersion;
+
+        lock (_logLock)
+        {
+            if (_disposed || cancellationToken.IsCancellationRequested)
+            {
+                _logFlushScheduled = false;
+                return;
+            }
+
+            logText = string.Join(Environment.NewLine, _logLines);
+            logVersion = _logVersion;
+            _logFlushScheduled = false;
+        }
+
+        if (!_dispatcherService.CheckAccess())
+        {
+            _dispatcherService.InvokeAsync(() =>
+            {
+                if (ShouldApplyLogFlush(logVersion, cancellationToken))
+                {
+                    ConsoleLog = logText;
+                }
+            });
+        }
+        else if (ShouldApplyLogFlush(logVersion, cancellationToken))
+        {
+            ConsoleLog = logText;
+        }
+    }
+
+    private bool ShouldApplyLogFlush(long logVersion, CancellationToken cancellationToken)
+    {
+        lock (_logLock)
+        {
+            return !_disposed
+                && !cancellationToken.IsCancellationRequested
+                && logVersion == _logVersion;
+        }
+    }
+
+    private void TrimLogIfNeeded()
+    {
+        var newlineLength = Environment.NewLine.Length;
+        var totalCharacters = _logCharCount + ((_logLines.Count - 1) * newlineLength);
+        if (totalCharacters <= MaxLogCharacters)
+        {
+            return;
+        }
+
+        while (_logLines.Count > 0 && totalCharacters > LogTrimTargetCharacters)
+        {
+            var removed = _logLines.Dequeue();
+            _logCharCount -= removed.Length;
+            totalCharacters = _logCharCount + ((_logLines.Count - 1) * newlineLength);
+        }
     }
 
     private void UpdateCommandPreview()
@@ -470,11 +576,21 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
             return;
         }
 
+        _disposed = true;
+
         _activeDecompileCancellationTokenSource?.Cancel();
         _activeDecompileCancellationTokenSource?.Dispose();
         _activeDecompileCancellationTokenSource = null;
+
+        lock (_logLock)
+        {
+            _logFlushCancellationTokenSource?.Cancel();
+            _logFlushCancellationTokenSource?.Dispose();
+            _logFlushCancellationTokenSource = null;
+            _logFlushScheduled = false;
+        }
+
         _apktoolRunner.OutputDataReceived -= OnOutputDataReceived;
-        _disposed = true;
     }
 
     private static string NormalizePath(string path)


### PR DESCRIPTION
### Motivation
- Ensure `DecompileViewModel` uses the same bounded, buffered console-log approach as `AnalyserViewModel` to reduce UI churn and memory growth when receiving many output lines.
- Keep log handling platform-neutral and deterministic so background output can be collected and presented efficiently without macOS-specific behavior.

### Description
- Added constants `MaxLogCharacters`, `LogTrimTargetCharacters`, and `LogFlushDelayMilliseconds` and introduced a locked `Queue<string>` as the backing log buffer with `_logCharCount`, `_logVersion`, and a cancellation source for flush scheduling.`
- Replaced direct `ConsoleLog += ...` and immediate `ConsoleLog = ...` updates with `AppendLog` and `SetConsoleLog` that enqueue sanitized lines under `_logLock` and mark a debounced flush; `SetConsoleLog` clears the buffer and schedules a UI update.
- Implemented a debounced flush (`ScheduleLogFlushLocked` / `FlushLog`) with a ~150 ms delay that marshals the joined buffer to the UI via `IDispatcherService` and uses a version check to avoid applying stale flushes.
- Added `TrimLogIfNeeded` to drop oldest lines when the buffered text exceeds `MaxLogCharacters`, and updated `Dispose` to cancel/clean up any pending flush work and remove event handlers.

### Testing
- Ran `git diff --check` which reported no whitespace errors and succeeded.
- Attempted `dotnet build` / `dotnet --info` but the environment does not have `dotnet` installed so a full build/test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47ce8045488322afee666fe9b69641)