### PR TITLE
Fix apktool launch from macOS zip

### DIFF
--- a/src/PulseAPK.Core/Services/ApktoolRunner.cs
+++ b/src/PulseAPK.Core/Services/ApktoolRunner.cs
@@ -64,20 +64,10 @@ namespace PulseAPK.Core.Services
 
         private async Task<ApktoolRunResult> RunProcessAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
         {
-            var apktoolPath = SanitizePathArgument(_settingsService.Settings.ApktoolPath);
-
-            if (string.IsNullOrWhiteSpace(apktoolPath))
-            {
-                throw new FileNotFoundException("Apktool path has not been configured.");
-            }
-
-            if (!File.Exists(apktoolPath))
-            {
-                throw new FileNotFoundException($"Apktool path '{apktoolPath}' does not exist.");
-            }
+            var apktoolPath = ResolveConfiguredApktoolPath(_settingsService.Settings.ApktoolPath, _settingsService.SettingsDirectory);
 
             var executableMode = GetExecutableMode(apktoolPath);
-            var startInfo = CreateStartInfo(apktoolPath, arguments);
+            var startInfo = CreateStartInfo(apktoolPath, arguments, _settingsService.SettingsDirectory);
             var stdoutLines = new List<string>();
             var stderrLines = new List<string>();
             var lineSyncRoot = new object();
@@ -184,8 +174,9 @@ namespace PulseAPK.Core.Services
                 : tail[^ProcessTailMaxCharacters..];
         }
 
-        private static ProcessStartInfo CreateStartInfo(string apktoolPath, IReadOnlyList<string> arguments)
+        private static ProcessStartInfo CreateStartInfo(string apktoolPath, IReadOnlyList<string> arguments, string settingsDirectory)
         {
+            var workingDirectory = ResolveProcessWorkingDirectory(settingsDirectory);
             var extension = Path.GetExtension(apktoolPath);
             var isJar = string.Equals(extension, ".jar", StringComparison.OrdinalIgnoreCase);
             var isBatchFile = string.Equals(extension, ".bat", StringComparison.OrdinalIgnoreCase)
@@ -199,7 +190,8 @@ namespace PulseAPK.Core.Services
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
+                    WorkingDirectory = workingDirectory
                 };
 
                 startInfo.ArgumentList.Add("-jar");
@@ -222,7 +214,8 @@ namespace PulseAPK.Core.Services
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
+                    WorkingDirectory = workingDirectory
                 };
             }
 
@@ -232,7 +225,8 @@ namespace PulseAPK.Core.Services
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                WorkingDirectory = workingDirectory
             };
 
             foreach (var argument in arguments)
@@ -241,6 +235,55 @@ namespace PulseAPK.Core.Services
             }
 
             return defaultStartInfo;
+        }
+
+        public static string ResolveConfiguredApktoolPath(string? configuredPath, string settingsDirectory)
+        {
+            var apktoolPath = SanitizePathArgument(configuredPath);
+
+            if (string.IsNullOrWhiteSpace(apktoolPath))
+            {
+                throw new FileNotFoundException("Apktool path has not been configured.");
+            }
+
+            foreach (var candidate in EnumerateApktoolPathCandidates(apktoolPath, settingsDirectory))
+            {
+                if (File.Exists(candidate))
+                {
+                    return Path.GetFullPath(candidate);
+                }
+            }
+
+            throw new FileNotFoundException($"Apktool path '{apktoolPath}' does not exist.");
+        }
+
+        private static IEnumerable<string> EnumerateApktoolPathCandidates(string apktoolPath, string settingsDirectory)
+        {
+            if (Path.IsPathFullyQualified(apktoolPath))
+            {
+                yield return apktoolPath;
+                yield break;
+            }
+
+            yield return Path.Combine(Environment.CurrentDirectory, apktoolPath);
+            yield return Path.Combine(AppContext.BaseDirectory, apktoolPath);
+
+            if (!string.IsNullOrWhiteSpace(settingsDirectory))
+            {
+                yield return Path.Combine(settingsDirectory, apktoolPath);
+                yield return Path.Combine(settingsDirectory, "tools", apktoolPath);
+            }
+        }
+
+        private static string ResolveProcessWorkingDirectory(string settingsDirectory)
+        {
+            if (!string.IsNullOrWhiteSpace(settingsDirectory))
+            {
+                Directory.CreateDirectory(settingsDirectory);
+                return settingsDirectory;
+            }
+
+            return Path.GetTempPath();
         }
 
         private static string SanitizePathArgument(string? path)

--- a/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/BuildViewModel.cs
@@ -147,7 +147,17 @@ public partial class BuildViewModel : ObservableObject
         }
 
         var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
-         if (string.IsNullOrWhiteSpace(apktoolPath) || !File.Exists(apktoolPath))
+         if (string.IsNullOrWhiteSpace(apktoolPath))
+        {
+            await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
+            return;
+        }
+
+        try
+        {
+            ApktoolRunner.ResolveConfiguredApktoolPath(apktoolPath, _settingsService.SettingsDirectory);
+        }
+        catch (FileNotFoundException)
         {
             await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
             return;

--- a/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/DecompileViewModel.cs
@@ -203,7 +203,11 @@ public partial class DecompileViewModel : ObservableObject, IDisposable
             return;
         }
 
-        if (!File.Exists(apktoolPath))
+        try
+        {
+            ApktoolRunner.ResolveConfiguredApktoolPath(apktoolPath, _settingsService.SettingsDirectory);
+        }
+        catch (FileNotFoundException)
         {
             await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.Error_InvalidApkFile);
             RunDecompileCommand.NotifyCanExecuteChanged();

