### PR TITLE
Revert "fix: bundle macOS native publish output in app"

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -80,7 +80,7 @@ dotnet publish "${project_path}" \
   ${app_version:+-p:InformationalVersion="${app_version}"} \
   /p:UseAppHost=true \
   /p:PublishSingleFile=true \
-  /p:IncludeNativeLibrariesForSelfExtract=false \
+  /p:IncludeNativeLibrariesForSelfExtract=true \
   /p:EnableCompressionInSingleFile=true \
   -o "${publish_dir}"
 
@@ -114,13 +114,6 @@ bundle_macos="${bundle_contents}/MacOS"
 bundle_resources="${bundle_contents}/Resources"
 
 mkdir -p "${bundle_macos}" "${bundle_resources}"
-
-# Copy the complete publish output into the .app bundle. macOS single-file
-# publish still emits native runtime/Avalonia binaries when
-# IncludeNativeLibrariesForSelfExtract=false, and Finder launches only the
-# bundle entry point. Keeping every published sidecar inside Contents/MacOS
-# makes the .app self-contained so users do not need the separate publish
-# directory next to it.
 cp -a "${publish_dir}/." "${bundle_macos}/"
 cp "${macos_icon_path}" "${bundle_resources}/${macos_icon_file}"
 chmod +x "${bundle_macos}/${app_exe}"


### PR DESCRIPTION
Reverts deemoun/PulseAPK-Core#294