### PR TITLE
Handle apktool cancellation cleanup

### DIFF
--- a/src/PulseAPK.Core/Services/ApktoolRunner.cs
+++ b/src/PulseAPK.Core/Services/ApktoolRunner.cs
@@ -110,7 +110,20 @@ namespace PulseAPK.Core.Services
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            await process.WaitForExitAsync(cancellationToken);
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync();
+                }
+
+                throw;
+            }
 
             return new ApktoolRunResult(process.ExitCode, stdoutLines.ToArray(), stderrLines.ToArray());
         }


### PR DESCRIPTION
### Motivation
- Ensure the apktool process tree is terminated and its resources are drained when cancellation occurs so no orphaned processes remain and the UI continues to show "Decompile canceled." 

### Description
- In `src/PulseAPK.Core/Services/ApktoolRunner.cs` wrap `await process.WaitForExitAsync(cancellationToken)` in a `try/catch (OperationCanceledException)` that calls `process.Kill(entireProcessTree: true)` if `!process.HasExited`, then awaits a non-cancelable `process.WaitForExitAsync()` and rethrows the exception.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted `dotnet test` but it failed because the `dotnet` CLI is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d0bd26c8832296cfe325084fb5aa)