--- a/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
+++ b/src/PulseAPK.Core/ViewModels/PatchViewModel.cs
@@ -218,7 +218,17 @@ public partial class PatchViewModel : ObservableObject
         }
 
         var apktoolPath = _settingsService.Settings.ApktoolPath?.Trim();
-        if (string.IsNullOrWhiteSpace(apktoolPath) || !File.Exists(apktoolPath))
+        if (string.IsNullOrWhiteSpace(apktoolPath))
+        {
+            await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
+            return;
+        }
+
+        try
+        {
+            ApktoolRunner.ResolveConfiguredApktoolPath(apktoolPath, _settingsService.SettingsDirectory);
+        }
+        catch (FileNotFoundException)
         {
             await _dialogService.ShowErrorAsync(string.Format(Properties.Resources.Error_InvalidApktoolPath, apktoolPath), Properties.Resources.SettingsHeader);
             return;

--- a/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
+++ b/tests/unit/PulseAPK.Tests/Services/ApktoolRunnerTests.cs
@@ -104,6 +104,58 @@ public class ApktoolRunnerTests
         }
     }
 
+
+    [Fact]
+    public async Task RunBuildAsync_ResolvesRelativeApktoolFromManagedToolsDirectoryAndUsesSettingsWorkingDirectory()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"pulseapk-tests-{Guid.NewGuid():N}");
+        var settingsDirectory = Path.Combine(tempRoot, "settings");
+        var toolsDirectory = Path.Combine(settingsDirectory, "tools");
+        Directory.CreateDirectory(toolsDirectory);
+
+        var fakeApktoolPath = Path.Combine(toolsDirectory, "apktool");
+        var capturedArgsPath = Path.Combine(tempRoot, "captured-args.txt");
+        var capturedWorkingDirectoryPath = Path.Combine(tempRoot, "captured-working-directory.txt");
+        var projectDir = Path.Combine(tempRoot, "decompiled");
+        var outputApk = Path.Combine(tempRoot, "compiled", "decompiled.apk");
+
+        Directory.CreateDirectory(projectDir);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputApk)!);
+
+        var escapedArgsPath = capturedArgsPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var escapedWorkingDirectoryPath = capturedWorkingDirectoryPath.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        var script = $"#!/usr/bin/env bash\nprintf '%s\n' \"$@\" > \"{escapedArgsPath}\"\npwd > \"{escapedWorkingDirectoryPath}\"\nexit 0\n";
+        File.WriteAllText(fakeApktoolPath, script);
+        MakeExecutable(fakeApktoolPath);
+
+        try
+        {
+            var settings = new TestSettingsService("apktool", settingsDirectory);
+            var runner = new ApktoolRunner(settings);
+
+            var exitCode = await runner.RunBuildAsync(projectDir, outputApk, useAapt2: false);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(settingsDirectory, File.ReadAllText(capturedWorkingDirectoryPath).Trim());
+
+            var args = File.ReadAllLines(capturedArgsPath);
+
+            Assert.Equal(new[] { "b", projectDir, "-o", outputApk }, args);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+            {
+                Directory.Delete(tempRoot, recursive: true);
+            }
+        }
+    }
+
     private static void MakeExecutable(string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -120,8 +172,11 @@ public class ApktoolRunnerTests
 
     private sealed class TestSettingsService : ISettingsService
     {
-        public TestSettingsService(string apktoolPath)
+        private readonly string _settingsDirectory;
+
+        public TestSettingsService(string apktoolPath, string? settingsDirectory = null)
         {
+            _settingsDirectory = settingsDirectory ?? Environment.CurrentDirectory;
             Settings = new AppSettings
             {
                 ApktoolPath = apktoolPath
@@ -129,7 +184,7 @@ public class ApktoolRunnerTests
         }
 
         public AppSettings Settings { get; }
-        public string SettingsDirectory => Environment.CurrentDirectory;
+        public string SettingsDirectory => _settingsDirectory;
         public event EventHandler? SettingsChanged;
 
         public void Save() => SettingsChanged?.Invoke(this, EventArgs.Empty);


### PR DESCRIPTION
### Motivation
- Decompiles were crashing on macOS when running the unzipped app because the apktool executable was being resolved from the process CWD (which can be translocated/read-only after unzipping) and relative configured paths inside the app's managed `tools` folder were not found.
- The runner also launched subprocesses without a stable writable working directory, causing failures when the app bundle's current directory is unsuitable for spawning `apktool` on macOS.

### Description
- Added a public resolver `ApktoolRunner.ResolveConfiguredApktoolPath` that enumerates candidate locations for the configured `apktool` (absolute path, `Environment.CurrentDirectory`, `AppContext.BaseDirectory`, settings directory, and `settings/tools`).
- Made the runner use the resolver in `RunProcessAsync` and changed `CreateStartInfo` to accept a `settingsDirectory` and set the process `WorkingDirectory` to a writable settings folder via `ResolveProcessWorkingDirectory`.
- Replaced direct `File.Exists` checks in `DecompileViewModel`, `BuildViewModel`, and `PatchViewModel` with validation using the new resolver so managed/relative tool paths are accepted when resolvable.
- Added a unit test `RunBuildAsync_ResolvesRelativeApktoolFromManagedToolsDirectoryAndUsesSettingsWorkingDirectory` and updated the test `TestSettingsService` helper to allow a custom `SettingsDirectory` for coverage of the managed/tools resolution behavior.

### Testing
- `git diff --check` passed with no problems.
- Changes were committed (message: `Fix apktool launch from macOS zip`).
- `dotnet test tests/unit/PulseAPK.Tests/PulseAPK.Tests.csproj --no-restore` was not run because `dotnet` is not available in the execution environment, so the new/updated unit test was added but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47d82a40a083228c181bb1a43dc3af)