### PR TITLE
Include macOS publish output in release ZIP

### DIFF
--- a/scripts/build-macos-binary.sh
+++ b/scripts/build-macos-binary.sh
@@ -114,13 +114,14 @@ bundle_macos="${bundle_contents}/MacOS"
 bundle_resources="${bundle_contents}/Resources"
 
 mkdir -p "${bundle_macos}" "${bundle_resources}"
+# PDB files can include local source paths and machine/user details.
+# Exclude them from distributable artifacts by default before copying the
+# publish output into every distributable package location.
+find "${publish_dir}" -maxdepth 1 -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
+
 cp -a "${publish_dir}/." "${bundle_macos}/"
 cp "${macos_icon_path}" "${bundle_resources}/${macos_icon_file}"
 chmod +x "${bundle_macos}/${app_exe}"
-
-# PDB files can include local source paths and machine/user details.
-# Exclude them from distributable artifacts by default.
-find "${bundle_macos}" -maxdepth 1 -type f \( -name '*.pdb' -o -name '*.dbg' \) -delete
 
 cat > "${bundle_contents}/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -190,7 +191,7 @@ create_zip() {
   rm -f "${destination}"
   (
     cd "${out_root}"
-    COPYFILE_DISABLE=1 zip -r "${destination}" "${bundle_name}.app"
+    COPYFILE_DISABLE=1 zip -r "${destination}" "${bundle_name}.app" "publish"
   )
 }
 


### PR DESCRIPTION
### Motivation
- CI-created macOS ZIP did not include the `publish` folder with the published executable and supporting files, preventing the distributed archive from working as intended.

### Description
- Update `scripts/build-macos-binary.sh` to remove debug symbol files (`*.pdb`/`*.dbg`) from `publish` before assembling the `.app` and to include the `publish` directory alongside the `.app` when creating the ZIP archive.

### Testing
- Ran a syntax check with `bash -n scripts/build-macos-binary.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48302f53dc832292f74e2b4fe03abd)